### PR TITLE
ensure bdio can be uploaded in parallel

### DIFF
--- a/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
@@ -651,6 +651,10 @@ public enum DetectProperty {
     @AcceptableValues(value = { "ALL", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "OFF" }, caseSensitive = false, strict = true)
     LOGGING_LEVEL_COM_SYNOPSYS_INTEGRATION("logging.level.com.synopsys.integration", "Logging Level", "5.3.0", PropertyType.STRING, PropertyAuthority.None, "INFO"),
 
+    @HelpGroup(primary = GROUP_GENERAL, additional = { SEARCH_GROUP_GLOBAL })
+    @HelpDescription("The number of scans to run in parallel, defaults to 0 (no thread pool), if you specify -1, the number of processors on the machine will be used.")
+    DETECT_BLACKDUCK_PROCESSORS("detect.blackduck.parallel.processors", "BDIO upload Parallel Processors", "5.3.1", PropertyType.INTEGER, PropertyAuthority.None, "0"),
+
     /**********************************************************************************************
      * DEPRECATED START
      *********************************************************************************************/

--- a/detect-configuration/src/main/java/com/synopsys/integration/detect/thread/NoThreadExecutorService.java
+++ b/detect-configuration/src/main/java/com/synopsys/integration/detect/thread/NoThreadExecutorService.java
@@ -1,0 +1,62 @@
+/**
+ * detect-configuration
+ *
+ * Copyright (C) 2019 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.detect.thread;
+
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class NoThreadExecutorService extends AbstractExecutorService {
+    @Override
+    public void shutdown() {
+        // no-op
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+        return false;
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+        command.run();
+    }
+}

--- a/src/main/groovy/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/groovy/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -177,6 +177,7 @@ public class DetectBoot {
         detectContext.registerBean(eventSystem);
         detectContext.registerBean(profiler);
 
+        detectContext.registerBean(detectOptionManager); // to clean up executor service if any
         detectContext.registerBean(detectConfiguration);
         detectContext.registerBean(detectInfo);
         detectContext.registerBean(directoryManager);


### PR DESCRIPTION
# Description

BDIO upload is very slow and not done in parallel (whereas it is pure IO).

My fix has two potential follow up but I consider out of scope for this quick win:

1. enhance common lib to support the executor service at that level - you will see I used reflection but since you own all the stack it shouldn't be needed
2. maybe move to nio instead of increasing threads number as in current impl

That said I divided by 46 my waiting time at bdio upload so it is already a huge win even if impl can be improved.

Related issue: https://github.com/blackducksoftware/synopsys-detect/issues/6