### PR TITLE
Npm will respect 'required' dev dependencies

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/NpmDependency.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/NpmDependency.java
@@ -54,20 +54,8 @@ public class NpmDependency {
         this.parent = parent;
     }
 
-    public void addRequires(final String name, final String fuzzyVersion) {
-        this.addRequires(new NpmRequires(name, fuzzyVersion));
-    }
-
-    public void addRequires(final NpmRequires required) {
-        this.requires.add(required);
-    }
-
     public void addAllRequires(final Collection<NpmRequires> required) {
         this.requires.addAll(required);
-    }
-
-    public void addDependency(final NpmDependency dependency) {
-        dependencies.add(dependency);
     }
 
     public void addAllDependencies(final Collection<NpmDependency> dependencies) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/NpmProject.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/NpmProject.java
@@ -1,0 +1,74 @@
+/**
+ * detectable
+ *
+ * Copyright (c) 2019 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.detectable.detectables.npm.lockfile.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class NpmProject {
+    private final String name;
+    private final String version;
+
+    private final List<NpmRequires> devDependencies = new ArrayList<>();
+    private final List<NpmRequires> dependencies = new ArrayList<>();
+
+    private final List<NpmDependency> resolvedDependencies = new ArrayList<>();
+
+    public NpmProject(final String name, final String version) {
+        this.name = name;
+        this.version = version;
+    }
+
+    public void addAllDevDependencies(final Collection<NpmRequires> requires) {
+        this.devDependencies.addAll(requires);
+    }
+
+    public void addAllDependencies(final Collection<NpmRequires> requires) {
+        this.dependencies.addAll(requires);
+    }
+
+    public void addAllResolvedDependencies(final Collection<NpmDependency> resolvedDependencies) {
+        this.resolvedDependencies.addAll(resolvedDependencies);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public List<NpmRequires> getDependencies(){
+        return dependencies;
+    }
+
+    public List<NpmRequires> getDevDependencies(){
+        return devDependencies;
+    }
+
+    public List<NpmDependency> getResolvedDependencies(){
+        return resolvedDependencies;
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileParser.java
@@ -22,6 +22,7 @@
  */
 package com.synopsys.integration.detectable.detectables.npm.lockfile.parse;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -37,6 +38,8 @@ import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.NpmDependencyConverter;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmDependency;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmParseResult;
+import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmProject;
+import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmRequires;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.PackageLock;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.model.PackageJson;
 
@@ -69,8 +72,27 @@ public class NpmLockfileParser {
             logger.info(String.format("Found %d dependencies.", packageLock.dependencies.size()));
             //Convert to our custom format
             final NpmDependencyConverter dependencyConverter = new NpmDependencyConverter(externalIdFactory);
-            final NpmDependency rootDependency = dependencyConverter.convertLockFile(packageLock, packageJson);
-            traverse(rootDependency, dependencyGraph, true, includeDevDependencies);
+            final NpmProject project = dependencyConverter.convertLockFile(packageLock, packageJson);
+
+            //First we will recreate the graph from the resolved npm dependencies
+            for (NpmDependency resolved : project.getResolvedDependencies()){
+                transformTreeToGraph(resolved, project, dependencyGraph, includeDevDependencies);
+            }
+
+            //Then we will add relationships between the project (root) and the graph
+            boolean atLeastOneRequired = project.getDependencies().size() > 0 || project.getDevDependencies().size() > 0;
+            if (atLeastOneRequired) {
+                addRootDependencies(project.getResolvedDependencies(), project.getDependencies(), dependencyGraph);
+                if (includeDevDependencies) {
+                    addRootDependencies(project.getResolvedDependencies(), project.getDevDependencies(), dependencyGraph);
+                }
+            } else {
+                project.getResolvedDependencies()
+                    .stream()
+                    .map(NpmDependency::getGraphDependency)
+                    .forEach(dependencyGraph::addChildToRoot);
+            }
+
         } else {
             logger.info("Lock file did not have a 'dependencies' section.");
         }
@@ -80,44 +102,60 @@ public class NpmLockfileParser {
         return new NpmParseResult(packageLock.name, packageLock.version, codeLocation);
     }
 
-    private void traverse(final NpmDependency npmDependency, final MutableDependencyGraph dependencyGraph, final boolean atRoot, final boolean includeDevDependencies) {
-        if (!shouldInclude(npmDependency, includeDevDependencies))
+    private void addRootDependencies(List<NpmDependency> resolvedDependencies, List<NpmRequires> requires, final MutableDependencyGraph dependencyGraph) {
+        for (NpmRequires dependency : requires) {
+            NpmDependency resolved = firstDependencyWithName(resolvedDependencies, dependency.getName());
+            if (resolved != null) {
+                dependencyGraph.addChildToRoot(resolved.getGraphDependency());
+            } else {
+                logger.error("No dependency found for package: " + dependency.getName());
+            }
+        }
+    }
+
+    private void transformTreeToGraph(final NpmDependency npmDependency, final NpmProject npmProject, final MutableDependencyGraph dependencyGraph, final boolean includeDevDependencies) {
+        if (!shouldIncludeDependency(npmDependency, includeDevDependencies))
             return;
 
         npmDependency.getRequires().forEach(required -> {
-            final NpmDependency resolved = lookupDependency(npmDependency, required.getName());
             logger.debug("Required package: " + required.getName() + " of version: " + required.getFuzzyVersion());
+            final NpmDependency resolved = lookupDependency(npmDependency, npmProject, required.getName());
             if (resolved != null) {
                 logger.debug("Found package: " + resolved.getName() + "with version: " + resolved.getVersion());
-                if (atRoot) {
-                    dependencyGraph.addChildToRoot(resolved.getGraphDependency());
-                } else {
-                    dependencyGraph.addChildWithParent(resolved.getGraphDependency(), npmDependency.getGraphDependency());
-                }
+                dependencyGraph.addChildWithParent(resolved.getGraphDependency(), npmDependency.getGraphDependency());
             } else {
                 logger.error("No dependency found for package: " + required.getName());
             }
         });
 
-        npmDependency.getDependencies().forEach(child -> traverse(child, dependencyGraph, false, includeDevDependencies));
+        npmDependency.getDependencies().forEach(child -> transformTreeToGraph(child, npmProject, dependencyGraph, includeDevDependencies));
     }
 
-    //returns the first dependency directly under this dependency or under a parent
-    private NpmDependency lookupDependency(final NpmDependency npmDependency, final String name) {
-        for (final NpmDependency current : npmDependency.getDependencies()) {
+    //returns the first dependency in the following order: directly under this dependency, under a parent, under the project
+    private NpmDependency lookupDependency(final NpmDependency npmDependency, final NpmProject project, final String name) {
+        NpmDependency resolved = firstDependencyWithName(npmDependency.getDependencies(), name);
+
+        if (resolved != null) {
+            return resolved;
+        } else {
+            if (npmDependency.getParent().isPresent()) {
+                return lookupDependency(npmDependency.getParent().get(), project, name);
+            } else {
+                return firstDependencyWithName(project.getResolvedDependencies(), name);
+            }
+        }
+    }
+
+    private NpmDependency firstDependencyWithName(final List<NpmDependency> dependencies, final String name) {
+        for (final NpmDependency current : dependencies) {
             if (current.getName().equals(name)) {
                 return current;
             }
         }
-
-        if (npmDependency.getParent().isPresent()) {
-            return lookupDependency(npmDependency.getParent().get(), name);
-        } else {
-            return null;
-        }
+        return null;
     }
 
-    private boolean shouldInclude(final NpmDependency packageLockDependency, final boolean includeDevDependencies) {
+    private boolean shouldIncludeDependency(final NpmDependency packageLockDependency, final boolean includeDevDependencies) {
         if (packageLockDependency.isDevDependency()) {
             return includeDevDependencies;
         }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmDevExclusionTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmDevExclusionTest.java
@@ -1,0 +1,65 @@
+package com.synopsys.integration.detectable.detectables.npm.lockfile.functional;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Before;
+import com.synopsys.integration.detectable.annotations.FunctionalTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.synopsys.integration.bdio.model.Forge;
+import com.synopsys.integration.bdio.model.externalid.ExternalId;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.detectable.annotations.FunctionalTest;
+import com.synopsys.integration.detectable.annotations.UnitTest;
+import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmParseResult;
+import com.synopsys.integration.detectable.detectables.npm.lockfile.model.PackageLock;
+import com.synopsys.integration.detectable.detectables.npm.lockfile.parse.NpmLockfileParser;
+import com.synopsys.integration.detectable.detectables.npm.packagejson.model.PackageJson;
+import com.synopsys.integration.detectable.util.FunctionalTestFiles;
+import com.synopsys.integration.detectable.util.GraphCompare;
+import com.synopsys.integration.detectable.util.GraphSummary;
+import com.synopsys.integration.detectable.util.graph.GraphAssert;
+
+@FunctionalTest
+public class NpmDevExclusionTest {
+    ExternalId childDev;
+    ExternalId parentDev;
+    NpmLockfileParser npmLockfileParser;
+    String packageJsonText;
+    String packageLockText;
+
+    @BeforeEach
+    void setup() {
+        ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+
+        npmLockfileParser = new NpmLockfileParser(new GsonBuilder().setPrettyPrinting().create(), externalIdFactory);
+
+        packageJsonText = FunctionalTestFiles.asString("/npm/dev-exclusion-test/package.json");
+        packageLockText = FunctionalTestFiles.asString("/npm/dev-exclusion-test/package-lock.json");
+
+        childDev = externalIdFactory.createNameVersionExternalId(Forge.NPM, "child-dev", "3.0.0");
+        parentDev = externalIdFactory.createNameVersionExternalId(Forge.NPM, "parent-dev", "2.0.0");
+    }
+
+    @Test
+    public void testDevDependencyNotExists() {
+        final NpmParseResult result = npmLockfileParser.parse("source", Optional.of(packageJsonText), packageLockText, false);
+        GraphAssert graphAssert = new GraphAssert(Forge.NPM, result.codeLocation.getDependencyGraph());
+        graphAssert.hasNoDependency(childDev);
+        graphAssert.hasNoDependency(parentDev);
+        graphAssert.hasRootSize(0);
+    }
+
+    @Test
+    public void testDevDependencyExists() {
+        final NpmParseResult result = npmLockfileParser.parse("source", Optional.of(packageJsonText), packageLockText, true);
+        GraphAssert graphAssert = new GraphAssert(Forge.NPM, result.codeLocation.getDependencyGraph());
+        graphAssert.hasDependency(childDev);
+        graphAssert.hasDependency(parentDev);
+        graphAssert.hasRootSize(1);
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/file/impl/SimpleFileFinderTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/file/impl/SimpleFileFinderTest.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.detectable.file.impl;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assume;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import com.synopsys.integration.detectable.detectable.file.impl.SimpleFileFinder;
 
@@ -32,7 +34,8 @@ public class SimpleFileFinderTest {
         initialDirectoryPath.toFile().delete();
     }
 
-    @Test
+
+    @DisabledOnOs(WINDOWS)
     public void testSymlinksNotFollowed() throws IOException {
         Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
@@ -56,6 +59,4 @@ public class SimpleFileFinderTest {
         // make sure symlink not followed during dir traversal
         assertEquals(4, foundFiles.size());
     }
-
-
 }

--- a/detectable/src/test/resources/detectables/functional/npm/dev-exclusion-test/package-lock.json
+++ b/detectable/src/test/resources/detectables/functional/npm/dev-exclusion-test/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "npm-dev",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "child-dev": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "parent-dev": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "child-dev": "3.0.0"
+      }
+    }
+  }
+}

--- a/detectable/src/test/resources/detectables/functional/npm/dev-exclusion-test/package.json
+++ b/detectable/src/test/resources/detectables/functional/npm/dev-exclusion-test/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "npm-dev",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "parent-dev": "^2.0.0"
+  }
+}


### PR DESCRIPTION
# Description

The bug happened because I was shoving the 'devDependencies' and 'dependencies' into a fake 'requires' and assuming the dev filter would catch it.

But I think the real problem was treating the project as a dependency because they happened to look similar but in reality I think the project is different enough to get it's own model. 

# Issues

Fixes IDETECT-1209
