### PR TITLE
Sb clang include epoch in ext

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/ClangPackageManagerFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/ClangPackageManagerFactory.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
 import com.synopsys.integration.detectable.detectables.clang.packagemanager.resolver.ApkArchitectureResolver;
 import com.synopsys.integration.detectable.detectables.clang.packagemanager.resolver.ApkPackageManagerResolver;
 import com.synopsys.integration.detectable.detectables.clang.packagemanager.resolver.DpkgPackageManagerResolver;
@@ -51,7 +52,7 @@ public class ClangPackageManagerFactory {
 
         packageManagers.add(new ClangPackageManager(packageManagerInfoFactory.apk(), new ApkPackageManagerResolver(new ApkArchitectureResolver())));
         packageManagers.add(new ClangPackageManager(packageManagerInfoFactory.dpkg(), new DpkgPackageManagerResolver(new DpkgVersionResolver())));
-        packageManagers.add(new ClangPackageManager(packageManagerInfoFactory.rpm(), new RpmPackageManagerResolver()));
+        packageManagers.add(new ClangPackageManager(packageManagerInfoFactory.rpm(), new RpmPackageManagerResolver(new Gson())));
 
         return packageManagers;
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/ClangPackageManagerInfoFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/ClangPackageManagerInfoFactory.java
@@ -54,7 +54,7 @@ public class ClangPackageManagerInfoFactory {
         rpm.setForge(Forge.CENTOS, Forge.FEDORA, Forge.REDHAT);
         rpm.setPresenceCheckArguments("--version");
         rpm.setPresenceCheckExpectedText("RPM version");
-        rpm.setGetOwnerArguments("-qf");
+        rpm.setGetOwnerArguments("-qf", "--queryformat=\\{ epoch: \\\"%{E}\\\", name: \\\"%{N}\\\", version: \\\"%{V}-%{R}\\\", arch: \\\"%{ARCH}\\\" \\}");
         return rpm.build();
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/RpmPackage.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/RpmPackage.java
@@ -1,0 +1,54 @@
+/**
+ * detectable
+ *
+ * Copyright (c) 2019 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.detectable.detectables.clang.packagemanager.resolver;
+
+public class RpmPackage {
+    private final String epoch;
+    private final String name;
+    private final String version;
+    private final String arch;
+
+    public RpmPackage(final String epoch, final String name, final String version, final String arch) {
+        super();
+        this.epoch = epoch;
+        this.name = name;
+        this.version = version;
+        this.arch = arch;
+    }
+
+    public String getEpoch() {
+        return epoch;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getArch() {
+        return arch;
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageDetailsTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageDetailsTransformerTest.java
@@ -1,0 +1,60 @@
+package com.synopsys.integration.detectable.detectables.clang.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.bdio.model.Forge;
+import com.synopsys.integration.bdio.model.dependency.Dependency;
+import com.synopsys.integration.bdio.model.externalid.ExternalId;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
+import com.synopsys.integration.detectable.detectables.clang.dependencyfile.ClangPackageDetailsTransformer;
+import com.synopsys.integration.detectable.detectables.clang.packagemanager.PackageDetails;
+
+public class ClangPackageDetailsTransformerTest {
+
+    @Test
+    public void testUbuntu() {
+
+        final ExternalIdFactory externalIdFactory = Mockito.mock(ExternalIdFactory.class);
+        final ClangPackageDetailsTransformer transformer = new ClangPackageDetailsTransformer(externalIdFactory);
+
+        final Forge codeLocationForge = null;
+        final List<Forge> dependencyForges = new ArrayList<>();
+        final Forge forge = Forge.UBUNTU;
+        dependencyForges.add(forge);
+
+        final File rootDir = null;
+        final Set<PackageDetails> packages = new HashSet<>();
+
+        final String packageName = "testPkgName";
+        final String packageVersion = "1:testPkgVersion";
+        final String packageArch = "testArch";
+        final PackageDetails pkg = new PackageDetails(packageName, packageVersion, packageArch);
+        packages.add(pkg);
+
+        final ExternalId externalId = new ExternalId(forge);
+        externalId.name = packageName;
+        externalId.version = packageVersion;
+        externalId.architecture = packageArch;
+
+        // The real test is: Does this get called: (if not, test will fail)
+        Mockito.when(externalIdFactory.createArchitectureExternalId(forge, packageName, packageVersion, packageArch)).thenReturn(externalId);
+        final CodeLocation codeLocation = transformer.toCodeLocation(codeLocationForge, dependencyForges, rootDir, packages);
+
+        assertEquals(1, codeLocation.getDependencyGraph().getRootDependencies().size());
+        final Dependency generatedDependency = codeLocation.getDependencyGraph().getRootDependencies().iterator().next();
+        assertEquals(packageName, generatedDependency.name);
+        assertEquals(packageVersion, generatedDependency.version);
+        final String expectedExternalId = String.format("%s/%s/%s", packageName, packageVersion, packageArch);
+        assertEquals(expectedExternalId, generatedDependency.externalId.createExternalId());
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageDetailsTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageDetailsTransformerTest.java
@@ -22,14 +22,21 @@ import com.synopsys.integration.detectable.detectables.clang.packagemanager.Pack
 public class ClangPackageDetailsTransformerTest {
 
     @Test
-    public void testUbuntu() {
+    public void testDpkg() {
+        doTest(Forge.UBUNTU);
+    }
 
+    @Test
+    public void testRpm() {
+        doTest(Forge.CENTOS);
+    }
+
+    private void doTest(final Forge forge) {
         final ExternalIdFactory externalIdFactory = Mockito.mock(ExternalIdFactory.class);
         final ClangPackageDetailsTransformer transformer = new ClangPackageDetailsTransformer(externalIdFactory);
 
         final Forge codeLocationForge = null;
         final List<Forge> dependencyForges = new ArrayList<>();
-        final Forge forge = Forge.UBUNTU;
         dependencyForges.add(forge);
 
         final File rootDir = null;
@@ -54,7 +61,9 @@ public class ClangPackageDetailsTransformerTest {
         final Dependency generatedDependency = codeLocation.getDependencyGraph().getRootDependencies().iterator().next();
         assertEquals(packageName, generatedDependency.name);
         assertEquals(packageVersion, generatedDependency.version);
+        assertEquals(forge, generatedDependency.externalId.forge);
         final String expectedExternalId = String.format("%s/%s/%s", packageName, packageVersion, packageArch);
         assertEquals(expectedExternalId, generatedDependency.externalId.createExternalId());
     }
+
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/DpkgPackageManagerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/DpkgPackageManagerTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.detectable.detectable.executable.ExecutableOutput;
@@ -65,6 +65,61 @@ public class DpkgPackageManagerTest {
         assertEquals(1, pkgs.size());
         assertEquals("libc6-dev", pkgs.get(0).getPackageName());
         assertEquals("2.27-3ubuntu1", pkgs.get(0).getPackageVersion());
+        assertEquals("amd64", pkgs.get(0).getPackageArch());
+    }
+
+    @Test
+    public void testEpoch() throws ExecutableRunnerException {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("garbage\n");
+        sb.append("nonsense\n");
+        sb.append("login:amd64: /usr/include/stdlib.h\n");
+        final String pkgMgrOwnedByOutput = sb.toString();
+
+        sb = new StringBuilder();
+
+        sb.append("Package: login\n");
+        sb.append("Essential: yes\n");
+        sb.append("Status: install ok installed\n");
+        sb.append("Priority: required\n");
+        sb.append("Section: admin\n");
+        sb.append("Installed-Size: 1212\n");
+        sb.append("Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\n");
+        sb.append("Architecture: amd64\n");
+        sb.append("Source: shadow\n");
+        sb.append("Version: 1:4.5-1ubuntu1\n");
+        sb.append("Replaces: manpages-de (<< 0.5-3), manpages-tr (<< 1.0.5), manpages-zh (<< 1.5.1-1)\n");
+        sb.append("Pre-Depends: libaudit1 (>= 1:2.2.1), libc6 (>= 2.14), libpam0g (>= 0.99.7.1), libpam-runtime, libpam-modules (>= 1.1.8-1)\n");
+        sb.append("Conflicts: amavisd-new (<< 2.3.3-8), backupninja (<< 0.9.3-5), echolot (<< 2.1.8-4), gnunet (<< 0.7.0c-2), python-4suite (<< 0.99cvs20060405-1)\n");
+        sb.append("Conffiles:\n");
+        sb.append(" /etc/login.defs 2a8f6cd8e00f54df72dc345a23f9db20\n");
+        sb.append(" /etc/pam.d/login 1fd6cb4d4267a68148ee9973510a9d3e\n");
+        sb.append(" /etc/pam.d/su ce6dcfda3b190a27a455bb38a45ff34a\n");
+        sb.append(" /etc/securetty d0124b1d2fb22d4ac9a91aa02ae6d6db\n");
+        sb.append("Description: system login tools\n");
+        sb.append(" These tools are required to be able to login and use your system. The\n");
+        sb.append(" login program invokes your user shell and enables command execution. The\n");
+        sb.append(" newgrp program is used to change your effective group ID (useful for\n");
+        sb.append(" workgroup type situations). The su program allows changing your effective\n");
+        sb.append(" user ID (useful being able to execute commands as another user).\n");
+        sb.append("Homepage: https://github.com/shadow-maint/shadow\n");
+        sb.append("Original-Maintainer: Shadow package maintainers <pkg-shadow-devel@lists.alioth.debian.org>\n");
+
+        final String pkgMgrVersionOutput = sb.toString();
+
+        String packageName = "login";
+        final ExecutableRunner executableRunner = Mockito.mock(ExecutableRunner.class);
+        Mockito.when(executableRunner.execute(null, "dpkg", Arrays.asList("-s", packageName))).thenReturn(new ExecutableOutput(0, pkgMgrVersionOutput, ""));
+
+        DpkgVersionResolver dpkgVersionResolver = new DpkgVersionResolver();
+        final DpkgPackageManagerResolver pkgMgr = new DpkgPackageManagerResolver(dpkgVersionResolver);
+
+        final List<PackageDetails> pkgs = pkgMgr.resolvePackages(new ClangPackageManagerInfoFactory().dpkg(), executableRunner, null, pkgMgrOwnedByOutput);
+
+        assertEquals(1, pkgs.size());
+        assertEquals("login", pkgs.get(0).getPackageName());
+        assertEquals("1:4.5-1ubuntu1", pkgs.get(0).getPackageVersion());
         assertEquals("amd64", pkgs.get(0).getPackageArch());
     }
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/RpmPackageManagerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/RpmPackageManagerTest.java
@@ -1,12 +1,17 @@
 package com.synopsys.integration.detectable.detectables.clang.unit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import com.google.gson.Gson;
+import com.synopsys.integration.detectable.detectable.executable.ExecutableRunner;
 import com.synopsys.integration.detectable.detectable.executable.ExecutableRunnerException;
+import com.synopsys.integration.detectable.detectables.clang.packagemanager.ClangPackageManagerInfo;
 import com.synopsys.integration.detectable.detectables.clang.packagemanager.ClangPackageManagerInfoFactory;
 import com.synopsys.integration.detectable.detectables.clang.packagemanager.PackageDetails;
 import com.synopsys.integration.detectable.detectables.clang.packagemanager.resolver.RpmPackageManagerResolver;
@@ -14,17 +19,32 @@ import com.synopsys.integration.detectable.detectables.clang.packagemanager.reso
 public class RpmPackageManagerTest {
 
     @Test
-    public void testValid() throws ExecutableRunnerException {
+    public void testValidNoEpoch() throws ExecutableRunnerException {
         final StringBuilder sb = new StringBuilder();
-        sb.append("glibc-headers-2.17-222.el7.x86_64\n");
+        sb.append("{ epoch: \"(none)\", name: \"boost-devel\", version: \"1.53.0-27.el7\", arch: \"x86_64\" }\n");
         final String pkgMgrOwnedByOutput = sb.toString();
 
-        final RpmPackageManagerResolver pkgMgr = new RpmPackageManagerResolver();
+        final RpmPackageManagerResolver pkgMgr = new RpmPackageManagerResolver(new Gson());
         final List<PackageDetails> pkgs = pkgMgr.resolvePackages(new ClangPackageManagerInfoFactory().rpm(), null, null, pkgMgrOwnedByOutput);
 
         assertEquals(1, pkgs.size());
-        assertEquals("glibc-headers", pkgs.get(0).getPackageName());
-        assertEquals("2.17-222.el7", pkgs.get(0).getPackageVersion());
+        assertEquals("boost-devel", pkgs.get(0).getPackageName());
+        assertEquals("1.53.0-27.el7", pkgs.get(0).getPackageVersion());
+        assertEquals("x86_64", pkgs.get(0).getPackageArch());
+    }
+
+    @Test
+    public void testValidWithEpoch() throws ExecutableRunnerException {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("{ epoch: \"9\", name: \"boost-devel\", version: \"1.53.0-27.el7\", arch: \"x86_64\" }\n");
+        final String pkgMgrOwnedByOutput = sb.toString();
+
+        final RpmPackageManagerResolver pkgMgr = new RpmPackageManagerResolver(new Gson());
+        final List<PackageDetails> pkgs = pkgMgr.resolvePackages(new ClangPackageManagerInfoFactory().rpm(), null, null, pkgMgrOwnedByOutput);
+
+        assertEquals(1, pkgs.size());
+        assertEquals("boost-devel", pkgs.get(0).getPackageName());
+        assertEquals("9:1.53.0-27.el7", pkgs.get(0).getPackageVersion());
         assertEquals("x86_64", pkgs.get(0).getPackageArch());
     }
 
@@ -36,10 +56,39 @@ public class RpmPackageManagerTest {
         sb.append("file /opt/hub-detect/clang-repos/hello_world/hello_world.cpp is not owned by any package\n");
         final String pkgMgrOwnedByOutput = sb.toString();
 
-        final RpmPackageManagerResolver pkgMgr = new RpmPackageManagerResolver();
+        final RpmPackageManagerResolver pkgMgr = new RpmPackageManagerResolver(new Gson());
         final List<PackageDetails> pkgs = pkgMgr.resolvePackages(new ClangPackageManagerInfoFactory().rpm(), null, null, pkgMgrOwnedByOutput);
 
         assertEquals(0, pkgs.size());
     }
 
+    @Test
+    public void testResolve() throws ExecutableRunnerException {
+
+        final RpmPackageManagerResolver resolver = new RpmPackageManagerResolver(new Gson());
+        final ClangPackageManagerInfo currentPackageManager = null;
+        final ExecutableRunner executableRunner = null;
+        final File workingDirectory = null;
+        final String queryPackageOutput = "{ epoch: \"(none)\", name: \"glibc-headers\", version: \"2.17-222.el7\", arch: \"x86_64\" }\n" +
+            "{ epoch: \"3\", name: \"test-package\", version: \"test-version\", arch: \"test_arch\" }\n";
+
+        final List<PackageDetails> pkgs = resolver.resolvePackages(currentPackageManager, executableRunner, workingDirectory, queryPackageOutput);
+        assertEquals(2, pkgs.size());
+        boolean foundGLibcHeaders = false;
+        boolean foundTestPkg = false;
+        for (final PackageDetails pkg : pkgs) {
+            if (pkg.getPackageName().equals("glibc-headers")) {
+                foundGLibcHeaders = true;
+                assertEquals("2.17-222.el7", pkg.getPackageVersion());
+                assertEquals("x86_64", pkg.getPackageArch());
+            }
+            if (pkg.getPackageName().equals("test-package")) {
+                foundTestPkg = true;
+                assertEquals("3:test-version", pkg.getPackageVersion());
+                assertEquals("test_arch", pkg.getPackageArch());
+            }
+        }
+        assertTrue(foundGLibcHeaders);
+        assertTrue(foundTestPkg);
+    }
 }


### PR DESCRIPTION
Clang: DPKG and RPM packages may or may not specify a version string. If specified, it should be be prefixed to the version string as: epoch:version. These changes make that happen. For DPKG, the epoch was already being included (no special code required since it's included in the version string in the pkg mgr command output) so I just added tests to verify that. 

For RPM, the pkg mgr command, and the way it is parsed, have changed to include epoch in version. The epoch is not built into the version string by the pkg mgr, so that work needs to be done in Detect code.