### PR TITLE
feat(file-filter) Added the ability to supply a path to a directory to exclude.

### DIFF
--- a/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
@@ -286,6 +286,10 @@ public enum DetectProperty {
     DETECT_DETECTOR_SEARCH_EXCLUSION_PATTERNS("detect.detector.search.exclusion.patterns", " Detector Directory Patterns Exclusions", "3.2.0", PropertyType.STRING_ARRAY, PropertyAuthority.None),
 
     @HelpGroup(primary = GROUP_PATHS, additional = { GROUP_DETECTOR, SEARCH_GROUP_GLOBAL, GROUP_SOURCE_SCAN })
+    @HelpDescription("A comma-separated list of directory paths to exclude from detector search. (e.g. 'foo/bar/biz' will only exclude the 'biz' directory if the parent directory structure is 'foo/bar/'.)")
+    DETECT_DETECTOR_SEARCH_EXCLUSION_PATHS("detect.detector.search.exclusion.paths", " Detector Directory Path Exclusions", "5.5.0", PropertyType.STRING_ARRAY, PropertyAuthority.None),
+
+    @HelpGroup(primary = GROUP_PATHS, additional = { GROUP_DETECTOR, SEARCH_GROUP_GLOBAL, GROUP_SOURCE_SCAN })
     @HelpDescription("If true, the bom tool search will exclude the default directory names. See the detailed help for more information.")
     @HelpDetailed("If true, these directories will be excluded from the detector search: " + DetectorSearchExcludedDirectories.DIRECTORY_NAMES)
     DETECT_DETECTOR_SEARCH_EXCLUSION_DEFAULTS("detect.detector.search.exclusion.defaults", "Detector Exclude Default Directories", "3.2.0", PropertyType.BOOLEAN, PropertyAuthority.None, "true"),
@@ -676,7 +680,7 @@ public enum DetectProperty {
     @AcceptableValues(value = { "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "OFF" }, caseSensitive = false, strict = true)
     LOGGING_LEVEL_COM_SYNOPSYS_INTEGRATION("logging.level.com.synopsys.integration", "Logging Level", "5.3.0", PropertyType.STRING, PropertyAuthority.None, "INFO"),
 
-    @HelpGroup(primary = GROUP_GENERAL, additional =  { SEARCH_GROUP_GLOBAL })
+    @HelpGroup(primary = GROUP_GENERAL, additional = { SEARCH_GROUP_GLOBAL })
     @HelpDescription("If set to true, Detect will wait for Synopsys products until results are available or the blackduck.timeout is exceeded.")
     DETECT_WAIT_FOR_RESULTS("detect.wait.for.results", "Wait For Results", "5.5.0", PropertyType.BOOLEAN, PropertyAuthority.None, "false"),
     /**********************************************************************************************

--- a/src/main/groovy/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/groovy/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -22,6 +22,7 @@
  */
 package com.synopsys.integration.detect.configuration;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -34,14 +35,15 @@ import com.synopsys.integration.detect.tool.signaturescanner.BlackDuckSignatureS
 import com.synopsys.integration.detect.util.filter.DetectToolFilter;
 import com.synopsys.integration.detect.workflow.bdio.BdioOptions;
 import com.synopsys.integration.detect.workflow.blackduck.BlackDuckPostOptions;
+import com.synopsys.integration.detect.workflow.blackduck.DetectProjectServiceOptions;
 import com.synopsys.integration.detect.workflow.file.AirGapOptions;
 import com.synopsys.integration.detect.workflow.file.DirectoryOptions;
-import com.synopsys.integration.detect.workflow.blackduck.DetectProjectServiceOptions;
 import com.synopsys.integration.detect.workflow.project.ProjectNameVersionOptions;
 import com.synopsys.integration.detector.evaluation.DetectorEvaluationOptions;
 import com.synopsys.integration.detector.finder.DetectorFinderOptions;
 import com.synopsys.integration.util.EnumUtils;
 
+// TODO: Create private method for accessing properties that assumes a PropertyAuthority of NONE.
 public class DetectConfigurationFactory {
     private final DetectConfiguration detectConfiguration;
 
@@ -91,14 +93,15 @@ public class DetectConfigurationFactory {
         return new AirGapOptions(dockerOverride, gradleOverride, nugetOverride);
     }
 
-    public DetectorFinderOptions createSearchOptions() {
+    public DetectorFinderOptions createSearchOptions(final Path sourcePath) {
         //Normal settings
         final int maxDepth = detectConfiguration.getIntegerProperty(DetectProperty.DETECT_DETECTOR_SEARCH_DEPTH, PropertyAuthority.None);
 
         //File Filter
         final List<String> excludedDirectories = Arrays.asList(detectConfiguration.getStringArrayProperty(DetectProperty.DETECT_DETECTOR_SEARCH_EXCLUSION, PropertyAuthority.None));
         final List<String> excludedDirectoryPatterns = Arrays.asList(detectConfiguration.getStringArrayProperty(DetectProperty.DETECT_DETECTOR_SEARCH_EXCLUSION_PATTERNS, PropertyAuthority.None));
-        DetectDetectorFileFilter fileFilter = new DetectDetectorFileFilter(excludedDirectories, excludedDirectoryPatterns);
+        final List<String> excludedDirectoryPaths = Arrays.asList(detectConfiguration.getStringArrayProperty(DetectProperty.DETECT_DETECTOR_SEARCH_EXCLUSION_PATHS, PropertyAuthority.None));
+        final DetectDetectorFileFilter fileFilter = new DetectDetectorFileFilter(sourcePath, excludedDirectories, excludedDirectoryPaths, excludedDirectoryPatterns);
 
         return new DetectorFinderOptions(fileFilter, maxDepth);
     }

--- a/src/test/groovy/com/synopsys/integration/detect/tool/detector/impl/DetectDetectorFileFilterTest.java
+++ b/src/test/groovy/com/synopsys/integration/detect/tool/detector/impl/DetectDetectorFileFilterTest.java
@@ -1,0 +1,70 @@
+package com.synopsys.integration.detect.tool.detector.impl;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+class DetectDetectorFileFilterTest {
+    @Test
+    void testIsExcludedDirectories() {
+        final Path sourcePath = new File("my/file/path").toPath();
+        final List<String> excludedDirectories = Arrays.asList("root", "root2");
+        final List<String> excludedDirectoryPaths = new ArrayList<>();
+        final List<String> excludedDirectoryNamePatterns = new ArrayList<>();
+        final DetectDetectorFileFilter detectDetectorFileFilter = new DetectDetectorFileFilter(sourcePath, excludedDirectories, excludedDirectoryPaths, excludedDirectoryNamePatterns);
+
+        final File root = new File(sourcePath.toFile(), "root");
+        final File root2 = new File(sourcePath.toFile(), "root2");
+        final File doNotExcludeDir = new File(root, "doNotExclude");
+
+        Assert.assertTrue(detectDetectorFileFilter.isExcluded(root));
+        Assert.assertTrue(detectDetectorFileFilter.isExcluded(root2));
+        Assert.assertFalse(detectDetectorFileFilter.isExcluded(doNotExcludeDir));
+    }
+
+    @Test
+    void testIsExcludedDirectoryPaths() {
+        final Path sourcePath = new File("my/subDir1/subDir2/file/path").toPath();
+        final List<String> excludedDirectories = new ArrayList<>();
+        final List<String> excludedDirectoryPaths = Collections.singletonList("subDir1/subDir2");
+        final List<String> excludedDirectoryNamePatterns = new ArrayList<>();
+        final DetectDetectorFileFilter detectDetectorFileFilter = new DetectDetectorFileFilter(sourcePath, excludedDirectories, excludedDirectoryPaths, excludedDirectoryNamePatterns);
+
+        final File root = new File("path/to/root");
+        final File subDir1 = new File(root, "subDir1");
+        final File subDir2 = new File(root, "subDir2");
+        final File deepSubDir2 = new File(subDir1, "subDir2");
+
+        Assert.assertFalse(detectDetectorFileFilter.isExcluded(root));
+        Assert.assertFalse(detectDetectorFileFilter.isExcluded(subDir1));
+        Assert.assertFalse(detectDetectorFileFilter.isExcluded(subDir2));
+        Assert.assertTrue(detectDetectorFileFilter.isExcluded(deepSubDir2));
+    }
+
+    @Test
+    void testIsExcludedDirectoryNamePatterns() {
+        final Path sourcePath = new File("my/subDir1/subDir2/file/path").toPath();
+        final List<String> excludedDirectories = new ArrayList<>();
+        final List<String> excludedDirectoryPaths = new ArrayList<>();
+        final List<String> excludedDirectoryNamePatterns = Arrays.asList("*1", "namePatternsDir*");
+        final DetectDetectorFileFilter detectDetectorFileFilter = new DetectDetectorFileFilter(sourcePath, excludedDirectories, excludedDirectoryPaths, excludedDirectoryNamePatterns);
+
+        final File root = new File(sourcePath.toFile(), "root");
+        final File subDir1 = new File(root, "subDir1");
+        final File subDir2 = new File(root, "subDir2");
+        final File deepSubDir2 = new File(subDir1, "subDir2");
+        final File namePatternsDir = new File(root, "namePatternsDir51134");
+
+        Assert.assertFalse(detectDetectorFileFilter.isExcluded(root));
+        Assert.assertTrue(detectDetectorFileFilter.isExcluded(subDir1));
+        Assert.assertFalse(detectDetectorFileFilter.isExcluded(subDir2));
+        Assert.assertFalse(detectDetectorFileFilter.isExcluded(deepSubDir2));
+        Assert.assertTrue(detectDetectorFileFilter.isExcluded(namePatternsDir));
+    }
+}


### PR DESCRIPTION
(Fixes IDETECT-1279)

# Description
Given the following directory structure, currently if "biz" is supplied via the "detect.detector.search.exclusion" property, both "biz" directories will be excluded.
foo/
|-- biz/
|-- bar/
\\ ---- biz

With these changes, if the user supplies "bar/biz" via the "detect.detector.search.exclusion.paths" property, only the "biz" with the parent "bar" will be excluded.

Note: I am not in love with this being a separate property from the first, but the fear is overloading the "detect.detector.search.exclusion" property. 
