### PR TITLE
feat(project-info) Uses Git data to figure out default project name/version name. (Fixes IDETECT-1270)

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/GitDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/GitDetectable.java
@@ -1,0 +1,82 @@
+/**
+ * detectable
+ *
+ * Copyright (c) 2019 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.detectable.detectables.git;
+
+import java.io.File;
+
+import com.synopsys.integration.detectable.Detectable;
+import com.synopsys.integration.detectable.DetectableEnvironment;
+import com.synopsys.integration.detectable.Extraction;
+import com.synopsys.integration.detectable.ExtractionEnvironment;
+import com.synopsys.integration.detectable.detectable.file.FileFinder;
+import com.synopsys.integration.detectable.detectable.result.DetectableResult;
+import com.synopsys.integration.detectable.detectable.result.FileNotFoundDetectableResult;
+import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
+
+public class GitDetectable extends Detectable {
+    private static final String GIT_DIRECTORY_NAME = ".git";
+    private static final String GIT_CONFIG_FILENAME = "config";
+    private static final String GIT_HEAD_FILENAME = "HEAD";
+
+    private final FileFinder fileFinder;
+    private final GitExtractor gitExtractor;
+
+    private File gitConfigFile;
+    private File gitHeadFile;
+
+    public GitDetectable(final DetectableEnvironment environment, final FileFinder fileFinder, final GitExtractor gitExtractor) {
+        super(environment, "Git", "GIT");
+        this.fileFinder = fileFinder;
+        this.gitExtractor = gitExtractor;
+    }
+
+    @Override
+    public DetectableResult applicable() {
+        final File gitDirectory = fileFinder.findFile(environment.getDirectory(), GIT_DIRECTORY_NAME);
+        if (gitDirectory == null) {
+            return new FileNotFoundDetectableResult(GIT_DIRECTORY_NAME);
+        }
+
+        gitConfigFile = fileFinder.findFile(gitDirectory, GIT_CONFIG_FILENAME);
+        gitHeadFile = fileFinder.findFile(gitDirectory, GIT_HEAD_FILENAME);
+
+        if (gitConfigFile == null) {
+            return new FileNotFoundDetectableResult(GIT_CONFIG_FILENAME);
+        } else if (gitHeadFile == null) {
+            return new FileNotFoundDetectableResult(GIT_HEAD_FILENAME);
+        }
+
+        return new PassedDetectableResult();
+    }
+
+    @Override
+    public DetectableResult extractable() {
+        return new PassedDetectableResult();
+    }
+
+    @Override
+    public Extraction extract(final ExtractionEnvironment extractionEnvironment) {
+        return gitExtractor.extract(gitConfigFile, gitHeadFile);
+    }
+
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/GitExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/GitExtractor.java
@@ -1,0 +1,74 @@
+package com.synopsys.integration.detectable.detectables.git;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.synopsys.integration.detectable.Extraction;
+import com.synopsys.integration.detectable.detectables.git.model.GitConfigElement;
+import com.synopsys.integration.detectable.detectables.git.parse.GitFileParser;
+import com.synopsys.integration.exception.IntegrationException;
+
+public class GitExtractor {
+    private final GitFileParser gitFileParser;
+
+    public GitExtractor(final GitFileParser gitFileParser) {
+        this.gitFileParser = gitFileParser;
+    }
+
+    public final Extraction extract(final File gitConfigFile, final File gitHeadFile) {
+        Extraction extraction;
+
+        try (final InputStream gitConfigInputStream = new FileInputStream(gitConfigFile); final InputStream headFileInputStream = new FileInputStream(gitHeadFile)) {
+            final String gitHead = gitFileParser.parseGitHead(headFileInputStream);
+            final List<GitConfigElement> gitConfigElements = gitFileParser.parseGitConfig(gitConfigInputStream);
+
+            final Optional<GitConfigElement> currentBranch = gitConfigElements.stream()
+                                                                 .filter(gitConfigElement -> gitConfigElement.getElementType().equals("branch"))
+                                                                 .filter(gitConfigElement -> gitConfigElement.containsKey("merge"))
+                                                                 .filter(gitConfigElement -> gitConfigElement.getProperty("merge").equalsIgnoreCase(gitHead))
+                                                                 .filter(gitConfigElement -> gitConfigElement.containsKey("remote"))
+                                                                 .findFirst();
+
+            final Optional<String> currentBranchRemoteName = currentBranch
+                                                                 .map(gitConfigElement -> gitConfigElement.getProperty("remote"));
+
+            if (!currentBranchRemoteName.isPresent()) {
+                throw new IntegrationException(String.format("Failed to find a remote name for head %s", gitHead));
+            }
+
+            final Optional<String> remoteUrlOptional = gitConfigElements.stream()
+                                                           .filter(gitConfigElement -> gitConfigElement.getElementType().equals("remote"))
+                                                           .filter(gitConfigElement -> gitConfigElement.getName().isPresent())
+                                                           .filter(gitConfigElement -> gitConfigElement.getName().get().equals(currentBranchRemoteName.get()))
+                                                           .filter(gitConfigElement -> gitConfigElement.containsKey("url"))
+                                                           .map(gitConfigElement -> gitConfigElement.getProperty("url"))
+                                                           .findAny();
+
+            if (!remoteUrlOptional.isPresent()) {
+                throw new IntegrationException("Failed to find a remote url.");
+            }
+
+            final URL remoteURL = new URL(remoteUrlOptional.get());
+            final String path = remoteURL.getPath();
+            final String projectName = StringUtils.removeEnd(StringUtils.removeStart(path, "/"), ".git");
+            final String projectVersionName = currentBranch.get().getName().orElse(null);
+
+            extraction = new Extraction.Builder()
+                             .success()
+                             .projectName(projectName)
+                             .projectVersion(projectVersionName)
+                             .build();
+        } catch (final IOException | IntegrationException e) {
+            extraction = new Extraction.Builder().exception(e).failure("Failed to parse git config.").build();
+        }
+
+        return extraction;
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/model/GitConfigElement.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/model/GitConfigElement.java
@@ -1,0 +1,32 @@
+package com.synopsys.integration.detectable.detectables.git.model;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class GitConfigElement {
+    private final String elementType;
+    private final String name;
+    private final Map<String, String> properties;
+
+    public GitConfigElement(final String elementType, final String name, final Map<String, String> properties) {
+        this.elementType = elementType;
+        this.name = name;
+        this.properties = properties;
+    }
+
+    public String getElementType() {
+        return elementType;
+    }
+
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    public String getProperty(final String propertyKey) {
+        return properties.get(propertyKey);
+    }
+
+    public boolean containsKey(final String key) {
+        return properties.containsKey(key);
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/parse/GitFileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/parse/GitFileParser.java
@@ -1,0 +1,97 @@
+package com.synopsys.integration.detectable.detectables.git.parse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.detectable.detectables.git.model.GitConfigElement;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.log.Slf4jIntLogger;
+
+public class GitFileParser {
+    private final IntLogger logger = new Slf4jIntLogger(LoggerFactory.getLogger(this.getClass()));
+
+    public String parseGitHead(final InputStream inputStream) throws IOException {
+        final String line = IOUtils.toString(inputStream, StandardCharsets.UTF_8).trim();
+        return line.replaceFirst("ref:\\w*", "").trim();
+    }
+
+    public List<GitConfigElement> parseGitConfig(final InputStream inputStream) throws IOException {
+        final List<String> gitConfigLines = IOUtils.readLines(inputStream, StandardCharsets.UTF_8);
+
+        final List<GitConfigElement> gitConfigElements = new ArrayList<>();
+        final List<String> lineBuffer = new ArrayList<>();
+        for (final String rawLine : gitConfigLines) {
+            final String line = StringUtils.stripToEmpty(rawLine);
+
+            if (StringUtils.isBlank(line)) {
+                continue;
+            }
+
+            if (isGitConfigElementStart(line)) {
+                final Optional<GitConfigElement> gitConfigElement = processGitConfigElementLines(lineBuffer);
+                gitConfigElement.ifPresent(gitConfigElements::add);
+                lineBuffer.clear();
+            }
+
+            lineBuffer.add(line);
+        }
+
+        final Optional<GitConfigElement> gitConfigElement = processGitConfigElementLines(lineBuffer);
+        gitConfigElement.ifPresent(gitConfigElements::add);
+
+        return gitConfigElements;
+    }
+
+    private boolean isGitConfigElementStart(final String line) {
+        return line.startsWith("[") && line.endsWith("]");
+    }
+
+    private Optional<GitConfigElement> processGitConfigElementLines(final List<String> lines) {
+        final Map<String, String> properties = new HashMap<>();
+        String elementType = null;
+        String elementName = null;
+
+        for (final String line : lines) {
+            if (isGitConfigElementStart(line)) {
+                final String lineWithoutBrackets = line.replace("[", "").replace("]", "");
+                final String[] pieces = lineWithoutBrackets.split(" ");
+
+                if (pieces.length == 1) {
+                    elementType = pieces[0].trim();
+                } else if (pieces.length == 2) {
+                    elementType = pieces[0].trim();
+                    elementName = pieces[1].replace("\"", "").trim();
+                } else {
+                    logger.warn(String.format("Invalid git config element. Skipping. %s", line));
+                    break;
+                }
+            } else {
+                final String[] pieces = line.split("=");
+
+                if (pieces.length == 2) {
+                    final String propertyKey = pieces[0].trim();
+                    final String propertyValue = pieces[1].trim();
+                    properties.put(propertyKey, propertyValue);
+                } else {
+                    logger.warn(String.format("Invalid git config element property. Skipping. %s", line));
+                }
+            }
+        }
+
+        if (StringUtils.isNotBlank(elementType)) {
+            return Optional.of(new GitConfigElement(elementType, elementName, properties));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/parse/GitFileTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/parse/GitFileTransformer.java
@@ -1,0 +1,49 @@
+package com.synopsys.integration.detectable.detectables.git.parse;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.synopsys.integration.detectable.detectables.git.model.GitConfigElement;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.util.NameVersion;
+
+public class GitFileTransformer {
+    public NameVersion transform(final List<GitConfigElement> gitConfigElements, final String gitHead) throws IntegrationException, MalformedURLException {
+        final Optional<GitConfigElement> currentBranch = gitConfigElements.stream()
+                                                             .filter(gitConfigElement -> gitConfigElement.getElementType().equals("branch"))
+                                                             .filter(gitConfigElement -> gitConfigElement.containsKey("merge"))
+                                                             .filter(gitConfigElement -> gitConfigElement.getProperty("merge").equalsIgnoreCase(gitHead))
+                                                             .filter(gitConfigElement -> gitConfigElement.containsKey("remote"))
+                                                             .findFirst();
+
+        final Optional<String> currentBranchRemoteName = currentBranch
+                                                             .map(gitConfigElement -> gitConfigElement.getProperty("remote"));
+
+        if (!currentBranchRemoteName.isPresent()) {
+            throw new IntegrationException(String.format("Failed to find a remote name for head %s", gitHead));
+        }
+
+        final Optional<String> remoteUrlOptional = gitConfigElements.stream()
+                                                       .filter(gitConfigElement -> gitConfigElement.getElementType().equals("remote"))
+                                                       .filter(gitConfigElement -> gitConfigElement.getName().isPresent())
+                                                       .filter(gitConfigElement -> gitConfigElement.getName().get().equals(currentBranchRemoteName.get()))
+                                                       .filter(gitConfigElement -> gitConfigElement.containsKey("url"))
+                                                       .map(gitConfigElement -> gitConfigElement.getProperty("url"))
+                                                       .findAny();
+
+        if (!remoteUrlOptional.isPresent()) {
+            throw new IntegrationException("Failed to find a remote url.");
+        }
+
+        final URL remoteURL = new URL(remoteUrlOptional.get());
+        final String path = remoteURL.getPath();
+        final String projectName = StringUtils.removeEnd(StringUtils.removeStart(path, "/"), ".git");
+        final String projectVersionName = currentBranch.get().getName().orElse(null);
+
+        return new NameVersion(projectName, projectVersionName);
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/git/parse/GitFileParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/git/parse/GitFileParserTest.java
@@ -1,0 +1,88 @@
+package com.synopsys.integration.detectable.detectables.git.parse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detectable.detectables.git.model.GitConfigElement;
+
+class GitFileParserTest {
+    @Test
+    void parseHeadFile() throws IOException {
+        final GitFileParser gitFileParser = new GitFileParser();
+        final String gitHeadContent = "ref: refs/heads/master\n";
+
+        final InputStream inputStream = IOUtils.toInputStream(gitHeadContent, StandardCharsets.UTF_8);
+        final String head = gitFileParser.parseGitHead(inputStream);
+
+        Assertions.assertEquals("refs/heads/master", head);
+    }
+
+    @Test
+    void parseGitConfig() throws IOException {
+        final GitFileParser gitFileParser = new GitFileParser();
+        final String gitConfigContent = "[core]\n"
+                                            + "\trepositoryformatversion = 0\n"
+                                            + "\tfilemode = true\n"
+                                            + "\tbare = false\n"
+                                            + "\tlogallrefupdates = true\n"
+                                            + "\tignorecase = true\n"
+                                            + "\tprecomposeunicode = true\n"
+                                            + "[remote \"origin\"]\n"
+                                            + "\turl = https://github.com/blackducksoftware/synopsys-detect.git\n"
+                                            + "\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+                                            + "[branch \"master\"]\n"
+                                            + "\tremote = origin\n"
+                                            + "\tmerge = refs/heads/master\n"
+                                            + "[branch \"master-backup\"]\n"
+                                            + "\tremote = origin\n"
+                                            + "\tmerge = refs/heads/master-backup\n"
+                                            + "[branch \"6.0.0-actual\"]\n"
+                                            + "\tremote = origin\n"
+                                            + "\tmerge = refs/heads/6.0.0-actual\n"
+                                            + "[branch \"deployment-test\"]\n"
+                                            + "\tremote = origin\n"
+                                            + "\tmerge = refs/heads/deployment-test\n"
+                                            + "[branch \"verify-config\"]\n"
+                                            + "\tremote = origin\n"
+                                            + "\tmerge = refs/heads/verify-config\n";
+
+        final InputStream inputStream = IOUtils.toInputStream(gitConfigContent, StandardCharsets.UTF_8);
+        final List<GitConfigElement> gitConfigElements = gitFileParser.parseGitConfig(inputStream);
+
+        Assertions.assertEquals(7, gitConfigElements.size());
+
+        final List<GitConfigElement> gitConfigCores = gitConfigElements.stream()
+                                                          .filter(gitConfigElement -> gitConfigElement.getElementType().equals("core"))
+                                                          .collect(Collectors.toList());
+        Assertions.assertEquals(1, gitConfigCores.size());
+
+        final List<GitConfigElement> gitConfigRemotes = gitConfigElements.stream()
+                                                            .filter(gitConfigElement -> gitConfigElement.getElementType().equals("remote"))
+                                                            .collect(Collectors.toList());
+        Assertions.assertEquals(1, gitConfigRemotes.size());
+
+        final List<GitConfigElement> gitConfigBranches = gitConfigElements.stream()
+                                                             .filter(gitConfigElement -> gitConfigElement.getElementType().equals("branch"))
+                                                             .collect(Collectors.toList());
+        Assertions.assertEquals(5, gitConfigBranches.size());
+
+        final Optional<GitConfigElement> remoteOrigin = gitConfigElements.stream()
+                                                            .filter(gitConfigElement -> gitConfigElement.getElementType().equals("remote"))
+                                                            .filter(gitConfigElement -> gitConfigElement.getName().isPresent())
+                                                            .filter(gitConfigElement -> gitConfigElement.getName().get().equals("origin"))
+                                                            .findAny();
+        Assertions.assertTrue(remoteOrigin.isPresent());
+        Assertions.assertTrue(remoteOrigin.get().containsKey("fetch"));
+
+        final String fetch = remoteOrigin.get().getProperty("fetch");
+        Assertions.assertEquals("+refs/heads/*:refs/remotes/origin/*", fetch);
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/git/parse/GitFileTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/git/parse/GitFileTransformerTest.java
@@ -1,0 +1,47 @@
+package com.synopsys.integration.detectable.detectables.git.parse;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detectable.detectables.git.model.GitConfigElement;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.util.NameVersion;
+
+class GitFileTransformerTest {
+
+    @Test
+    void transform() throws MalformedURLException, IntegrationException {
+        final Map<String, String> remoteProperties = new HashMap<>();
+        remoteProperties.put("url", "https://github.com/blackducksoftware/blackduck-artifactory.git");
+        remoteProperties.put("fetch", "+refs/heads/*:refs/remotes/origin/");
+        final GitConfigElement remote = new GitConfigElement("remote", "origin", remoteProperties);
+
+        final Map<String, String> branchProperties = new HashMap<>();
+        branchProperties.put("remote", "origin");
+        branchProperties.put("merge", "refs/heads/master");
+        final GitConfigElement branch = new GitConfigElement("branch", "master", branchProperties);
+
+        final Map<String, String> badBranchProperties = new HashMap<>();
+        badBranchProperties.put("remote", "origin");
+        badBranchProperties.put("merge", "refs/heads/bad-branch");
+        final GitConfigElement badBranch = new GitConfigElement("branch", "bad-branch", badBranchProperties);
+
+        final String gitHead = "refs/heads/master";
+        final List<GitConfigElement> gitConfigElements = new ArrayList<>();
+        gitConfigElements.add(remote);
+        gitConfigElements.add(branch);
+        gitConfigElements.add(badBranch);
+
+        final GitFileTransformer gitFileTransformer = new GitFileTransformer();
+        final NameVersion nameVersion = gitFileTransformer.transform(gitConfigElements, gitHead);
+
+        Assertions.assertEquals("blackducksoftware/blackduck-artifactory", nameVersion.getName());
+        Assertions.assertEquals("master", nameVersion.getVersion());
+    }
+}

--- a/detector/src/main/java/com/synopsys/integration/detector/base/DetectorType.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/base/DetectorType.java
@@ -32,6 +32,7 @@ public enum DetectorType {
     CONDA,
     CPAN,
     CRAN,
+    GIT,
     GO_DEP,
     GO_VNDR,
     GO_VENDOR,

--- a/src/main/groovy/com/synopsys/integration/detect/DetectableBeanConfiguration.java
+++ b/src/main/groovy/com/synopsys/integration/detect/DetectableBeanConfiguration.java
@@ -40,9 +40,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.bdio.BdioTransformer;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.detect.configuration.ConnectionManager;
-import com.synopsys.integration.detect.configuration.DetectProperty;
 import com.synopsys.integration.detect.configuration.DetectableOptionFactory;
-import com.synopsys.integration.detect.configuration.PropertyAuthority;
 import com.synopsys.integration.detect.tool.detector.DetectableFactory;
 import com.synopsys.integration.detect.tool.detector.impl.DetectExecutableResolver;
 import com.synopsys.integration.detect.tool.detector.inspectors.AirgapNugetInspectorInstaller;
@@ -101,6 +99,9 @@ import com.synopsys.integration.detectable.detectables.docker.DockerDetectable;
 import com.synopsys.integration.detectable.detectables.docker.DockerExtractor;
 import com.synopsys.integration.detectable.detectables.docker.DockerInspectorResolver;
 import com.synopsys.integration.detectable.detectables.docker.DockerProperties;
+import com.synopsys.integration.detectable.detectables.git.GitDetectable;
+import com.synopsys.integration.detectable.detectables.git.GitExtractor;
+import com.synopsys.integration.detectable.detectables.git.parse.GitFileParser;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepCliDetectable;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepExtractor;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepLockDetectable;
@@ -307,6 +308,16 @@ public class DetectableBeanConfiguration {
     }
 
     @Bean
+    public GitFileParser gitFileParser() {
+        return new GitFileParser();
+    }
+
+    @Bean
+    public GitExtractor gitExtractor() {
+        return new GitExtractor(gitFileParser());
+    }
+
+    @Bean
     public GoLockParser goLockParser() {
         return new GoLockParser(externalIdFactory);
     }
@@ -393,9 +404,9 @@ public class DetectableBeanConfiguration {
 
     @Bean
     public NugetInspectorResolver nugetInspectorResolver() {
-        NugetInstallerOptions installerOptions = detectableOptionFactory.createNugetInstallerOptions();
-        NugetInspectorInstaller installer;
-        Optional<File> nugetAirGapPath = airGapManager.getNugetInspectorAirGapFile();
+        final NugetInstallerOptions installerOptions = detectableOptionFactory.createNugetInstallerOptions();
+        final NugetInspectorInstaller installer;
+        final Optional<File> nugetAirGapPath = airGapManager.getNugetInspectorAirGapFile();
         if (nugetAirGapPath.isPresent()) {
             installer = new AirgapNugetInspectorInstaller(airGapManager);
         } else {
@@ -650,6 +661,12 @@ public class DetectableBeanConfiguration {
     @Scope(scopeName = BeanDefinition.SCOPE_PROTOTYPE)
     public GemlockDetectable gemlockBomTool(final DetectableEnvironment environment) {
         return new GemlockDetectable(environment, fileFinder, gemlockExtractor());
+    }
+
+    @Bean
+    @Scope(scopeName = BeanDefinition.SCOPE_PROTOTYPE)
+    public GitDetectable gitBomTool(final DetectableEnvironment environment) {
+        return new GitDetectable(environment, fileFinder, gitExtractor());
     }
 
     @Bean

--- a/src/main/groovy/com/synopsys/integration/detect/DetectableBeanConfiguration.java
+++ b/src/main/groovy/com/synopsys/integration/detect/DetectableBeanConfiguration.java
@@ -102,6 +102,7 @@ import com.synopsys.integration.detectable.detectables.docker.DockerProperties;
 import com.synopsys.integration.detectable.detectables.git.GitDetectable;
 import com.synopsys.integration.detectable.detectables.git.GitExtractor;
 import com.synopsys.integration.detectable.detectables.git.parse.GitFileParser;
+import com.synopsys.integration.detectable.detectables.git.parse.GitFileTransformer;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepCliDetectable;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepExtractor;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepLockDetectable;
@@ -313,8 +314,13 @@ public class DetectableBeanConfiguration {
     }
 
     @Bean
+    public GitFileTransformer gitFileTransformer() {
+        return new GitFileTransformer();
+    }
+
+    @Bean
     public GitExtractor gitExtractor() {
-        return new GitExtractor(gitFileParser());
+        return new GitExtractor(gitFileParser(), gitFileTransformer());
     }
 
     @Bean

--- a/src/main/groovy/com/synopsys/integration/detect/tool/detector/DetectableFactory.java
+++ b/src/main/groovy/com/synopsys/integration/detect/tool/detector/DetectableFactory.java
@@ -35,6 +35,7 @@ import com.synopsys.integration.detectable.detectables.conda.CondaCliDetectable;
 import com.synopsys.integration.detectable.detectables.cpan.CpanCliDetectable;
 import com.synopsys.integration.detectable.detectables.cran.PackratLockDetectable;
 import com.synopsys.integration.detectable.detectables.docker.DockerDetectable;
+import com.synopsys.integration.detectable.detectables.git.GitDetectable;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepCliDetectable;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepLockDetectable;
 import com.synopsys.integration.detectable.detectables.go.vendor.GoVendorDetectable;
@@ -99,6 +100,10 @@ public class DetectableFactory implements BeanFactoryAware {
 
     public GemlockDetectable createGemlockDetectable(final DetectableEnvironment environment) {
         return beanFactory.getBean(GemlockDetectable.class, environment);
+    }
+
+    public GitDetectable createGitDetectable(final DetectableEnvironment environment) {
+        return beanFactory.getBean(GitDetectable.class, environment);
     }
 
     public GemspecParseDetectable createGemspecParseDetectable(final DetectableEnvironment environment) {

--- a/src/main/groovy/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
+++ b/src/main/groovy/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
@@ -94,6 +94,8 @@ public class DetectorRuleFactory {
 
         ruleSet.addDetector(DetectorType.CLANG, "Clang", detectableFactory::createClangDetectable).defaultNested().build();
 
+        ruleSet.addDetector(DetectorType.GIT, "Git", detectableFactory::createGitDetectable).defaultNested().build();
+
         return ruleSet.build();
     }
 
@@ -134,6 +136,8 @@ public class DetectorRuleFactory {
         ruleSet.yield(gemspec).to(gemlock);
 
         ruleSet.addDetector(DetectorType.SBT, "Sbt Resolution Cache", detectableFactory::createSbtResolutionCacheDetectable).defaultNotNested().build();
+
+        ruleSet.addDetector(DetectorType.GIT, "Git", detectableFactory::createGitDetectable).defaultNested().build();
 
         return ruleSet.build();
     }


### PR DESCRIPTION
# Description

The default name for projects and versions could be more relevant that "Default Detect Version".
This PR creates a GitDetectable whose only job is to gather project info.
There is some wackiness to how the project name is decided because we only want to use results from Git if there are no other alternatives. If someone has a better was of handling this please speak up.

An example:
Current Branch = 7.0.0
Current Remote = https://github.com/blackducksoftware/blackduck-artifactory.git

Expected Project Name: blackducksoftware/blackduck-artifactory
Expected Project Version Name: 7.0.0