### PR TITLE
fix(git): Git will no longer log invalid URL formats.

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/cli/GitUrlParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/cli/GitUrlParser.java
@@ -23,37 +23,20 @@
 package com.synopsys.integration.detectable.detectables.git.cli;
 
 import java.net.MalformedURLException;
-import java.net.URL;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.synopsys.integration.exception.IntegrationException;
-
 public class GitUrlParser {
-
-    public String getRepoName(final String remoteUrlString) throws IntegrationException, MalformedURLException {
-        final String remoteUrlPath;
-        if (remoteUrlString.startsWith("ssh://") || remoteUrlString.startsWith("git://")) {
-            // Parses urls such as: ssh://user@synopsys.com:12345/blackducksoftware/synopsys-detect
-            final int lastIndexOfSlash = remoteUrlString.lastIndexOf('/');
-            final String projectName = remoteUrlString.substring(lastIndexOfSlash);
-            final String remainder = remoteUrlString.substring(0, lastIndexOfSlash);
-            final int remainderLastIndexOfSlash = remainder.lastIndexOf('/');
-            final String organization = remainder.substring(remainderLastIndexOfSlash);
-            remoteUrlPath = organization + projectName;
-        } else if (remoteUrlString.contains("@")) {
-            // Parses urls such as: git@github.com:blackducksoftware/synopsys-detect.git
-            final String[] tokens = remoteUrlString.split(":");
-            if (tokens.length != 2) {
-                throw new IntegrationException(String.format("Failed to extract project name from: %s", remoteUrlString));
-            }
-            remoteUrlPath = tokens[1].trim();
+    // Parses urls such as: https://github.com/blackducksoftware/synopsys-detect
+    public String getRepoName(final String remoteUrlString) throws MalformedURLException {
+        final String[] pieces = remoteUrlString.split("[/:]");
+        if (pieces.length >= 2) {
+            final String organization = pieces[pieces.length - 2];
+            final String repo = pieces[pieces.length - 1];
+            final String name = String.format("%s/%s", organization, repo);
+            return StringUtils.removeEnd(StringUtils.removeStart(name, "/"), ".git");
         } else {
-            // Parses urls such as: https://github.com/blackducksoftware/synopsys-detect
-            final URL remoteURL = new URL(remoteUrlString);
-            remoteUrlPath = remoteURL.getPath().trim();
+            throw new MalformedURLException("Failed to extract repository name from url. Not logging url for security.");
         }
-
-        return StringUtils.removeEnd(StringUtils.removeStart(remoteUrlPath, "/"), ".git");
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/parsing/parse/GitFileTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/git/parsing/parse/GitFileTransformer.java
@@ -23,17 +23,21 @@
 package com.synopsys.integration.detectable.detectables.git.parsing.parse;
 
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.synopsys.integration.detectable.detectables.git.cli.GitUrlParser;
 import com.synopsys.integration.detectable.detectables.git.parsing.model.GitConfigElement;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.NameVersion;
 
 public class GitFileTransformer {
+    private final GitUrlParser gitUrlParser;
+
+    public GitFileTransformer(final GitUrlParser gitUrlParser) {
+        this.gitUrlParser = gitUrlParser;
+    }
+
     public NameVersion transformGitConfigElements(final List<GitConfigElement> gitConfigElements, final String gitHead) throws IntegrationException, MalformedURLException {
         final Optional<GitConfigElement> currentBranch = gitConfigElements.stream()
                                                              .filter(gitConfigElement -> gitConfigElement.getElementType().equals("branch"))
@@ -61,9 +65,7 @@ public class GitFileTransformer {
             throw new IntegrationException("Failed to find a remote url.");
         }
 
-        final URL remoteURL = new URL(remoteUrlOptional.get());
-        final String path = remoteURL.getPath();
-        final String projectName = StringUtils.removeEnd(StringUtils.removeStart(path, "/"), ".git");
+        final String projectName = gitUrlParser.getRepoName(remoteUrlOptional.get());
         final String projectVersionName = currentBranch.get().getName().orElse(null);
 
         return new NameVersion(projectName, projectVersionName);

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/git/cli/GitUrlParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/git/cli/GitUrlParserTest.java
@@ -43,4 +43,13 @@ class GitUrlParserTest {
 
         Assertions.assertEquals("blackducksoftware/synopsys-detect", repoName);
     }
+
+    @Test
+    void httpsEncodedUsernamePasswordUrl() throws MalformedURLException, IntegrationException {
+        final GitUrlParser gitUrlParser = new GitUrlParser();
+        final String remoteUrl = "https://USERNAME:PASSWORD@SERVER/test/path/to/blackducksoftware/synopsys-detect.git";
+        final String repoName = gitUrlParser.getRepoName(remoteUrl);
+
+        Assertions.assertEquals("blackducksoftware/synopsys-detect", repoName);
+    }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/git/parsing/parse/GitFileTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/git/parsing/parse/GitFileTransformerTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.detectable.detectables.git.cli.GitUrlParser;
 import com.synopsys.integration.detectable.detectables.git.parsing.model.GitConfigElement;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.NameVersion;
@@ -38,7 +39,8 @@ class GitFileTransformerTest {
         gitConfigElements.add(branch);
         gitConfigElements.add(badBranch);
 
-        final GitFileTransformer gitFileTransformer = new GitFileTransformer();
+        final GitUrlParser gitUrlParser = new GitUrlParser();
+        final GitFileTransformer gitFileTransformer = new GitFileTransformer(gitUrlParser);
         final NameVersion nameVersion = gitFileTransformer.transformGitConfigElements(gitConfigElements, gitHead);
 
         Assertions.assertEquals("blackducksoftware/blackduck-artifactory", nameVersion.getName());

--- a/src/main/java/com/synopsys/integration/detect/DetectableBeanConfiguration.java
+++ b/src/main/java/com/synopsys/integration/detect/DetectableBeanConfiguration.java
@@ -332,7 +332,7 @@ public class DetectableBeanConfiguration {
 
     @Bean
     public GitFileTransformer gitFileTransformer() {
-        return new GitFileTransformer();
+        return new GitFileTransformer(gitUrlParser());
     }
 
     @Bean


### PR DESCRIPTION
Git will no longer log invalid URL formats. Simplified git url parsing. GitCliDetectable and GitParseDetectable will both use the GitUrlParser. (Fixes IDETECT-1738)
