### PR TITLE
Avoid transitive vulnerabilities by updating to commons-beanutils 1.9.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ def createBatteryPath() {
 allprojects {
     apply plugin: 'org.jetbrains.kotlin.jvm'
     apply plugin: 'io.spring.dependency-management'
+    
+    configurations.all {
+        resolutionStrategy {
+            force 'commons-beanutils:commons-beanutils:1.9.3', 'commons-beanutils:commons-beanutils:1.9.4'
+        }
+    }
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"


### PR DESCRIPTION
There is a vulnerability in commons-beanutils:commons-beanutils:1.9.3
that is fixed in the subsequent micro release. This change updates all
instances of the vulnerable version, including in transitive
dependencies, to the fixed version
