### PR TITLE
Build fix IDETECT-1797

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,8 +134,7 @@ if ("true" == project.findProperty('refresh.cache')) {
     project.dependencies {
         implementation 'com.blackducksoftware.integration:integration-gradle-inspector:0.6.0'
     }
-
-    project.repositories.clear()
+    
     project.repositories {
         maven {
             url "${project.ext.deployArtifactoryUrl}/bds-integration-public-cache"

--- a/build.gradle
+++ b/build.gradle
@@ -130,22 +130,6 @@ compileTestKotlin {
 
 springBoot { mainClassName = 'com.synopsys.integration.detect.Application' }
 
-if ("true" == project.findProperty('refresh.cache')) {
-    project.dependencies {
-        implementation 'com.blackducksoftware.integration:integration-gradle-inspector:0.6.0'
-    }
-    
-    project.repositories {
-        maven {
-            url "${project.ext.deployArtifactoryUrl}/bds-integration-public-cache"
-            credentials {
-                username = project.ext.artifactoryDeployerUsername
-                password = project.ext.artifactoryDeployerPassword
-            }
-        }
-    }
-}
-
 tasks['testBattery'].doFirst {
     def batteryPath = new File(createBatteryPath())
     batteryPath.mkdirs()


### PR DESCRIPTION
# Description

This pipeline step is failing the Detect build because Detect has dependencies in Jcenter, and this line (https://github.com/blackducksoftware/synopsys-detect/blob/master/build.gradle#L138) is clearing out all repositories which causes this pipeline step to fail.
```
integrationNode()
{
    println "Using directory ${directory}"
    stage("Update Caches")
    {
        dir(directory)
        {
            sh './gradlew clean build -x test -Prefresh.cache=true --info --stacktrace --no-daemon'
        }
    }
}
```

The goal at some point seemed to be to update a cache repository for the gradle inspector so that the dependencies for an air-gapped gradle inspector can be properly resolved. 

It seems like the GradleAirGapCreator class (https://github.com/blackducksoftware/synopsys-detect/blob/master/src/main/java/com/synopsys/integration/detect/workflow/airgap/GradleAirGapCreator.java) creates a build.gradle file from a template (https://github.com/blackducksoftware/synopsys-detect/blob/master/src/main/resources/create-gradle-airgap-script.ftl) with which to resolve dependencies. It resolves dependencies from the "bds-integration-public-cache" repository which is a remote repo with its own cache. I don't see why this repo wouldn't provide the correct dependencies to the build.gradle we build from the template without this update cache step.

I would like to remove the update cache step entirely if it is not needed. If it is needed, perhaps we need to rethink how we are refreshing it.