### PR TITLE
Ac

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ import com.synopsys.integration.log.PrintStreamIntLogger
 buildscript {
     ext {
         springBootVersion = '2.1.5.RELEASE'
-        blackDuckCommonVersion = '45.0.0'
+        blackDuckCommonVersion = '45.0.1'
         polarisCommonVersion = '0.13.2'
         junitPlatformDefaultTestTags = "integration, performance, battery"
     }

--- a/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
@@ -269,6 +269,10 @@ public enum DetectProperty {
     @HelpDescription(category = ADVANCED, value = "If set, this will aggregate all the BOMs to create a single BDIO file with the name provided.")
     DETECT_BOM_AGGREGATE_NAME("detect.bom.aggregate.name", "Aggregate BDIO File Name", "3.0.0", PropertyType.STRING, PropertyAuthority.NONE),
 
+    @HelpGroup(primary = GROUP_PROJECT, additional = { SEARCH_GROUP_PROJECT_SETTING })
+    @HelpDescription(category = ADVANCED, value = "If set to true, aggregate BDIO file will exclude code locations from top layer of dependency tree to preserve correct identification of direct dependencies.")
+    DETECT_BOM_AGGREGATE_DIRECT("detect.bom.aggregate.direct", "BDIO Aggregate Direct", "6.1.0", PropertyType.BOOLEAN, PropertyAuthority.NONE),
+
     @HelpGroup(primary = GROUP_GENERAL, additional = { SEARCH_GROUP_GLOBAL })
     @HelpDescription("If set to true, only Detector's capable of running without a build will be run.")
     DETECT_BUILDLESS("detect.detector.buildless", "Buildless Mode", "5.4.0", PropertyType.BOOLEAN, PropertyAuthority.NONE, "false"),

--- a/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
@@ -270,9 +270,9 @@ public enum DetectProperty {
     DETECT_BOM_AGGREGATE_NAME("detect.bom.aggregate.name", "Aggregate BDIO File Name", "3.0.0", PropertyType.STRING, PropertyAuthority.NONE),
 
     @HelpGroup(primary = GROUP_PROJECT, additional = { SEARCH_GROUP_PROJECT_SETTING })
-    @HelpDescription(category = ADVANCED, value = "If set to DIRECT, aggregate BDIO file will exclude code locations from top layer of dependency tree to preserve correct identification of direct dependencies. Default is TRANSITIVE.")
+    @HelpDescription(category = ADVANCED, value = "If set to DIRECT, aggregate BDIO file will exclude code locations from top layer of dependency tree to preserve correct identification of direct dependencies.")
     @AcceptableValues(value = {"DIRECT", "TRANSITIVE"}, caseSensitive = true, strict = true, isCommaSeparatedList = false)
-    DETECT_BOM_AGGREGATE_MODE("detect.bom.aggregate.mode", "BDIO Aggregate Direct", "6.1.0", PropertyType.STRING, PropertyAuthority.NONE),
+    DETECT_BOM_AGGREGATE_MODE("detect.bom.aggregate.mode", "BDIO Aggregate Direct", "6.1.0", PropertyType.STRING, PropertyAuthority.NONE, "TRANSITIVE"),
 
     @HelpGroup(primary = GROUP_GENERAL, additional = { SEARCH_GROUP_GLOBAL })
     @HelpDescription("If set to true, only Detector's capable of running without a build will be run.")

--- a/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
+++ b/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectProperty.java
@@ -270,8 +270,9 @@ public enum DetectProperty {
     DETECT_BOM_AGGREGATE_NAME("detect.bom.aggregate.name", "Aggregate BDIO File Name", "3.0.0", PropertyType.STRING, PropertyAuthority.NONE),
 
     @HelpGroup(primary = GROUP_PROJECT, additional = { SEARCH_GROUP_PROJECT_SETTING })
-    @HelpDescription(category = ADVANCED, value = "If set to true, aggregate BDIO file will exclude code locations from top layer of dependency tree to preserve correct identification of direct dependencies.")
-    DETECT_BOM_AGGREGATE_DIRECT("detect.bom.aggregate.direct", "BDIO Aggregate Direct", "6.1.0", PropertyType.BOOLEAN, PropertyAuthority.NONE),
+    @HelpDescription(category = ADVANCED, value = "If set to DIRECT, aggregate BDIO file will exclude code locations from top layer of dependency tree to preserve correct identification of direct dependencies. Default is TRANSITIVE.")
+    @AcceptableValues(value = {"DIRECT", "TRANSITIVE"}, caseSensitive = true, strict = true, isCommaSeparatedList = false)
+    DETECT_BOM_AGGREGATE_MODE("detect.bom.aggregate.mode", "BDIO Aggregate Direct", "6.1.0", PropertyType.STRING, PropertyAuthority.NONE),
 
     @HelpGroup(primary = GROUP_GENERAL, additional = { SEARCH_GROUP_GLOBAL })
     @HelpDescription("If set to true, only Detector's capable of running without a build will be run.")

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -77,10 +77,11 @@ public class DetectConfigurationFactory {
 
         final boolean unmapCodeLocations = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PROJECT_CODELOCATION_UNMAP, PropertyAuthority.NONE);
         final String aggregateName = detectConfiguration.getProperty(DetectProperty.DETECT_BOM_AGGREGATE_NAME, PropertyAuthority.NONE);
+        final boolean aggregateDirect = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_BOM_AGGREGATE_DIRECT, PropertyAuthority.NONE);
         final String preferredTools = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_TOOL, PropertyAuthority.NONE);
         final boolean useBdio2 = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_BDIO2_ENABLED, PropertyAuthority.NONE);
 
-        return new RunOptions(unmapCodeLocations, aggregateName, preferredTools, detectToolFilter, useBdio2);
+        return new RunOptions(unmapCodeLocations, aggregateName, aggregateDirect, preferredTools, detectToolFilter, useBdio2);
     }
 
     public DirectoryOptions createDirectoryOptions() {

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -38,6 +38,7 @@ import com.synopsys.integration.detect.tool.signaturescanner.BlackDuckSignatureS
 import com.synopsys.integration.detect.util.DetectEnumUtil;
 import com.synopsys.integration.detect.util.filter.DetectToolFilter;
 import com.synopsys.integration.detect.workflow.airgap.AirGapOptions;
+import com.synopsys.integration.detect.workflow.bdio.AggregateMode;
 import com.synopsys.integration.detect.workflow.bdio.BdioOptions;
 import com.synopsys.integration.detect.workflow.blackduck.BlackDuckPostOptions;
 import com.synopsys.integration.detect.workflow.blackduck.CustomFieldDocument;
@@ -77,11 +78,12 @@ public class DetectConfigurationFactory {
 
         final boolean unmapCodeLocations = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_PROJECT_CODELOCATION_UNMAP, PropertyAuthority.NONE);
         final String aggregateName = detectConfiguration.getProperty(DetectProperty.DETECT_BOM_AGGREGATE_NAME, PropertyAuthority.NONE);
-        final boolean aggregateDirect = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_BOM_AGGREGATE_DIRECT, PropertyAuthority.NONE);
+        final String aggregateMode = detectConfiguration.getProperty(DetectProperty.DETECT_BOM_AGGREGATE_MODE, PropertyAuthority.NONE);
         final String preferredTools = detectConfiguration.getProperty(DetectProperty.DETECT_PROJECT_TOOL, PropertyAuthority.NONE);
         final boolean useBdio2 = detectConfiguration.getBooleanProperty(DetectProperty.DETECT_BDIO2_ENABLED, PropertyAuthority.NONE);
 
-        return new RunOptions(unmapCodeLocations, aggregateName, aggregateDirect, preferredTools, detectToolFilter, useBdio2);
+        AggregateMode aggregateModeEnum = Enum.valueOf(AggregateMode.class, aggregateMode);
+        return new RunOptions(unmapCodeLocations, aggregateName, aggregateModeEnum, preferredTools, detectToolFilter, useBdio2);
     }
 
     public DirectoryOptions createDirectoryOptions() {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunManager.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunManager.java
@@ -145,7 +145,7 @@ public class RunManager {
         final UniversalToolsResult universalToolsResult = runUniversalProjectTools(detectConfiguration, detectConfigurationFactory, directoryManager, eventSystem, runResult, runOptions, detectToolFilter);
 
         if (productRunData.shouldUseBlackDuckProduct()) {
-            final AggregateOptions aggregateOptions = determineAggregationStrategy(runOptions.getAggregateName(), universalToolsResult);
+            final AggregateOptions aggregateOptions = determineAggregationStrategy(runOptions.getAggregateName(), runOptions.shouldAggregateDirect(), universalToolsResult);
             runBlackDuckProduct(productRunData, detectConfiguration, detectConfigurationFactory, directoryManager, eventSystem, codeLocationNameManager, bdioCodeLocationCreator, detectInfo, runResult, runOptions, detectToolFilter,
                 universalToolsResult.getNameVersion(), aggregateOptions);
         } else {
@@ -158,15 +158,15 @@ public class RunManager {
         return runResult;
     }
 
-    private AggregateOptions determineAggregationStrategy(final String aggregateName, final UniversalToolsResult universalToolsResult) {
+    private AggregateOptions determineAggregationStrategy(final String aggregateName, final boolean aggregateDirect, final UniversalToolsResult universalToolsResult) {
         if (StringUtils.isNotBlank(aggregateName)) {
             if (universalToolsResult.anyFailed()) {
-                return AggregateOptions.aggregateButSkipEmpty(aggregateName);
+                return AggregateOptions.aggregateButSkipEmpty(aggregateName, aggregateDirect);
             } else {
-                return AggregateOptions.aggregateAndAlwaysUpload(aggregateName);
+                return AggregateOptions.aggregateAndAlwaysUpload(aggregateName, aggregateDirect);
             }
         } else {
-            return AggregateOptions.doNotAggregate();
+            return AggregateOptions.doNotAggregate(aggregateDirect);
         }
     }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunManager.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunManager.java
@@ -72,6 +72,7 @@ import com.synopsys.integration.detect.tool.signaturescanner.BlackDuckSignatureS
 import com.synopsys.integration.detect.tool.signaturescanner.BlackDuckSignatureScannerTool;
 import com.synopsys.integration.detect.tool.signaturescanner.SignatureScannerToolResult;
 import com.synopsys.integration.detect.util.filter.DetectToolFilter;
+import com.synopsys.integration.detect.workflow.bdio.AggregateMode;
 import com.synopsys.integration.detect.workflow.bdio.AggregateOptions;
 import com.synopsys.integration.detect.workflow.bdio.BdioManager;
 import com.synopsys.integration.detect.workflow.bdio.BdioResult;
@@ -145,7 +146,7 @@ public class RunManager {
         final UniversalToolsResult universalToolsResult = runUniversalProjectTools(detectConfiguration, detectConfigurationFactory, directoryManager, eventSystem, runResult, runOptions, detectToolFilter);
 
         if (productRunData.shouldUseBlackDuckProduct()) {
-            final AggregateOptions aggregateOptions = determineAggregationStrategy(runOptions.getAggregateName(), runOptions.shouldAggregateDirect(), universalToolsResult);
+            final AggregateOptions aggregateOptions = determineAggregationStrategy(runOptions.getAggregateName(), runOptions.getAggregateMode(), universalToolsResult);
             runBlackDuckProduct(productRunData, detectConfiguration, detectConfigurationFactory, directoryManager, eventSystem, codeLocationNameManager, bdioCodeLocationCreator, detectInfo, runResult, runOptions, detectToolFilter,
                 universalToolsResult.getNameVersion(), aggregateOptions);
         } else {
@@ -158,15 +159,15 @@ public class RunManager {
         return runResult;
     }
 
-    private AggregateOptions determineAggregationStrategy(final String aggregateName, final boolean aggregateDirect, final UniversalToolsResult universalToolsResult) {
+    private AggregateOptions determineAggregationStrategy(final String aggregateName, final AggregateMode aggregateMode, final UniversalToolsResult universalToolsResult) {
         if (StringUtils.isNotBlank(aggregateName)) {
             if (universalToolsResult.anyFailed()) {
-                return AggregateOptions.aggregateButSkipEmpty(aggregateName, aggregateDirect);
+                return AggregateOptions.aggregateButSkipEmpty(aggregateName, aggregateMode);
             } else {
-                return AggregateOptions.aggregateAndAlwaysUpload(aggregateName, aggregateDirect);
+                return AggregateOptions.aggregateAndAlwaysUpload(aggregateName, aggregateMode);
             }
         } else {
-            return AggregateOptions.doNotAggregate(aggregateDirect);
+            return AggregateOptions.doNotAggregate();
         }
     }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunOptions.java
@@ -27,13 +27,15 @@ import com.synopsys.integration.detect.util.filter.DetectToolFilter;
 public class RunOptions {
     private final boolean unmapCodeLocations;
     private final String aggregateName;
+    private final boolean aggregateDirect;
     private final String preferredTools;
     private final DetectToolFilter detectToolFilter;
     private final boolean useBdio2;
 
-    public RunOptions(final boolean unmapCodeLocations, final String aggregateName, final String preferredTools, final DetectToolFilter detectToolFilter, final boolean useBdio2) {
+    public RunOptions(final boolean unmapCodeLocations, final String aggregateName, final boolean aggregateDirect, final String preferredTools, final DetectToolFilter detectToolFilter, final boolean useBdio2) {
         this.unmapCodeLocations = unmapCodeLocations;
         this.aggregateName = aggregateName;
+        this.aggregateDirect = aggregateDirect;
         this.preferredTools = preferredTools;
         this.detectToolFilter = detectToolFilter;
         this.useBdio2 = useBdio2;
@@ -45,6 +47,10 @@ public class RunOptions {
 
     public String getAggregateName() {
         return aggregateName;
+    }
+
+    public boolean shouldAggregateDirect() {
+        return aggregateDirect;
     }
 
     public String getPreferredTools() {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunOptions.java
@@ -23,19 +23,20 @@
 package com.synopsys.integration.detect.lifecycle.run;
 
 import com.synopsys.integration.detect.util.filter.DetectToolFilter;
+import com.synopsys.integration.detect.workflow.bdio.AggregateMode;
 
 public class RunOptions {
     private final boolean unmapCodeLocations;
     private final String aggregateName;
-    private final boolean aggregateDirect;
+    private final AggregateMode aggregateMode;
     private final String preferredTools;
     private final DetectToolFilter detectToolFilter;
     private final boolean useBdio2;
 
-    public RunOptions(final boolean unmapCodeLocations, final String aggregateName, final boolean aggregateDirect, final String preferredTools, final DetectToolFilter detectToolFilter, final boolean useBdio2) {
+    public RunOptions(final boolean unmapCodeLocations, final String aggregateName, final AggregateMode aggregateMode, final String preferredTools, final DetectToolFilter detectToolFilter, final boolean useBdio2) {
         this.unmapCodeLocations = unmapCodeLocations;
         this.aggregateName = aggregateName;
-        this.aggregateDirect = aggregateDirect;
+        this.aggregateMode = aggregateMode;
         this.preferredTools = preferredTools;
         this.detectToolFilter = detectToolFilter;
         this.useBdio2 = useBdio2;
@@ -49,8 +50,8 @@ public class RunOptions {
         return aggregateName;
     }
 
-    public boolean shouldAggregateDirect() {
-        return aggregateDirect;
+    public AggregateMode getAggregateMode() {
+        return aggregateMode;
     }
 
     public String getPreferredTools() {

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateBdioCreator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateBdioCreator.java
@@ -130,16 +130,18 @@ public class AggregateBdioCreator {
         }
     }
 
-    private DependencyGraph createAggregateDependencyGraph(final File sourcePath, final List<DetectCodeLocation> codeLocations, final AggregateMode aggregateMode) {
+    private DependencyGraph createAggregateDependencyGraph(final File sourcePath, final List<DetectCodeLocation> codeLocations, final AggregateMode aggregateMode) throws DetectUserFriendlyException {
         final MutableDependencyGraph aggregateDependencyGraph = simpleBdioFactory.createMutableDependencyGraph();
 
         for (final DetectCodeLocation detectCodeLocation : codeLocations) {
             if (aggregateMode.equals(AggregateMode.DIRECT)) {
                 aggregateDependencyGraph.addGraphAsChildrenToRoot(detectCodeLocation.getDependencyGraph());
-            } else {
+            } else if (aggregateMode.equals(AggregateMode.TRANSITIVE)) {
                 final Dependency codeLocationDependency = createAggregateDependency(sourcePath, detectCodeLocation);
                 aggregateDependencyGraph.addChildrenToRoot(codeLocationDependency);
                 aggregateDependencyGraph.addGraphAsChildrenToParent(codeLocationDependency, detectCodeLocation.getDependencyGraph());
+            } else {
+                throw new DetectUserFriendlyException("Did not specify aggregation mode via detect.bom.aggregate.mode, will not aggregate at this time.", ExitCodeType.FAILURE_GENERAL_ERROR);
             }
         }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateBdioCreator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateBdioCreator.java
@@ -78,10 +78,10 @@ public class AggregateBdioCreator {
         this.detectBdioWriter = detectBdioWriter;
     }
 
-    public Optional<UploadTarget> createAggregateBdio1File(final String aggregateName, final boolean aggregateDirect, final boolean uploadEmptyAggregate, final File sourcePath, final File bdioDirectory, final List<DetectCodeLocation> codeLocations,
+    public Optional<UploadTarget> createAggregateBdio1File(final String aggregateName, final AggregateMode aggregateMode, final boolean uploadEmptyAggregate, final File sourcePath, final File bdioDirectory, final List<DetectCodeLocation> codeLocations,
         final NameVersion projectNameVersion) throws DetectUserFriendlyException {
 
-        final DependencyGraph aggregateDependencyGraph = createAggregateDependencyGraph(sourcePath, codeLocations, aggregateDirect);
+        final DependencyGraph aggregateDependencyGraph = createAggregateDependencyGraph(sourcePath, codeLocations, aggregateMode);
         final ExternalId projectExternalId = simpleBdioFactory.createNameVersionExternalId(new Forge("/", "DETECT"), projectNameVersion.getName(), projectNameVersion.getVersion());
         final String codeLocationName = codeLocationNameManager.createAggregateCodeLocationName(projectNameVersion);
 
@@ -95,10 +95,10 @@ public class AggregateBdioCreator {
         return createUploadTarget(codeLocationName, aggregateBdioFile, aggregateDependencyGraph, uploadEmptyAggregate);
     }
 
-    public Optional<UploadTarget> createAggregateBdio2File(final String aggregateName, final boolean aggregateDirect, final boolean uploadEmptyAggregate, final File sourcePath, final File bdioDirectory, final List<DetectCodeLocation> codeLocations,
+    public Optional<UploadTarget> createAggregateBdio2File(final String aggregateName, final AggregateMode aggregateMode, final boolean uploadEmptyAggregate, final File sourcePath, final File bdioDirectory, final List<DetectCodeLocation> codeLocations,
         final NameVersion projectNameVersion) throws DetectUserFriendlyException {
 
-        final DependencyGraph aggregateDependencyGraph = createAggregateDependencyGraph(sourcePath, codeLocations, aggregateDirect);
+        final DependencyGraph aggregateDependencyGraph = createAggregateDependencyGraph(sourcePath, codeLocations, aggregateMode);
         final ExternalId projectExternalId = simpleBdioFactory.createNameVersionExternalId(new Forge("/", "DETECT"), projectNameVersion.getName(), projectNameVersion.getVersion());
         final String codeLocationName = codeLocationNameManager.createAggregateCodeLocationName(projectNameVersion);
 
@@ -130,11 +130,11 @@ public class AggregateBdioCreator {
         }
     }
 
-    private DependencyGraph createAggregateDependencyGraph(final File sourcePath, final List<DetectCodeLocation> codeLocations, final boolean aggregateDirect) {
+    private DependencyGraph createAggregateDependencyGraph(final File sourcePath, final List<DetectCodeLocation> codeLocations, final AggregateMode aggregateMode) {
         final MutableDependencyGraph aggregateDependencyGraph = simpleBdioFactory.createMutableDependencyGraph();
 
         for (final DetectCodeLocation detectCodeLocation : codeLocations) {
-            if (aggregateDirect) {
+            if (aggregateMode.equals(AggregateMode.DIRECT)) {
                 aggregateDependencyGraph.addGraphAsChildrenToRoot(detectCodeLocation.getDependencyGraph());
             } else {
                 final Dependency codeLocationDependency = createAggregateDependency(sourcePath, detectCodeLocation);

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateBdioCreator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateBdioCreator.java
@@ -52,6 +52,7 @@ import com.synopsys.integration.blackduck.bdio2.Bdio2Document;
 import com.synopsys.integration.blackduck.bdio2.Bdio2Factory;
 import com.synopsys.integration.blackduck.bdio2.Bdio2Writer;
 import com.synopsys.integration.blackduck.codelocation.bdioupload.UploadTarget;
+import com.synopsys.integration.detect.configuration.DetectProperty;
 import com.synopsys.integration.detect.exception.DetectUserFriendlyException;
 import com.synopsys.integration.detect.exitcode.ExitCodeType;
 import com.synopsys.integration.detect.workflow.codelocation.CodeLocationNameManager;
@@ -141,7 +142,7 @@ public class AggregateBdioCreator {
                 aggregateDependencyGraph.addChildrenToRoot(codeLocationDependency);
                 aggregateDependencyGraph.addGraphAsChildrenToParent(codeLocationDependency, detectCodeLocation.getDependencyGraph());
             } else {
-                throw new DetectUserFriendlyException("Did not specify aggregation mode via detect.bom.aggregate.mode, will not aggregate at this time.", ExitCodeType.FAILURE_GENERAL_ERROR);
+                throw new DetectUserFriendlyException(String.format("The %s property was set to an unsupported aggregation mode, will not aggregate at this time.", DetectProperty.DETECT_BOM_AGGREGATE_MODE.getPropertyKey()), ExitCodeType.FAILURE_GENERAL_ERROR);
             }
         }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateMode.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateMode.java
@@ -1,0 +1,6 @@
+package com.synopsys.integration.detect.workflow.bdio;
+
+public enum AggregateMode {
+    DIRECT,
+    TRANSITIVE
+}

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateOptions.java
@@ -27,28 +27,32 @@ import java.util.Optional;
 public class AggregateOptions {
 
     private Optional<String> aggregateName;
+    private boolean aggregateDirect;
     private boolean uploadEmptyAggregate;
 
-    public AggregateOptions(final Optional<String> aggregateName, final boolean uploadEmptyAggregate) {
+    public AggregateOptions(final Optional<String> aggregateName, final boolean aggregateDirect, final boolean uploadEmptyAggregate) {
         this.aggregateName = aggregateName;
+        this.aggregateDirect = aggregateDirect;
         this.uploadEmptyAggregate = uploadEmptyAggregate;
     }
 
-    public static AggregateOptions doNotAggregate() {
-        return new AggregateOptions(Optional.empty(), false);
+    public static AggregateOptions doNotAggregate(boolean aggregateDirect) {
+        return new AggregateOptions(Optional.empty(), aggregateDirect, false);
     }
 
-    public static AggregateOptions aggregateAndAlwaysUpload(String aggregateName) {
-        return new AggregateOptions(Optional.of(aggregateName), true);
+    public static AggregateOptions aggregateAndAlwaysUpload(String aggregateName, boolean aggregateDirect) {
+        return new AggregateOptions(Optional.of(aggregateName), aggregateDirect, true);
     }
 
-    public static AggregateOptions aggregateButSkipEmpty(String aggregateName) {
-        return new AggregateOptions(Optional.of(aggregateName), false);
+    public static AggregateOptions aggregateButSkipEmpty(String aggregateName, boolean aggregateDirect) {
+        return new AggregateOptions(Optional.of(aggregateName), aggregateDirect,false);
     }
 
     public Optional<String> getAggregateName() {
         return aggregateName;
     }
+
+    public boolean shouldAggregateDirect() { return aggregateDirect; }
 
     public boolean shouldUploadEmptyAggregate() {
         return uploadEmptyAggregate;

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdio/AggregateOptions.java
@@ -24,35 +24,39 @@ package com.synopsys.integration.detect.workflow.bdio;
 
 import java.util.Optional;
 
+import javax.swing.text.html.Option;
+
 public class AggregateOptions {
 
     private Optional<String> aggregateName;
-    private boolean aggregateDirect;
+    private AggregateMode aggregateMode;
     private boolean uploadEmptyAggregate;
 
-    public AggregateOptions(final Optional<String> aggregateName, final boolean aggregateDirect, final boolean uploadEmptyAggregate) {
+    public AggregateOptions(final Optional<String> aggregateName, final AggregateMode aggregateMode, final boolean uploadEmptyAggregate) {
         this.aggregateName = aggregateName;
-        this.aggregateDirect = aggregateDirect;
+        this.aggregateMode = aggregateMode;
         this.uploadEmptyAggregate = uploadEmptyAggregate;
     }
 
-    public static AggregateOptions doNotAggregate(boolean aggregateDirect) {
-        return new AggregateOptions(Optional.empty(), aggregateDirect, false);
+    public static AggregateOptions doNotAggregate() {
+        return new AggregateOptions(Optional.empty(), AggregateMode.TRANSITIVE, false);
     }
 
-    public static AggregateOptions aggregateAndAlwaysUpload(String aggregateName, boolean aggregateDirect) {
-        return new AggregateOptions(Optional.of(aggregateName), aggregateDirect, true);
+    public static AggregateOptions aggregateAndAlwaysUpload(String aggregateName, AggregateMode aggregateMode) {
+        return new AggregateOptions(Optional.of(aggregateName), aggregateMode, true);
     }
 
-    public static AggregateOptions aggregateButSkipEmpty(String aggregateName, boolean aggregateDirect) {
-        return new AggregateOptions(Optional.of(aggregateName), aggregateDirect,false);
+    public static AggregateOptions aggregateButSkipEmpty(String aggregateName, AggregateMode aggregateMode) {
+        return new AggregateOptions(Optional.of(aggregateName), aggregateMode,false);
     }
 
     public Optional<String> getAggregateName() {
         return aggregateName;
     }
 
-    public boolean shouldAggregateDirect() { return aggregateDirect; }
+    public AggregateMode getAggregateMode() {
+        return aggregateMode;
+    }
 
     public boolean shouldUploadEmptyAggregate() {
         return uploadEmptyAggregate;

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdio/BdioManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdio/BdioManager.java
@@ -77,7 +77,7 @@ public class BdioManager {
         if (aggregateOptions.shouldAggregate() && aggregateName.isPresent()) {
             logger.debug("Creating aggregate BDIO file.");
             final AggregateBdioCreator aggregateBdioCreator = new AggregateBdioCreator(bdio2Factory, simpleBdioFactory, integrationEscapeUtil, codeLocationNameManager, detectBdioWriter);
-            final Optional<UploadTarget> uploadTarget = createAggregatedBdioUploadTarget(aggregateBdioCreator, codeLocations, projectNameVersion, useBdio2, aggregateName.get(), aggregateOptions.shouldUploadEmptyAggregate());
+            final Optional<UploadTarget> uploadTarget = createAggregatedBdioUploadTarget(aggregateBdioCreator, codeLocations, projectNameVersion, useBdio2, aggregateName.get(), aggregateOptions.shouldAggregateDirect(), aggregateOptions.shouldUploadEmptyAggregate());
 
             return new BdioResult(uploadTarget, useBdio2);
         } else {
@@ -104,13 +104,13 @@ public class BdioManager {
     }
 
     private Optional<UploadTarget> createAggregatedBdioUploadTarget(final AggregateBdioCreator aggregateBdioCreator, final List<DetectCodeLocation> detectCodeLocations, final NameVersion projectNameVersion, final boolean useBdio2,
-        final String aggregateName, final boolean shouldUploadEmptyAggregate)
+        final String aggregateName, final boolean aggregateDirect, final boolean shouldUploadEmptyAggregate)
         throws DetectUserFriendlyException {
 
         if (useBdio2) {
-            return aggregateBdioCreator.createAggregateBdio2File(aggregateName, shouldUploadEmptyAggregate, directoryManager.getSourceDirectory(), directoryManager.getBdioOutputDirectory(), detectCodeLocations, projectNameVersion);
+            return aggregateBdioCreator.createAggregateBdio2File(aggregateName, aggregateDirect,  shouldUploadEmptyAggregate, directoryManager.getSourceDirectory(), directoryManager.getBdioOutputDirectory(), detectCodeLocations, projectNameVersion);
         }
 
-        return aggregateBdioCreator.createAggregateBdio1File(aggregateName, shouldUploadEmptyAggregate, directoryManager.getSourceDirectory(), directoryManager.getBdioOutputDirectory(), detectCodeLocations, projectNameVersion);
+        return aggregateBdioCreator.createAggregateBdio1File(aggregateName, aggregateDirect, shouldUploadEmptyAggregate, directoryManager.getSourceDirectory(), directoryManager.getBdioOutputDirectory(), detectCodeLocations, projectNameVersion);
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdio/BdioManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdio/BdioManager.java
@@ -77,7 +77,7 @@ public class BdioManager {
         if (aggregateOptions.shouldAggregate() && aggregateName.isPresent()) {
             logger.debug("Creating aggregate BDIO file.");
             final AggregateBdioCreator aggregateBdioCreator = new AggregateBdioCreator(bdio2Factory, simpleBdioFactory, integrationEscapeUtil, codeLocationNameManager, detectBdioWriter);
-            final Optional<UploadTarget> uploadTarget = createAggregatedBdioUploadTarget(aggregateBdioCreator, codeLocations, projectNameVersion, useBdio2, aggregateName.get(), aggregateOptions.shouldAggregateDirect(), aggregateOptions.shouldUploadEmptyAggregate());
+            final Optional<UploadTarget> uploadTarget = createAggregatedBdioUploadTarget(aggregateBdioCreator, codeLocations, projectNameVersion, useBdio2, aggregateName.get(), aggregateOptions.getAggregateMode(), aggregateOptions.shouldUploadEmptyAggregate());
 
             return new BdioResult(uploadTarget, useBdio2);
         } else {
@@ -104,13 +104,13 @@ public class BdioManager {
     }
 
     private Optional<UploadTarget> createAggregatedBdioUploadTarget(final AggregateBdioCreator aggregateBdioCreator, final List<DetectCodeLocation> detectCodeLocations, final NameVersion projectNameVersion, final boolean useBdio2,
-        final String aggregateName, final boolean aggregateDirect, final boolean shouldUploadEmptyAggregate)
+        final String aggregateName, final AggregateMode aggregateMode, final boolean shouldUploadEmptyAggregate)
         throws DetectUserFriendlyException {
 
         if (useBdio2) {
-            return aggregateBdioCreator.createAggregateBdio2File(aggregateName, aggregateDirect,  shouldUploadEmptyAggregate, directoryManager.getSourceDirectory(), directoryManager.getBdioOutputDirectory(), detectCodeLocations, projectNameVersion);
+            return aggregateBdioCreator.createAggregateBdio2File(aggregateName, aggregateMode,  shouldUploadEmptyAggregate, directoryManager.getSourceDirectory(), directoryManager.getBdioOutputDirectory(), detectCodeLocations, projectNameVersion);
         }
 
-        return aggregateBdioCreator.createAggregateBdio1File(aggregateName, aggregateDirect, shouldUploadEmptyAggregate, directoryManager.getSourceDirectory(), directoryManager.getBdioOutputDirectory(), detectCodeLocations, projectNameVersion);
+        return aggregateBdioCreator.createAggregateBdio1File(aggregateName, aggregateMode, shouldUploadEmptyAggregate, directoryManager.getSourceDirectory(), directoryManager.getBdioOutputDirectory(), detectCodeLocations, projectNameVersion);
     }
 }


### PR DESCRIPTION
# Description

Now users can indicate-using a property that I called detect.bom.aggregate.direct (not married to it)-that they want to exclude detect code locations from top level of aggregated dependency tree.

# Github Issues

(Optional) Please link to any applicable github issues.
