### PR TITLE
Resolve import issue with pip 20+

### DIFF
--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -30,7 +30,7 @@ import pip
 pip_major_version = int(pip.__version__.split(".")[0])
 if pip_major_version >= 20:
     from pip._internal.req import parse_requirements
-    class PipSession: {}
+    from pip._internal.network.session import PipSession
 elif pip_major_version >= 10:
     from pip._internal.req import parse_requirements
     from pip._internal.download import PipSession

--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -28,7 +28,10 @@ import getopt
 import pip
 
 pip_major_version = int(pip.__version__.split(".")[0])
-if pip_major_version >= 10:
+if pip_major_version >= 20:
+    from pip._internal.req import parse_requirements
+    class PipSession: {}
+elif pip_major_version >= 10:
     from pip._internal.req import parse_requirements
     from pip._internal.download import PipSession
 else:


### PR DESCRIPTION
# Description

pip changed internal folder structure in version 20, and the `PipSession` class is no longer available at pip._internal.download, resulting in the pip-inspector.py script failing on systems with pip 20+. The resulting error is:

```
Traceback (most recent call last):
  File ".\pip-inspector.py", line 36, in <module>
    from pip._internal.download import PipSession
ModuleNotFoundError: No module named 'pip._internal.download'
```

# Solution

This PR updates the reference to `PipSession` to the new pip 20+ location, for systems where the pip version is 20+. For pip versions lower than 20, the old behavior remains the same. 

# Recommendations

This script should likely be refactored at some point to remove these internal references, per recommendations in [this issue](https://github.com/pypa/pip/issues/7645). An alternative to this PR is to declare an empty `PipSession` class for pip 20+:

```python
class PipSession: {}
```

The above actually works as well, as `parse_requirements` does not appear to actually require a `session` to be defined, at least in pip 20+. 