### PR TITLE
fix(git): Removing .git directory from DetectorSearchExcludedDirectories. (Fixes IDETECT-1945)

### DIFF
--- a/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectorSearchExcludedDirectories.java
+++ b/detect-configuration/src/main/java/com/synopsys/integration/detect/configuration/DetectorSearchExcludedDirectories.java
@@ -25,7 +25,6 @@ package com.synopsys.integration.detect.configuration;
 public enum DetectorSearchExcludedDirectories {
     BIN("bin"),
     BUILD("build"),
-    DOT_GIT(".git"),
     DOT_GRADLE(".gradle"),
     NODE_MODULES("node_modules"),
     OUT("out"),


### PR DESCRIPTION
Git is considered a Detector and provides project info. The .git directory is it's key.
This was not how we achieved this result before.
I was unable to find the prior solution through the Git history.
I think this is still the right approach.

This fixes IDETECT-1945