### PR TITLE
feat: Detect stops when docker detects windows. (Fixes IDETECT-1876)

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
@@ -71,10 +71,6 @@ public class DockerDetectable extends Detectable {
 
     @Override
     public DetectableResult applicable() {
-        if (OperatingSystemType.determineFromSystem() == OperatingSystemType.WINDOWS) {
-            return new WrongOperatingSystemResult(OperatingSystemType.determineFromSystem());
-        }
-
         if (!dockerDetectableOptions.hasDockerImageOrTar()) {
             return new PropertyInsufficientDetectableResult();
         }
@@ -83,6 +79,9 @@ public class DockerDetectable extends Detectable {
 
     @Override
     public DetectableResult extractable() throws DetectableException {
+        if (OperatingSystemType.determineFromSystem() == OperatingSystemType.WINDOWS) {
+            return new WrongOperatingSystemResult(OperatingSystemType.determineFromSystem());
+        }
         javaExe = javaResolver.resolveJava();
         if (javaExe == null) {
             return new ExecutableNotFoundDetectableResult("java");

--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -152,6 +152,7 @@ public class Application implements ApplicationRunner {
         }
 
         //Create status output file.
+        logger.info("");
         try {
             if (detectBootResultOptional.isPresent() && detectBootResultOptional.get().getDirectoryManager().isPresent()) {
                 DirectoryManager directoryManager = detectBootResultOptional.get().getDirectoryManager().get();

--- a/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
@@ -84,11 +84,11 @@ public class DetectableTool {
         final DetectableResult applicable = detectable.applicable();
 
         if (!applicable.getPassed()) {
-            logger.info("Was not applicable.");
+            logger.debug("Was not applicable.");
             return DetectableToolResult.skip();
         }
 
-        logger.info("Applicable passed.");
+        logger.debug("Applicable passed.");
 
         DetectableResult extractable;
         try {
@@ -101,10 +101,10 @@ public class DetectableTool {
             logger.error("Was not extractable: " + extractable.toDescription());
             eventSystem.publishEvent(Event.StatusSummary, new Status(name, StatusType.FAILURE));
             eventSystem.publishEvent(Event.ExitCode, new ExitCodeRequest(ExitCodeType.FAILURE_GENERAL_ERROR, extractable.toDescription()));
-            return DetectableToolResult.failed();
+            return DetectableToolResult.failed(extractable);
         }
 
-        logger.info("Extractable passed.");
+        logger.debug("Extractable passed.");
 
         final ExtractionEnvironment extractionEnvironment = extractionEnvironmentProvider.createExtractionEnvironment(name);
         final Extraction extraction = detectable.extract(extractionEnvironment);
@@ -115,7 +115,7 @@ public class DetectableTool {
             eventSystem.publishEvent(Event.ExitCode, new ExitCodeRequest(ExitCodeType.FAILURE_GENERAL_ERROR, extractable.toDescription()));
             return DetectableToolResult.failed();
         } else {
-            logger.info("Extraction success.");
+            logger.debug("Extraction success.");
             eventSystem.publishEvent(Event.StatusSummary, new Status(name, StatusType.SUCCESS));
         }
 
@@ -132,7 +132,7 @@ public class DetectableTool {
             projectInfo = new DetectToolProjectInfo(detectTool, nameVersion);
         }
 
-        logger.info("Tool finished.");
+        logger.debug("Tool finished.");
 
         return DetectableToolResult.success(detectCodeLocations, projectInfo, dockerTar);
     }

--- a/src/main/java/com/synopsys/integration/detect/tool/DetectableToolResult.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/DetectableToolResult.java
@@ -31,6 +31,7 @@ import org.antlr.v4.runtime.misc.Nullable;
 
 import com.synopsys.integration.detect.workflow.codelocation.DetectCodeLocation;
 import com.synopsys.integration.detect.workflow.project.DetectToolProjectInfo;
+import com.synopsys.integration.detectable.detectable.result.DetectableResult;
 
 public class DetectableToolResult {
     private enum DetectableToolResultType {
@@ -46,24 +47,34 @@ public class DetectableToolResult {
     private final File dockerTar;
     @Nullable
     private final DetectToolProjectInfo detectToolProjectInfo;
+    @Nullable
+    private final DetectableResult failedExtractableResult;
 
-    public DetectableToolResult(final DetectableToolResultType resultType, final DetectToolProjectInfo detectToolProjectInfo, final List<DetectCodeLocation> detectCodeLocations, final File dockerTar) {
+    public DetectableToolResult(final DetectableToolResultType resultType, final DetectToolProjectInfo detectToolProjectInfo, final List<DetectCodeLocation> detectCodeLocations, final File dockerTar,
+        final DetectableResult failedExtractableResult) {
         this.resultType = resultType;
         this.detectToolProjectInfo = detectToolProjectInfo;
         this.detectCodeLocations = detectCodeLocations;
         this.dockerTar = dockerTar;
+        this.failedExtractableResult = failedExtractableResult;
     }
 
     public static DetectableToolResult skip() {
-        return new DetectableToolResult(DetectableToolResultType.SKIPPED, null, Collections.emptyList(), null);
+        return new DetectableToolResult(DetectableToolResultType.SKIPPED, null, Collections.emptyList(), null, null);
+    }
+
+    //extractableResult is a workaround for docker. Technically we want to throw an exception when docker extractable fails for Windows but neither the tool nor the detectable supports that.
+    //This allows the caller to make determinations based on the extractable result.
+    public static DetectableToolResult failed(DetectableResult extractableResult) {
+        return new DetectableToolResult(DetectableToolResultType.FAILED, null, Collections.emptyList(), null, extractableResult);
     }
 
     public static DetectableToolResult failed() {
-        return new DetectableToolResult(DetectableToolResultType.FAILED, null, Collections.emptyList(), null);
+        return failed(null);
     }
 
     public static DetectableToolResult success(final List<DetectCodeLocation> codeLocations, @Nullable final DetectToolProjectInfo projectInfo, @Nullable final File dockerTar) {
-        return new DetectableToolResult(DetectableToolResultType.SUCCESS, projectInfo, codeLocations, dockerTar);
+        return new DetectableToolResult(DetectableToolResultType.SUCCESS, projectInfo, codeLocations, dockerTar, null);
     }
 
     public Optional<File> getDockerTar() {
@@ -80,5 +91,9 @@ public class DetectableToolResult {
 
     public boolean isFailure() {
         return resultType == DetectableToolResultType.FAILED;
+    }
+
+    public Optional<DetectableResult> getFailedExtractableResult() {
+        return Optional.ofNullable(failedExtractableResult);
     }
 }


### PR DESCRIPTION
Moved Docker's OS check from applicable to extractable. 

Detectable Tool now passes back the extractable result and the RunManager will throw a Detect User Friendly exception if the reason is wrong OS. 

This should only be temporary until we support Docker on Windows.

