### PR TITLE
fix(docker): download DI 9.x latest from artifactory

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstants.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstants.java
@@ -39,8 +39,8 @@ public class ArtifactoryConstants {
     public static final String CLASSIC_NUGET_INSPECTOR_VERSION_OVERRIDE = "/IntegrationNugetInspector." + ArtifactoryConstants.VERSION_PLACEHOLDER + ".nupkg";
 
     public static final String DOCKER_INSPECTOR_REPO = "bds-integrations-release/com/synopsys/integration/blackduck-docker-inspector";
-    public static final String DOCKER_INSPECTOR_PROPERTY = "DOCKER_INSPECTOR_LATEST_8";
-    public static final String DOCKER_INSPECTOR_AIR_GAP_PROPERTY = "DOCKER_INSPECTOR_AIR_GAP_LATEST_8";
+    public static final String DOCKER_INSPECTOR_PROPERTY = "DOCKER_INSPECTOR_LATEST_9";
+    public static final String DOCKER_INSPECTOR_AIR_GAP_PROPERTY = "DOCKER_INSPECTOR_AIR_GAP_LATEST_9";
     public static final String DOCKER_INSPECTOR_VERSION_OVERRIDE = "/" + ArtifactoryConstants.VERSION_PLACEHOLDER + "/blackduck-docker-inspector-" + ArtifactoryConstants.VERSION_PLACEHOLDER + ".jar";
 
 }


### PR DESCRIPTION
# Description

Pull the latest version of Docker Inspector 9.x from artifactory
