### PR TITLE
Polaris common fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     ext {
         springBootVersion = '2.2.4.RELEASE'
         blackDuckCommonVersion = '47.1.0'
-        polarisCommonVersion = '0.13.2'
+        polarisCommonVersion = '0.20.0'
         junitPlatformDefaultTestTags = 'integration, performance, battery'
     }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/PolarisConnectivityChecker.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/PolarisConnectivityChecker.java
@@ -25,11 +25,11 @@ package com.synopsys.integration.detect.lifecycle.boot.product;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.synopsys.integration.rest.client.ConnectionResult;
 import com.synopsys.integration.log.SilentIntLogger;
 import com.synopsys.integration.polaris.common.configuration.PolarisServerConfig;
 import com.synopsys.integration.polaris.common.rest.AccessTokenPolarisHttpClient;
-import com.synopsys.integration.rest.request.Response;
+import com.synopsys.integration.rest.client.ConnectionResult;
+import com.synopsys.integration.rest.response.Response;
 
 public class PolarisConnectivityChecker {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/src/main/java/com/synopsys/integration/detect/tool/polaris/PolarisTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/polaris/PolarisTool.java
@@ -74,7 +74,7 @@ public class PolarisTool {
         final File toolsDirectory = directoryManager.getPermanentDirectory();
 
         final PolarisDownloadUtility polarisDownloadUtility = PolarisDownloadUtility.fromPolaris(logger, polarisHttpClient, toolsDirectory);
-        final Optional<String> polarisCliPath = polarisDownloadUtility.retrievePolarisCliExecutablePath();
+        final Optional<String> polarisCliPath = polarisDownloadUtility.getOrDownloadPolarisCliExecutable();
 
         //TODO this should be revised to use PolarisCliExecutable and PolarisCliRunner
         if (polarisCliPath.isPresent()) {


### PR DESCRIPTION
When running Polaris tools with Detect 6.3.0-SIGQA1, a classpath error occured due to using an outdated version of the polaris-common library.

Upgraded the polaris-common dependency from 0.13.2 to 0.20.0.

Fixes IDETECT-2013