### PR TITLE
using properties instead of environment variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,7 +257,7 @@ task signJar() {
     dependsOn build
     doLast {
         exec {
-            commandLine 'jarsigner', '-tsa', 'http://timestamp.globalsign.com/scripts/timestamp.dll', '-storetype', 'pkcs12', '-storepass', "${System.env.JARSIGNER_KEYSTORE_PASS}", '-keystore', "${System.env.JARSIGNER_KEYSTORE_PATH}", "${createArtifactName()}", "${System.env.JARSIGNER_CERT_ALIAS}"
+            commandLine 'jarsigner', '-tsa', 'http://timestamp.globalsign.com/scripts/timestamp.dll', '-storetype', 'pkcs12', '-storepass', "${jarSigningKeystorePassword}", '-keystore', "${jarSigningKeystorePath}", "${createArtifactName()}", "${jarSigningCertificateAlias}"
         }
     }
 }


### PR DESCRIPTION
Let's use gradle properties instead of environment variables - it will make it easier to share this feature with other projects.