### PR TITLE
Sb fix gradle inspector url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://d
 
 For scripts, please see [Detect Scripts](https://github.com/synopsys-sig/synopsys-detect-scripts)
 
-For AirGap, please use our [Artifactory](https://repo.blackducksoftware.com/artifactory/webapp/#/artifacts/browse/tree/General/bds-integrations-release/com/synopsys/integration/synopsys-detect).
+For AirGap, please use our [Artifactory](https://sig-repo.synopsys.com/webapp/#/artifacts/browse/tree/General/bds-integrations-release/com/synopsys/integration/synopsys-detect).
 
 ## Documentation
 

--- a/docs/templates/content/advanced/language-and-package-managers/nuget.ftl
+++ b/docs/templates/content/advanced/language-and-package-managers/nuget.ftl
@@ -18,7 +18,7 @@ The NuGet detectors do not work with mono.
 
 Source: https://github.com/blackducksoftware/blackduck-nuget-inspector
 
-Binary: https://repo.blackducksoftware.com:443/artifactory/bds-integrations-nuget-release/BlackduckNugetInspector
+Binary: https://sig-repo.synopsys.com/bds-integrations-nuget-release/BlackduckNugetInspector/
 
 Requires: .NET framework version 4.5
 
@@ -26,7 +26,7 @@ Requires: .NET framework version 4.5
 
 Source: https://github.com/blackducksoftware/integration-nuget-inspector
 
-Binary: https://repo.blackducksoftware.com:443/artifactory/bds-integrations-nuget-release/IntegrationNugetInspector
+Binary: https://sig-repo.synopsys.com/bds-integrations-nuget-release/IntegrationNugetInspector/
 
 ## Operation
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstants.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstants.java
@@ -28,7 +28,7 @@ public class ArtifactoryConstants {
 
     public static final String GRADLE_INSPECTOR_REPO = "bds-integrations-release/com/blackducksoftware/integration/integration-gradle-inspector";
     public static final String GRADLE_INSPECTOR_PROPERTY = "GRADLE_INSPECTOR_LATEST_0";
-    public static final String GRADLE_INSPECTOR_MAVEN_REPO = "https://repo.blackducksoftware.com/artifactory/bds-integration-public-cache/";
+    public static final String GRADLE_INSPECTOR_MAVEN_REPO = ARTIFACTORY_URL + "bds-integration-public-cache/";
 
     public static final String NUGET_INSPECTOR_REPO = "bds-integrations-nuget-release/BlackduckNugetInspector";
     public static final String NUGET_INSPECTOR_PROPERTY = "NUGET_INSPECTOR_LATEST_0";

--- a/src/main/resources/create-gradle-airgap-script.ftl
+++ b/src/main/resources/create-gradle-airgap-script.ftl
@@ -1,6 +1,6 @@
 repositories {
     maven {
-        url 'https://repo.blackducksoftware.com:443/artifactory/bds-integration-public-cache'
+        url 'https://sig-repo.synopsys.com/bds-integration-public-cache/'
     }
 }
 

--- a/src/test/resources/test-server/setup_centos.sh
+++ b/src/test/resources/test-server/setup_centos.sh
@@ -56,8 +56,8 @@ echo "	/opt/blackduck/detect.sh --blackduck.url=https://int-hub04.dc1.lan --blac
 echo "" >> README.txt
 echo "" >> README.txt
 echo "You may want to download a newer Detect snapshot version to test. You can do this with a command like:" >> README.txt
-echo "    curl -O https://repo.blackducksoftware.com:443/artifactory/bds-integrations-snapshot/com/synopsys/integration/synopsys-detect/5.4.0-SNAPSHOT/synopsys-detect-5.4.0-20190326.211416-26.jar" >> README.txt
-echo "To determine the URL to the .jar, point your browser to: https://repo.blackducksoftware.com:443/artifactory/bds-integrations-snapshot/com/synopsys/integration/synopsys-detect" >> README.txt
+echo "    curl -O https://sig-repo.synopsys.com/bds-integrations-snapshot/com/synopsys/integration/synopsys-detect/6.4.0-SNAPSHOT/synopsys-detect-6.4.0-20200515.045330-70.jar" >> README.txt
+echo "To determine the URL to the .jar, point your browser to: https://sig-repo.synopsys.com/bds-integrations-snapshot/com/synopsys/integration/synopsys-detect/" >> README.txt
 echo "" >> README.txt
 echo "Then you could execute that early version by doing something like this:" >> README.txt
 echo "	cd /opt/blackduck/projects/<repos-dir>/<project>" >> README.txt


### PR DESCRIPTION
# Description

Detect uses an old artifactory URL to download the gradle inspector.
JIRA ticket: IDETECT-2037
This PR is a fix for that.
