### PR TITLE
refactor: Moving issue publishing to detector tool.

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -159,6 +159,25 @@ public class Application implements ApplicationRunner {
             }
         }
 
+        //Create status output file.
+        logger.info("");
+        try {
+            if (detectBootResultOptional.isPresent() && detectBootResultOptional.get().getDirectoryManager().isPresent()) {
+                DirectoryManager directoryManager = detectBootResultOptional.get().getDirectoryManager().get();
+
+                File statusFile = new File(directoryManager.getStatusOutputDirectory(), "status.json");
+                logger.info(String.format("Creating status file: %s", statusFile.toString()));
+
+                String json = gson.toJson(formattedOutputManager.createFormattedOutput(detectInfo));
+                FileUtils.writeStringToFile(statusFile, json, Charset.defaultCharset());
+            } else {
+                logger.info("Will not create status file, detect did not boot.");
+            }
+        } catch (Exception e) {
+            logger.warn("There was a problem writing the status output file. The detect run was not affected.");
+            logger.debug("The problem creating the status file was: ", e);
+        }
+
         try {
             logger.debug("Detect shutdown begin.");
             final ShutdownManager shutdownManager = new ShutdownManager();
@@ -187,27 +206,7 @@ public class Application implements ApplicationRunner {
 
         //Print detect's status
         if (printOutput) {
-            reportManager.printDetectorIssues();
             statusManager.logDetectResults(new Slf4jIntLogger(logger), finalExitCode);
-        }
-
-        //Create status output file.
-        logger.info("");
-        try {
-            if (detectBootResultOptional.isPresent() && detectBootResultOptional.get().getDirectoryManager().isPresent()) {
-                DirectoryManager directoryManager = detectBootResultOptional.get().getDirectoryManager().get();
-
-                File statusFile = new File(directoryManager.getStatusOutputDirectory(), "status.json");
-                logger.info(String.format("Creating status file: %s", statusFile.toString()));
-
-                String json = gson.toJson(formattedOutputManager.createFormattedOutput(detectInfo));
-                FileUtils.writeStringToFile(statusFile, json, Charset.defaultCharset());
-            } else {
-                logger.info("Will not create status file, detect did not boot.");
-            }
-        } catch (Exception e) {
-            logger.warn("There was a problem writing the status output file. The detect run was not affected.");
-            logger.debug("The problem creating the status file was: ", e);
         }
 
         //Print duration of run

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunManager.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunManager.java
@@ -24,15 +24,15 @@ package com.synopsys.integration.detect.lifecycle.run;
 
 import java.net.URL;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.jetbrains.annotations.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +67,7 @@ import com.synopsys.integration.detect.tool.binaryscanner.BinaryScanToolResult;
 import com.synopsys.integration.detect.tool.binaryscanner.BlackDuckBinaryScannerTool;
 import com.synopsys.integration.detect.tool.detector.CodeLocationConverter;
 import com.synopsys.integration.detect.tool.detector.DetectExecutableRunner;
+import com.synopsys.integration.detect.tool.detector.DetectorIssuePublisher;
 import com.synopsys.integration.detect.tool.detector.DetectorRuleFactory;
 import com.synopsys.integration.detect.tool.detector.DetectorTool;
 import com.synopsys.integration.detect.tool.detector.DetectorToolResult;
@@ -153,7 +154,8 @@ public class RunManager {
             logger.info("Polaris tools will not be run.");
         }
 
-        final UniversalToolsResult universalToolsResult = runUniversalProjectTools(detectConfiguration, detectConfigurationFactory, directoryManager, eventSystem, detectDetectableFactory, runResult, runOptions, detectToolFilter, codeLocationNameManager);
+        final UniversalToolsResult universalToolsResult = runUniversalProjectTools(detectConfiguration, detectConfigurationFactory, directoryManager, eventSystem, detectDetectableFactory, runResult, runOptions, detectToolFilter,
+            codeLocationNameManager);
 
         if (productRunData.shouldUseBlackDuckProduct()) {
             final AggregateOptions aggregateOptions = determineAggregationStrategy(runOptions.getAggregateName().orElse(null), runOptions.getAggregateMode(), universalToolsResult);
@@ -240,7 +242,8 @@ public class RunManager {
             final DetectorFinderOptions finderOptions = detectConfigurationFactory.createSearchOptions(sourcePath);
             final DetectorEvaluationOptions detectorEvaluationOptions = detectConfigurationFactory.createDetectorEvaluationOptions();
 
-            final DetectorTool detectorTool = new DetectorTool(new DetectorFinder(), extractionEnvironmentProvider, eventSystem, codeLocationConverter);
+            final DetectorIssuePublisher detectorIssuePublisher = new DetectorIssuePublisher();
+            final DetectorTool detectorTool = new DetectorTool(new DetectorFinder(), extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
             final DetectorToolResult detectorToolResult = detectorTool.performDetectors(directoryManager.getSourceDirectory(), detectRuleSet, finderOptions, detectorEvaluationOptions, projectBomTool, requiredDetectors);
 
             detectorToolResult.getBomToolProjectNameVersion().ifPresent(it -> runResult.addToolNameVersion(DetectTool.DETECTOR, new NameVersion(it.getName(), it.getVersion())));

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorIssuePublisher.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorIssuePublisher.java
@@ -20,7 +20,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.synopsys.integration.detect.workflow.report;
+package com.synopsys.integration.detect.tool.detector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import com.synopsys.integration.detect.workflow.event.Event;
 import com.synopsys.integration.detect.workflow.event.EventSystem;
+import com.synopsys.integration.detect.workflow.report.ExceptionUtil;
 import com.synopsys.integration.detect.workflow.report.util.DetectorEvaluationUtils;
 import com.synopsys.integration.detect.workflow.status.DetectIssue;
 import com.synopsys.integration.detect.workflow.status.DetectIssueType;

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorTool.java
@@ -68,12 +68,15 @@ public class DetectorTool {
     private final ExtractionEnvironmentProvider extractionEnvironmentProvider;
     private final EventSystem eventSystem;
     private final CodeLocationConverter codeLocationConverter;
+    private final DetectorIssuePublisher detectorIssuePublisher;
 
-    public DetectorTool(final DetectorFinder detectorFinder, final ExtractionEnvironmentProvider extractionEnvironmentProvider, final EventSystem eventSystem, final CodeLocationConverter codeLocationConverter) {
+    public DetectorTool(final DetectorFinder detectorFinder, final ExtractionEnvironmentProvider extractionEnvironmentProvider, final EventSystem eventSystem, final CodeLocationConverter codeLocationConverter,
+        final DetectorIssuePublisher detectorIssuePublisher) {
         this.detectorFinder = detectorFinder;
         this.extractionEnvironmentProvider = extractionEnvironmentProvider;
         this.eventSystem = eventSystem;
         this.codeLocationConverter = codeLocationConverter;
+        this.detectorIssuePublisher = detectorIssuePublisher;
     }
 
     public DetectorToolResult performDetectors(final File directory, final DetectorRuleSet detectorRuleSet, final DetectorFinderOptions detectorFinderOptions, final DetectorEvaluationOptions evaluationOptions, final String projectDetector,
@@ -178,6 +181,8 @@ public class DetectorTool {
                 }
             }
         }
+
+        detectorIssuePublisher.publishEvents(eventSystem, rootEvaluation);
 
         Map<CodeLocation, DetectCodeLocation> codeLocationMap = createCodeLocationMap(detectorEvaluations, directory);
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/ReportManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/ReportManager.java
@@ -24,6 +24,7 @@ package com.synopsys.integration.detect.workflow.report;
 
 import java.util.Map;
 
+import com.synopsys.integration.detect.tool.detector.DetectorIssuePublisher;
 import com.synopsys.integration.detect.tool.detector.DetectorToolResult;
 import com.synopsys.integration.detect.workflow.codelocation.DetectCodeLocation;
 import com.synopsys.integration.detect.workflow.event.Event;
@@ -43,7 +44,6 @@ public class ReportManager {
     private final PreparationSummaryReporter preparationSummaryReporter;
     private final ExtractionSummaryReporter extractionSummaryReporter;
     private final DiscoverySummaryReporter discoverySummaryReporter;
-    private final DetectorIssuePublisher detectorIssuePublisher;
 
     private final ReportWriter traceLogWriter = new TraceLogReportWriter();
     private final ReportWriter debugLogWriter = new DebugLogReportWriter();
@@ -64,7 +64,6 @@ public class ReportManager {
         this.extractionSummaryReporter = extractionSummaryReporter;
         this.searchSummaryReporter = searchSummaryReporter;
         this.discoverySummaryReporter = discoverySummaryReporter;
-        this.detectorIssuePublisher = detectorIssuePublisher;
         this.extractionLogger = extractionLogger;
         this.discoveryLogger = discoveryLogger;
 
@@ -133,12 +132,6 @@ public class ReportManager {
     public void codeLocationsCompleted(final Map<DetectCodeLocation, String> codeLocationNameMap) {
         if (detectorToolResult != null && detectorToolResult.getRootDetectorEvaluationTree().isPresent()) {
             extractionSummaryReporter.writeSummary(debugLogWriter, detectorToolResult.getRootDetectorEvaluationTree().get(), detectorToolResult.getCodeLocationMap(), codeLocationNameMap, false);
-        }
-    }
-
-    public void printDetectorIssues() {
-        if (detectorToolResult != null && detectorToolResult.getRootDetectorEvaluationTree().isPresent()) {
-            detectorIssuePublisher.publishEvents(eventSystem, detectorToolResult.getRootDetectorEvaluationTree().get());
         }
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/tool/detector/DetectorToolTest.java
+++ b/src/test/java/com/synopsys/integration/detect/tool/detector/DetectorToolTest.java
@@ -50,8 +50,9 @@ public class DetectorToolTest {
         final DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
         final EventSystem eventSystem = Mockito.mock(EventSystem.class);
         final CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
+        final DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
 
-        final DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter);
+        final DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
 
         final File directory = new File(".");
         final DetectorRuleSet detectorRuleSet = Mockito.mock(DetectorRuleSet.class);


### PR DESCRIPTION
This prevents us from having to move the status json creation to after shutdown - which we can't/shouldn't do because shutdown cleans up the output folder - the folder status json should be written to.

When I originally added issues I had refactored the 'reporter' into the 'publisher' but left the publisher with the report package - which meant it was called at the end when reports should be written. 

Instead I have moved it to be with the Detector Tool and the tool will publish the issues when it publishes it's existing detector related events.

This way we don't have to move the creation of the status json. (I moved it back in this PR but hopefully we could just remove that change or make sure merging it doesn't move the creation of the json file).