### PR TITLE
Resized columns in the help text to fit longer property names.

### DIFF
--- a/detect-configuration/src/main/java/com/synopsys/integration/detect/help/print/HelpTextWriter.java
+++ b/detect-configuration/src/main/java/com/synopsys/integration/detect/help/print/HelpTextWriter.java
@@ -43,7 +43,7 @@ public class HelpTextWriter {
     
     public void printColumns(String... columns) {
         final List<String> headerColumns = Arrays.asList(columns);
-        final String headerText = formatColumns(headerColumns, 51, 30, 95);
+        final String headerText = formatColumns(headerColumns, 69, 30, 77);
         pieces.add(headerText);
     }
     


### PR DESCRIPTION
The names of some of our newer properties had become so long that
they were no longer fitting in the column. This caused
https://github.com/thaljef/synopsys-detect-bash-completion to break
because it parses property names out of the help text.

Since the property name field is now 18 chars wider, I also reduced
the property description field by the same amount, so the total
width remains the same.

Ideally, the width of the column should by dyanmically computed
based on the longest property name. But that's more work than
I have time for right now.

# Description

Please include a short description of the changes and problems fixed.

# Github Issues

(Optional) Please link to any applicable github issues.
