### PR TITLE
Fix markdown-lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-## Overview ##
+## Overview
+
 Synopsys Detect consolidates the functionality of Black Duck™ , Black Duck Binary Analysis™ (formerly known as Protecode SC) and Coverity™ on Polaris™ into a single solution. Synopsys Detect is designed to integrate natively into the build/CI environment and support all Coverity languages for Static Analysis. For Black Duck & Black Duck Binary Analysis, it makes it easier to set up and scan code bases using a variety of languages and package managers to identify open source risk.
 
-## Build ##
+## Build
 
 [![Build Status](https://travis-ci.org/blackducksoftware/hub-gradle-plugin.svg?branch=master)](https://travis-ci.org/blackducksoftware/synopsys-detect)
 [![Coverage Status](https://coveralls.io/repos/github/blackducksoftware/synopsys-detect/badge.svg?branch=master)](https://coveralls.io/github/blackducksoftware/synopsys-detect?branch=master)
@@ -9,15 +10,21 @@ Synopsys Detect consolidates the functionality of Black Duck™ , Black Duck Bin
 [![Black Duck Security Risk](https://copilot.blackducksoftware.com/github/repos/blackducksoftware/synopsys-detect/branches/master/badge-risk.svg)](https://copilot.blackducksoftware.com/github/repos/blackducksoftware/synopsys-detect/branches/master)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=com.synopsys.integration%3Asynopsys-detect&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.synopsys.integration%3Asynopsys-detect)
 
-## Where can I get the latest release? ##
+## Where can I get the latest release?
 
-*Available from GitHub for Linux/MacOS by running:*  
+Available from GitHub for Linux/MacOS by running:
+
+```bash
 bash <(curl -s -L https://detect.synopsys.com/detect.sh)
+```
 
-*Available from GitHub for Windows by running:*  
+Available from GitHub for Windows by running:
+
+```cmd
 powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect.ps1?$(Get-Random) | iex; detect"
+```
 
-For scripts, please see [Detect Scripts](https://github.com/synopsys-sig/synopsys-detect-scripts)
+For scripts, please see [Detect Scripts](https://github.com/synopsys-sig/synopsys-detect-scripts).
 
 For AirGap, please use our [Artifactory](https://sig-repo.synopsys.com/webapp/#/artifacts/browse/tree/General/bds-integrations-release/com/synopsys/integration/synopsys-detect).
 


### PR DESCRIPTION
# Description

The `README.md` file violated some [markdown-lint's rules](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#rules). I like [markdown-lint](https://github.com/DavidAnson/markdownlint#markdownlint) as its application results in consistent and readable markdown files.

