### PR TITLE
Sb docker on windows

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
@@ -47,20 +47,18 @@ public class DockerDetectable extends Detectable {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final DockerInspectorResolver dockerInspectorResolver;
     private final JavaResolver javaResolver;
-    private final BashResolver bashResolver;
     private final DockerResolver dockerResolver;
     private final DockerExtractor dockerExtractor;
     private final DockerDetectableOptions dockerDetectableOptions;
 
     private File javaExe;
-    private File bashExe;
+    private File dockerExe;
     private DockerInspectorInfo dockerInspectorInfo;
 
     public DockerDetectable(DetectableEnvironment environment, DockerInspectorResolver dockerInspectorResolver, JavaResolver javaResolver, BashResolver bashResolver, DockerResolver dockerResolver,
         DockerExtractor dockerExtractor, DockerDetectableOptions dockerDetectableOptions) {
         super(environment);
         this.javaResolver = javaResolver;
-        this.bashResolver = bashResolver;
         this.dockerResolver = dockerResolver;
         this.dockerExtractor = dockerExtractor;
         this.dockerInspectorResolver = dockerInspectorResolver;
@@ -81,11 +79,6 @@ public class DockerDetectable extends Detectable {
         if (javaExe == null) {
             return new ExecutableNotFoundDetectableResult("java");
         }
-        bashExe = bashResolver.resolveBash();
-        if (bashExe == null) {
-            logger.warn("Bash executable not found. Docker Inspector will not work in air gap mode.");
-        }
-        File dockerExe;
         try {
             dockerExe = dockerResolver.resolveDocker();
         } catch (Exception e) {
@@ -95,7 +88,7 @@ public class DockerDetectable extends Detectable {
             if (dockerDetectableOptions.isDockerPathRequired()) {
                 return new ExecutableNotFoundDetectableResult("docker");
             } else {
-                logger.debug("Docker executable not found, but it has been configured as not-required; proceeding with execution of Docker tool");
+                logger.debug("Docker executable not found, but it has been configured as not-required; proceeding with execution of Docker tool. Running in air-gap mode will not work without a Docker executable.");
             }
         }
         dockerInspectorInfo = dockerInspectorResolver.resolveDockerInspector();
@@ -110,7 +103,7 @@ public class DockerDetectable extends Detectable {
         String image = dockerDetectableOptions.getSuppliedDockerImage().orElse("");
         String imageId = dockerDetectableOptions.getSuppliedDockerImageId().orElse("");
         String tar = dockerDetectableOptions.getSuppliedDockerTar().orElse("");
-        return dockerExtractor.extract(environment.getDirectory(), extractionEnvironment.getOutputDirectory(), bashExe, javaExe, image, imageId, tar, dockerInspectorInfo,
+        return dockerExtractor.extract(environment.getDirectory(), extractionEnvironment.getOutputDirectory(), dockerExe, javaExe, image, imageId, tar, dockerInspectorInfo,
             new DockerProperties(dockerDetectableOptions)); //TODO, doesn't feel right to construct properties here. -jp
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
@@ -79,9 +79,6 @@ public class DockerDetectable extends Detectable {
 
     @Override
     public DetectableResult extractable() throws DetectableException {
-        if (OperatingSystemType.determineFromSystem() == OperatingSystemType.WINDOWS) {
-            return new WrongOperatingSystemResult(OperatingSystemType.determineFromSystem());
-        }
         javaExe = javaResolver.resolveJava();
         if (javaExe == null) {
             return new ExecutableNotFoundDetectableResult("java");

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
@@ -41,8 +41,6 @@ import com.synopsys.integration.detectable.detectable.result.ExecutableNotFoundD
 import com.synopsys.integration.detectable.detectable.result.InspectorNotFoundDetectableResult;
 import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
 import com.synopsys.integration.detectable.detectable.result.PropertyInsufficientDetectableResult;
-import com.synopsys.integration.detectable.detectable.result.WrongOperatingSystemResult;
-import com.synopsys.integration.util.OperatingSystemType;
 
 @DetectableInfo(language = "N/A", forge = "Derived from the Linux distribution", requirementsMarkdown = "Access to a Docker Engine. See <a href='https://blackducksoftware.github.io/blackduck-docker-inspector/latest/overview/'>Docker Inspector documentation</a> for details.")
 public class DockerDetectable extends Detectable {
@@ -58,8 +56,8 @@ public class DockerDetectable extends Detectable {
     private File bashExe;
     private DockerInspectorInfo dockerInspectorInfo;
 
-    public DockerDetectable(final DetectableEnvironment environment, final DockerInspectorResolver dockerInspectorResolver, final JavaResolver javaResolver, final BashResolver bashResolver, final DockerResolver dockerResolver,
-        final DockerExtractor dockerExtractor, final DockerDetectableOptions dockerDetectableOptions) {
+    public DockerDetectable(DetectableEnvironment environment, DockerInspectorResolver dockerInspectorResolver, JavaResolver javaResolver, BashResolver bashResolver, DockerResolver dockerResolver,
+        DockerExtractor dockerExtractor, DockerDetectableOptions dockerDetectableOptions) {
         super(environment);
         this.javaResolver = javaResolver;
         this.bashResolver = bashResolver;
@@ -85,12 +83,12 @@ public class DockerDetectable extends Detectable {
         }
         bashExe = bashResolver.resolveBash();
         if (bashExe == null) {
-            return new ExecutableNotFoundDetectableResult("bash");
+            logger.warn("Bash executable not found. Docker Inspector will not work in air gap mode.");
         }
         File dockerExe;
         try {
             dockerExe = dockerResolver.resolveDocker();
-        } catch (final Exception e) {
+        } catch (Exception e) {
             dockerExe = null;
         }
         if (dockerExe == null) {
@@ -108,10 +106,10 @@ public class DockerDetectable extends Detectable {
     }
 
     @Override
-    public Extraction extract(final ExtractionEnvironment extractionEnvironment) {
-        final String image = dockerDetectableOptions.getSuppliedDockerImage().orElse("");
-        final String imageId = dockerDetectableOptions.getSuppliedDockerImageId().orElse("");
-        final String tar = dockerDetectableOptions.getSuppliedDockerTar().orElse("");
+    public Extraction extract(ExtractionEnvironment extractionEnvironment) {
+        String image = dockerDetectableOptions.getSuppliedDockerImage().orElse("");
+        String imageId = dockerDetectableOptions.getSuppliedDockerImageId().orElse("");
+        String tar = dockerDetectableOptions.getSuppliedDockerTar().orElse("");
         return dockerExtractor.extract(environment.getDirectory(), extractionEnvironment.getOutputDirectory(), bashExe, javaExe, image, imageId, tar, dockerInspectorInfo,
             new DockerProperties(dockerDetectableOptions)); //TODO, doesn't feel right to construct properties here. -jp
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
@@ -33,7 +33,6 @@ import com.synopsys.integration.detectable.Extraction;
 import com.synopsys.integration.detectable.ExtractionEnvironment;
 import com.synopsys.integration.detectable.detectable.annotation.DetectableInfo;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
-import com.synopsys.integration.detectable.detectable.executable.resolver.BashResolver;
 import com.synopsys.integration.detectable.detectable.executable.resolver.DockerResolver;
 import com.synopsys.integration.detectable.detectable.executable.resolver.JavaResolver;
 import com.synopsys.integration.detectable.detectable.result.DetectableResult;
@@ -55,7 +54,7 @@ public class DockerDetectable extends Detectable {
     private File dockerExe;
     private DockerInspectorInfo dockerInspectorInfo;
 
-    public DockerDetectable(DetectableEnvironment environment, DockerInspectorResolver dockerInspectorResolver, JavaResolver javaResolver, BashResolver bashResolver, DockerResolver dockerResolver,
+    public DockerDetectable(DetectableEnvironment environment, DockerInspectorResolver dockerInspectorResolver, JavaResolver javaResolver, DockerResolver dockerResolver,
         DockerExtractor dockerExtractor, DockerDetectableOptions dockerDetectableOptions) {
         super(environment);
         this.javaResolver = javaResolver;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerExtractor.java
@@ -120,25 +120,25 @@ public class DockerExtractor {
     private void importTars(List<File> importTars, File directory, Map<String, String> environmentVariables, File dockerExe) {
         try {
             for (File imageToImport : importTars) {
-                // The -c is a bash option, the following String is the command we want to run
-                List<String> dockerImportArguments = Arrays.asList(
-                    "load",
-                    "-i",
-                    imageToImport.getCanonicalPath());
-
-                Executable dockerImportImageExecutable = new Executable(directory, environmentVariables, dockerExe.toString(), dockerImportArguments);
-                ExecutableOutput exeOut = executableRunner.execute(dockerImportImageExecutable);
-                if (exeOut.getReturnCode() != 0) {
-                    throw new IntegrationException(String.format("Command %s %s returned %d: %s",
-                        dockerExe.getAbsolutePath(),
-                        dockerImportArguments,
-                        exeOut.getReturnCode(),
-                        exeOut.getErrorOutput()));
-                }
+                loadDockerImage(directory, environmentVariables, dockerExe, imageToImport);
             }
         } catch (Exception e) {
-            logger.debug("Exception encountered when resolving paths for docker air gap, running in online mode instead");
-            logger.debug(e.getMessage());
+            logger.debug(String.format("Exception encountered when resolving paths for docker air gap: %s", e.getMessage()));
+            logger.debug("Running in online mode instead");
+        }
+    }
+
+    private void loadDockerImage(File directory, Map<String, String> environmentVariables, File dockerExe, File imageToImport) throws IOException, ExecutableRunnerException, IntegrationException {
+        List<String> dockerImportArguments = Arrays.asList(
+            "load",
+            "-i",
+            imageToImport.getCanonicalPath());
+        Executable dockerImportImageExecutable = new Executable(directory, environmentVariables, dockerExe.toString(), dockerImportArguments);
+        ExecutableOutput exeOut = executableRunner.execute(dockerImportImageExecutable);
+        if (exeOut.getReturnCode() != 0) {
+            throw new IntegrationException(String.format("Command %s %s returned %d: %s",
+                dockerExe.getAbsolutePath(), dockerImportArguments,
+                exeOut.getReturnCode(), exeOut.getErrorOutput()));
         }
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerExtractor.java
@@ -52,10 +52,12 @@ import com.synopsys.integration.detectable.Extraction;
 import com.synopsys.integration.detectable.ExtractionMetadata;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectable.executable.Executable;
+import com.synopsys.integration.detectable.detectable.executable.ExecutableOutput;
 import com.synopsys.integration.detectable.detectable.executable.ExecutableRunner;
 import com.synopsys.integration.detectable.detectable.executable.ExecutableRunnerException;
 import com.synopsys.integration.detectable.detectable.file.FileFinder;
 import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+import com.synopsys.integration.exception.IntegrationException;
 
 public class DockerExtractor {
     public static final ExtractionMetadata<File> DOCKER_TAR_META_DATA = new ExtractionMetadata<>("dockerTar", File.class);
@@ -77,7 +79,7 @@ public class DockerExtractor {
 
     private ImageIdentifierType imageIdentifierType;
 
-    public DockerExtractor(final FileFinder fileFinder, final ExecutableRunner executableRunner, final BdioTransformer bdioTransformer, final ExternalIdFactory externalIdFactory, final Gson gson) {
+    public DockerExtractor(FileFinder fileFinder, ExecutableRunner executableRunner, BdioTransformer bdioTransformer, ExternalIdFactory externalIdFactory, Gson gson) {
         this.fileFinder = fileFinder;
         this.executableRunner = executableRunner;
         this.bdioTransformer = bdioTransformer;
@@ -85,13 +87,13 @@ public class DockerExtractor {
         this.gson = gson;
     }
 
-    public Extraction extract(final File directory, final File outputDirectory, final File bashExe, final File javaExe, final String image, final String imageId, final String tar, final DockerInspectorInfo dockerInspectorInfo,
+    public Extraction extract(File directory, File outputDirectory, File dockerExe, File javaExe, String image, String imageId, String tar, DockerInspectorInfo dockerInspectorInfo,
         DockerProperties dockerProperties) {
         try {
             String imageArgument = null;
             String imagePiece = null;
             if (StringUtils.isNotBlank(tar)) {
-                final File dockerTarFile = new File(tar);
+                File dockerTarFile = new File(tar);
                 imageArgument = String.format("--docker.tar=%s", dockerTarFile.getCanonicalPath());
                 imagePiece = dockerTarFile.getName();
                 imageIdentifierType = ImageIdentifierType.TAR;
@@ -108,51 +110,59 @@ public class DockerExtractor {
             if (StringUtils.isBlank(imageArgument) || StringUtils.isBlank(imagePiece)) {
                 return new Extraction.Builder().failure("No docker image found.").build();
             } else {
-                return executeDocker(outputDirectory, imageArgument, imagePiece, tar, directory, javaExe, bashExe, dockerInspectorInfo, dockerProperties);
+                return executeDocker(outputDirectory, imageArgument, imagePiece, tar, directory, javaExe, dockerExe, dockerInspectorInfo, dockerProperties);
             }
-        } catch (final Exception e) {
+        } catch (Exception e) {
             return new Extraction.Builder().exception(e).build();
         }
     }
 
-    private void importTars(final List<File> importTars, final File directory, final Map<String, String> environmentVariables, final File bashExe) {
+    private void importTars(List<File> importTars, File directory, Map<String, String> environmentVariables, File dockerExe) {
         try {
-            for (final File imageToImport : importTars) {
+            for (File imageToImport : importTars) {
                 // The -c is a bash option, the following String is the command we want to run
-                final List<String> dockerImportArguments = Arrays.asList(
-                    "-c",
-                    "docker load -i \"" + imageToImport.getCanonicalPath() + "\"");
+                List<String> dockerImportArguments = Arrays.asList(
+                    "load",
+                    "-i",
+                    imageToImport.getCanonicalPath());
 
-                final Executable dockerImportImageExecutable = new Executable(directory, environmentVariables, bashExe.toString(), dockerImportArguments);
-                executableRunner.execute(dockerImportImageExecutable);
+                Executable dockerImportImageExecutable = new Executable(directory, environmentVariables, dockerExe.toString(), dockerImportArguments);
+                ExecutableOutput exeOut = executableRunner.execute(dockerImportImageExecutable);
+                if (exeOut.getReturnCode() != 0) {
+                    throw new IntegrationException(String.format("Command %s %s returned %d: %s",
+                        dockerExe.getAbsolutePath(),
+                        dockerImportArguments,
+                        exeOut.getReturnCode(),
+                        exeOut.getErrorOutput()));
+                }
             }
-        } catch (final Exception e) {
+        } catch (Exception e) {
             logger.debug("Exception encountered when resolving paths for docker air gap, running in online mode instead");
             logger.debug(e.getMessage());
         }
     }
 
-    private Extraction executeDocker(final File outputDirectory, final String imageArgument, final String suppliedImagePiece, final String dockerTarFilePath, final File directory, final File javaExe, final File bashExe,
-        final DockerInspectorInfo dockerInspectorInfo, DockerProperties dockerProperties)
+    private Extraction executeDocker(File outputDirectory, String imageArgument, String suppliedImagePiece, String dockerTarFilePath, File directory, File javaExe, File dockerExe,
+        DockerInspectorInfo dockerInspectorInfo, DockerProperties dockerProperties)
         throws IOException, ExecutableRunnerException {
 
-        final File dockerPropertiesFile = new File(outputDirectory, "application.properties");
+        File dockerPropertiesFile = new File(outputDirectory, "application.properties");
         dockerProperties.populatePropertiesFile(dockerPropertiesFile, outputDirectory);
-        final Map<String, String> environmentVariables = new HashMap<>(0);
-        final List<String> dockerArguments = new ArrayList<>();
+        Map<String, String> environmentVariables = new HashMap<>(0);
+        List<String> dockerArguments = new ArrayList<>();
         dockerArguments.add("-jar");
         dockerArguments.add(dockerInspectorInfo.getDockerInspectorJar().getAbsolutePath());
         dockerArguments.add("--spring.config.location=file:" + dockerPropertiesFile.getCanonicalPath());
         dockerArguments.add(imageArgument);
         if (dockerInspectorInfo.hasAirGapImageFiles()) {
-            importTars(dockerInspectorInfo.getAirGapInspectorImageTarFiles(), outputDirectory, environmentVariables, bashExe);
+            importTars(dockerInspectorInfo.getAirGapInspectorImageTarFiles(), outputDirectory, environmentVariables, dockerExe);
         }
-        final Executable dockerExecutable = new Executable(outputDirectory, environmentVariables, javaExe.getAbsolutePath(), dockerArguments);
+        Executable dockerExecutable = new Executable(outputDirectory, environmentVariables, javaExe.getAbsolutePath(), dockerArguments);
         executableRunner.execute(dockerExecutable);
 
         File scanFile = null;
-        final File producedSquashedImageFile = fileFinder.findFile(outputDirectory, SQUASHED_IMAGE_FILENAME_PATTERN);
-        final File producedContainerFileSystemFile = fileFinder.findFile(outputDirectory, CONTAINER_FILESYSTEM_FILENAME_PATTERN);
+        File producedSquashedImageFile = fileFinder.findFile(outputDirectory, SQUASHED_IMAGE_FILENAME_PATTERN);
+        File producedContainerFileSystemFile = fileFinder.findFile(outputDirectory, CONTAINER_FILESYSTEM_FILENAME_PATTERN);
         if (null != producedSquashedImageFile && producedSquashedImageFile.isFile()) {
             logger.debug(String.format("Will signature scan: %s", producedSquashedImageFile.getAbsolutePath()));
             scanFile = producedSquashedImageFile;
@@ -162,7 +172,7 @@ public class DockerExtractor {
         } else {
             logger.debug(String.format("No files found matching pattern [%s]. Expected docker-inspector to produce file in %s", CONTAINER_FILESYSTEM_FILENAME_PATTERN, outputDirectory.getCanonicalPath()));
             if (StringUtils.isNotBlank(dockerTarFilePath)) {
-                final File dockerTarFile = new File(dockerTarFilePath);
+                File dockerTarFile = new File(dockerTarFilePath);
                 if (dockerTarFile.isFile()) {
                     logger.debug(String.format("Will scan the provided Docker tar file %s", dockerTarFile.getCanonicalPath()));
                     scanFile = dockerTarFile;
@@ -170,35 +180,35 @@ public class DockerExtractor {
             }
         }
 
-        final Extraction.Builder extractionBuilder = findCodeLocations(outputDirectory, directory);
-        final String imageIdentifier = getImageIdentifierFromOutputDirectoryIfImageIdPresent(outputDirectory, suppliedImagePiece, imageIdentifierType);
+        Extraction.Builder extractionBuilder = findCodeLocations(outputDirectory, directory);
+        String imageIdentifier = getImageIdentifierFromOutputDirectoryIfImageIdPresent(outputDirectory, suppliedImagePiece, imageIdentifierType);
         extractionBuilder.metaData(DOCKER_TAR_META_DATA, scanFile).metaData(DOCKER_IMAGE_NAME_META_DATA, imageIdentifier);
         return extractionBuilder.build();
     }
 
-    private Extraction.Builder findCodeLocations(final File directoryToSearch, final File directory) {
-        final File bdioFile = fileFinder.findFile(directoryToSearch, DEPENDENCIES_PATTERN);
+    private Extraction.Builder findCodeLocations(File directoryToSearch, File directory) {
+        File bdioFile = fileFinder.findFile(directoryToSearch, DEPENDENCIES_PATTERN);
         if (bdioFile != null) {
             SimpleBdioDocument simpleBdioDocument = null;
 
-            try (final InputStream dockerOutputInputStream = new FileInputStream(bdioFile); final BdioReader bdioReader = new BdioReader(gson, dockerOutputInputStream)) {
+            try (InputStream dockerOutputInputStream = new FileInputStream(bdioFile); BdioReader bdioReader = new BdioReader(gson, dockerOutputInputStream)) {
                 simpleBdioDocument = bdioReader.readSimpleBdioDocument();
-            } catch (final Exception e) {
+            } catch (Exception e) {
                 return new Extraction.Builder().exception(e);
             }
 
             if (simpleBdioDocument != null) {
-                final DependencyGraph dependencyGraph = bdioTransformer.transformToDependencyGraph(simpleBdioDocument.getProject(), simpleBdioDocument.getComponents());
+                DependencyGraph dependencyGraph = bdioTransformer.transformToDependencyGraph(simpleBdioDocument.getProject(), simpleBdioDocument.getComponents());
 
-                final String projectName = simpleBdioDocument.getProject().name;
-                final String projectVersionName = simpleBdioDocument.getProject().version;
+                String projectName = simpleBdioDocument.getProject().name;
+                String projectVersionName = simpleBdioDocument.getProject().version;
 
                 // TODO ejk - update this when project external id is not req'd anymore
-                final Forge dockerForge = new Forge(BdioId.BDIO_ID_SEPARATOR, simpleBdioDocument.getProject().bdioExternalIdentifier.forge);
-                final String externalIdPath = simpleBdioDocument.getProject().bdioExternalIdentifier.externalId;
-                final ExternalId projectExternalId = externalIdFactory.createPathExternalId(dockerForge, externalIdPath);
+                Forge dockerForge = new Forge(BdioId.BDIO_ID_SEPARATOR, simpleBdioDocument.getProject().bdioExternalIdentifier.forge);
+                String externalIdPath = simpleBdioDocument.getProject().bdioExternalIdentifier.externalId;
+                ExternalId projectExternalId = externalIdFactory.createPathExternalId(dockerForge, externalIdPath);
 
-                final CodeLocation detectCodeLocation = new CodeLocation(dependencyGraph, projectExternalId);
+                CodeLocation detectCodeLocation = new CodeLocation(dependencyGraph, projectExternalId);
 
                 return new Extraction.Builder().success(detectCodeLocation).projectName(projectName).projectVersion(projectVersionName);
             }
@@ -208,18 +218,18 @@ public class DockerExtractor {
     }
 
     public String getImageIdentifierFromOutputDirectoryIfImageIdPresent(File outputDirectory, String suppliedImagePiece, ImageIdentifierType imageIdentifierType) {
-        final File producedResultFile = fileFinder.findFile(outputDirectory, RESULTS_FILENAME_PATTERN);
+        File producedResultFile = fileFinder.findFile(outputDirectory, RESULTS_FILENAME_PATTERN);
         if (imageIdentifierType.equals(ImageIdentifierType.IMAGE_ID) && producedResultFile != null) {
             String jsonText;
             try {
                 jsonText = FileUtils.readFileToString(producedResultFile, StandardCharsets.UTF_8);
                 DockerImageInfo dockerImageInfo = gson.fromJson(jsonText, DockerImageInfo.class);
-                final String imageRepo = dockerImageInfo.getImageRepo();
-                final String imageTag = dockerImageInfo.getImageTag();
+                String imageRepo = dockerImageInfo.getImageRepo();
+                String imageTag = dockerImageInfo.getImageTag();
                 if (StringUtils.isNotBlank(imageRepo) && StringUtils.isNotBlank(imageTag)) {
                     return imageRepo + ":" + imageTag;
                 }
-            } catch (final IOException | JsonSyntaxException e) {
+            } catch (IOException | JsonSyntaxException e) {
                 logger.debug("Failed to parse results file from run of Docker Inspector, thus could not get name of image.  The code location name for this scan will be derived from the passed image ID");
             }
         }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -235,7 +235,7 @@ public class DetectableFactory {
 
     public DockerDetectable createDockerDetectable(DetectableEnvironment environment, DockerDetectableOptions dockerDetectableOptions, DockerInspectorResolver dockerInspectorResolver, JavaResolver javaResolver, BashResolver bashResolver,
         DockerResolver dockerResolver) {
-        return new DockerDetectable(environment, dockerInspectorResolver, javaResolver, bashResolver, dockerResolver, dockerExtractor(), dockerDetectableOptions);
+        return new DockerDetectable(environment, dockerInspectorResolver, javaResolver, dockerResolver, dockerExtractor(), dockerDetectableOptions);
     }
 
     public BazelDetectable createBazelDetectable(DetectableEnvironment environment, BazelDetectableOptions bazelDetectableOptions, BazelResolver bazelResolver) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -233,7 +233,7 @@ public class DetectableFactory {
     //Should be scoped to Prototype so a new Detectable is created every time one is needed.
     //Should only be accessed through the DetectableFactory.
 
-    public DockerDetectable createDockerDetectable(DetectableEnvironment environment, DockerDetectableOptions dockerDetectableOptions, DockerInspectorResolver dockerInspectorResolver, JavaResolver javaResolver, BashResolver bashResolver,
+    public DockerDetectable createDockerDetectable(DetectableEnvironment environment, DockerDetectableOptions dockerDetectableOptions, DockerInspectorResolver dockerInspectorResolver, JavaResolver javaResolver,
         DockerResolver dockerResolver) {
         return new DockerDetectable(environment, dockerInspectorResolver, javaResolver, dockerResolver, dockerExtractor(), dockerDetectableOptions);
     }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerDetectableTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.detectable.DetectableEnvironment;
-import com.synopsys.integration.detectable.detectable.executable.resolver.BashResolver;
 import com.synopsys.integration.detectable.detectable.executable.resolver.DockerResolver;
 import com.synopsys.integration.detectable.detectable.executable.resolver.JavaResolver;
 import com.synopsys.integration.detectable.detectable.result.DetectableResult;
@@ -42,20 +41,19 @@ public class DockerDetectableTest {
 
     @Test
     public void testApplicable() {
-        final DetectableEnvironment environment = null;
-        final DockerInspectorResolver dockerInspectorResolver = null;
-        final JavaResolver javaResolver = null;
-        final BashResolver bashResolver = null;
-        final DockerResolver dockerResolver = null;
-        final DockerExtractor dockerExtractor = null;
-        final DockerDetectableOptions dockerDetectableOptions = Mockito.mock(DockerDetectableOptions.class);
+        DetectableEnvironment environment = null;
+        DockerInspectorResolver dockerInspectorResolver = null;
+        JavaResolver javaResolver = null;
+        DockerResolver dockerResolver = null;
+        DockerExtractor dockerExtractor = null;
+        DockerDetectableOptions dockerDetectableOptions = Mockito.mock(DockerDetectableOptions.class);
 
         Mockito.when(dockerDetectableOptions.hasDockerImageOrTar()).thenReturn(Boolean.TRUE);
 
-        final DockerDetectable detectable = new DockerDetectable(environment, dockerInspectorResolver, javaResolver, bashResolver, dockerResolver,
-         dockerExtractor, dockerDetectableOptions);
+        DockerDetectable detectable = new DockerDetectable(environment, dockerInspectorResolver, javaResolver, dockerResolver,
+            dockerExtractor, dockerDetectableOptions);
 
-        final DetectableResult result = detectable.applicable();
+        DetectableResult result = detectable.applicable();
 
         assertTrue(result.getPassed() || result instanceof WrongOperatingSystemResult);
     }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunManager.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/RunManager.java
@@ -107,8 +107,6 @@ import com.synopsys.integration.detect.workflow.status.Status;
 import com.synopsys.integration.detect.workflow.status.StatusType;
 import com.synopsys.integration.detectable.detectable.executable.ExecutableRunner;
 import com.synopsys.integration.detectable.detectable.file.impl.SimpleFileFinder;
-import com.synopsys.integration.detectable.detectable.result.DetectableResult;
-import com.synopsys.integration.detectable.detectable.result.WrongOperatingSystemResult;
 import com.synopsys.integration.detector.base.DetectorType;
 import com.synopsys.integration.detector.evaluation.DetectorEvaluationOptions;
 import com.synopsys.integration.detector.finder.DetectorFinder;
@@ -206,7 +204,6 @@ public class RunManager {
                 eventSystem);
 
             DetectableToolResult detectableToolResult = detectableTool.execute(directoryManager.getSourceDirectory());
-            assertValidOperatingSystem(detectableToolResult);
 
             runResult.addDetectableToolResult(detectableToolResult);
             eventSystem.publishEvent(Event.CodeLocationNamesAdded, createCodeLocationNames(detectableToolResult, codeLocationNameManager, directoryManager));
@@ -278,16 +275,6 @@ public class RunManager {
             return UniversalToolsResult.failure(projectNameVersion);
         } else {
             return UniversalToolsResult.success(projectNameVersion);
-        }
-    }
-
-    //TODO: Remove hack when windows docker support added. This workaround allows docker to throw a user friendly exception when not-extractable due to operating system.
-    private void assertValidOperatingSystem(DetectableToolResult detectableToolResult) throws DetectUserFriendlyException {
-        if (detectableToolResult.getFailedExtractableResult().isPresent()) {
-            DetectableResult extractable = detectableToolResult.getFailedExtractableResult().get();
-            if (WrongOperatingSystemResult.class.isAssignableFrom(extractable.getClass())) {
-                throw new DetectUserFriendlyException("Docker currently requires a non-Windows OS to run. Attempting to run Docker on Windows is not currently supported.", ExitCodeType.FAILURE_CONFIGURATION);
-            }
         }
     }
 

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/impl/DetectDetectableFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/impl/DetectDetectableFactory.java
@@ -92,7 +92,7 @@ public class DetectDetectableFactory {
     }
 
     public DockerDetectable createDockerDetectable(DetectableEnvironment environment) {
-        return detectableFactory.createDockerDetectable(environment, detectableOptionFactory.createDockerDetectableOptions(), dockerInspectorResolver, detectExecutableResolver, detectExecutableResolver, detectExecutableResolver);
+        return detectableFactory.createDockerDetectable(environment, detectableOptionFactory.createDockerDetectableOptions(), dockerInspectorResolver, detectExecutableResolver, detectExecutableResolver);
     }
 
     public BazelDetectable createBazelDetectable(DetectableEnvironment environment) {
@@ -223,11 +223,11 @@ public class DetectDetectableFactory {
         return detectableFactory.createPodLockDetectable(environment);
     }
 
-    public PoetryDetectable createPoetryDetectable( DetectableEnvironment environment) {
+    public PoetryDetectable createPoetryDetectable(DetectableEnvironment environment) {
         return detectableFactory.createPoetryDetectable(environment);
     }
 
-    public RebarDetectable createRebarDetectable( DetectableEnvironment environment) {
+    public RebarDetectable createRebarDetectable(DetectableEnvironment environment) {
         return detectableFactory.createRebarDetectable(environment, detectExecutableResolver);
     }
 


### PR DESCRIPTION
Changes to allow the Docker functionality to run (and work) on Windows.
Docker Inspector 9.1.0 (which seems about ready to start going through the release process) is required for Docker functionality to fully work in Detect.