### PR TITLE
Fix pip-inspector for pip>=20.1

### DIFF
--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -86,8 +86,8 @@ def main():
                         raise Exception()
                     project.children = project.children + [requirement]
                 except:
-                    if req is not None and req.req is not None:
-                        print('--' + req.req.name)
+                    if req is not None and package_name is not None:
+                        print('--' + package_name)
         except AssertionError:
             print('r?' + requirements_path)
         except:


### PR DESCRIPTION
# Description

There is a reference to `req.req`, which is not valid in pip>=20.1. This leads to an `AttributeError`, which is being captured by too broad `except:` clause making it hard to track down whats happening.

In fact, this script uses quite a few anti-patterns: too broad exceptions, using internal API of pip, runtime imports, using assertions to drive execution flow, etc. On top of that, its output API is not documented, therefore it's very hard to debug whether it's working correctly.

I would **strongly recommend** building on top of some standard solution to get list of pip requirements, like [pip-tools](https://github.com/jazzband/pip-tools) or [pipdeptree](https://github.com/naiquevin/pipdeptree).