### PR TITLE
feat(status): Detectors field in status.json now has more concise and…

### DIFF
--- a/detector/src/main/java/com/synopsys/integration/detector/base/DetectorEvaluation.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/base/DetectorEvaluation.java
@@ -155,6 +155,45 @@ public class DetectorEvaluation {
         return getDetectorResultDescription(extractable).orElse(NO_MESSAGE);
     }
 
+    public DetectorStatusType getStatus() {
+        if (getStatusCode().equals("PASSED")) {
+            return DetectorStatusType.SUCCESS;
+        }
+        return DetectorStatusType.FAILURE;
+    }
+
+    public String getStatusCode() {
+        if (!isSearchable()) {
+            return searchable.getStatusCode();
+        }
+        if (!isApplicable()) {
+            return applicable.getStatusCode();
+        }
+        if (!isExtractable()) {
+            return extractable.getStatusCode();
+        }
+        if (extraction.getResult() != Extraction.ExtractionResultType.SUCCESS) {
+            return "EXTRACTION_UNSUCCESSFUL"; // TODO (IDETECT-2189)
+        }
+        return "PASSED";
+    }
+
+    public String getStatusReason() {
+        if (!isSearchable()) {
+            return searchable.getDescription();
+        }
+        if (!isApplicable()) {
+            return applicable.getDescription();
+        }
+        if (!isExtractable()) {
+            return extractable.getDescription();
+        }
+        if (extraction.getResult() != Extraction.ExtractionResultType.SUCCESS) {
+            return "See logs for further explanation"; // TODO (IDETECT-2189)
+        }
+        return "Passed";
+    }
+
     public Optional<DetectorEvaluation> getSuccessfullFallback() {
         if (fallbackTo != null) {
             if (fallbackTo.isExtractable()) {
@@ -224,5 +263,9 @@ public class DetectorEvaluation {
 
     public void setFallbackFrom(final DetectorEvaluation fallbackFrom) {
         this.fallbackFrom = fallbackFrom;
+    }
+
+    public enum DetectorStatusType {
+        SUCCESS, FAILURE
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/base/DetectorEvaluation.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/base/DetectorEvaluation.java
@@ -36,7 +36,8 @@ import com.synopsys.integration.detector.result.DetectorResult;
 import com.synopsys.integration.detector.rule.DetectorRule;
 
 public class DetectorEvaluation {
-    public static final String NO_MESSAGE = "Unknown";
+    private static final String NO_MESSAGE = "Unknown";
+    private static final String PASSED_RESULT = "PassedDetectorResult";
 
     private final DetectorRule detectorRule;
     private Detectable detectable;
@@ -156,26 +157,26 @@ public class DetectorEvaluation {
     }
 
     public DetectorStatusType getStatus() {
-        if (getStatusCode().equals("PASSED")) {
+        if (getResultClassName().equals(PASSED_RESULT)) {
             return DetectorStatusType.SUCCESS;
         }
         return DetectorStatusType.FAILURE;
     }
 
-    public String getStatusCode() {
+    public String getResultClassName() {
         if (!isSearchable()) {
-            return searchable.getStatusCode();
+            return searchable.getResultClassName();
         }
         if (!isApplicable()) {
-            return applicable.getStatusCode();
+            return applicable.getResultClassName();
         }
         if (!isExtractable()) {
-            return extractable.getStatusCode();
+            return extractable.getResultClassName();
         }
         if (extraction.getResult() != Extraction.ExtractionResultType.SUCCESS) {
             return "EXTRACTION_UNSUCCESSFUL"; // TODO (IDETECT-2189)
         }
-        return "PASSED";
+        return PASSED_RESULT;
     }
 
     public String getStatusReason() {

--- a/detector/src/main/java/com/synopsys/integration/detector/evaluation/DetectorEvaluator.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/evaluation/DetectorEvaluator.java
@@ -85,7 +85,7 @@ public class DetectorEvaluator {
                 detectorEvaluation.setDetectable(detectable);
 
                 final DetectableResult applicable = detectable.applicable();
-                final DetectorResult applicableResult = new DetectorResult(applicable.getPassed(), applicable.toDescription());
+                final DetectorResult applicableResult = new DetectorResult(applicable.getPassed(), applicable.toDescription(), applicable.getClass().getName());
                 detectorEvaluation.setApplicable(applicableResult);
 
                 if (detectorEvaluation.isApplicable()) {
@@ -127,7 +127,7 @@ public class DetectorEvaluator {
                 logger.trace("Checking to see if this detector is a fallback detector.");
                 DetectableResult detectableExtractableResult = getDetectableExtractableResult(detectorEvaluationTree, detectorEvaluation);
 
-                final DetectorResult extractableResult = new DetectorResult(detectableExtractableResult.getPassed(), detectableExtractableResult.toDescription());
+                final DetectorResult extractableResult = new DetectorResult(detectableExtractableResult.getPassed(), detectableExtractableResult.toDescription(), detectableExtractableResult.getClass().getName());
                 detectorEvaluation.setExtractable(extractableResult);
                 if (detectorEvaluation.isExtractable()) {
                     logger.trace("Extractable passed. Done evaluating for now.");

--- a/detector/src/main/java/com/synopsys/integration/detector/result/DetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/DetectorResult.java
@@ -28,12 +28,12 @@ public class DetectorResult {
     private final boolean passed;
     @NotNull
     private final String description;
-    private final String resultName;
+    private final String resultClassName;
 
-    public DetectorResult(final boolean passed, @NotNull final String description, final String resultName) {
+    public DetectorResult(final boolean passed, @NotNull final String description, final String resultClassName) {
         this.passed = passed;
         this.description = description;
-        this.resultName = resultName;
+        this.resultClassName = resultClassName;
     }
 
     public boolean getPassed() {
@@ -45,19 +45,8 @@ public class DetectorResult {
         return description;
     }
 
-    public String getStatusCode() {
-        if (!passed) {
-            return formatResultNameToStatusCode(resultName);
-        }
-        return "PASSED";
+    public String getResultClassName() {
+        return resultClassName;
     }
 
-    private String formatResultNameToStatusCode(String resultName) {
-        String[] classnamePieces = resultName.split("\\.");
-        String actualResultName = classnamePieces[classnamePieces.length-1].replace("DetectResult", "");
-
-        return actualResultName
-                   .replaceAll("([a-z])([A-Z]+)", "$1_$2")
-                   .toUpperCase();
-    }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/DetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/DetectorResult.java
@@ -53,18 +53,11 @@ public class DetectorResult {
     }
 
     private String formatResultNameToStatusCode(String resultName) {
-        // Regular Expression
-        String regex = "([a-z])([A-Z]+)";
-
-        // Replacement string
-        String replacement = "$1_$2";
-
-        // Strip fully qualified class name
         String[] classnamePieces = resultName.split("\\.");
         String actualResultName = classnamePieces[classnamePieces.length-1].replace("DetectResult", "");
 
         return actualResultName
-                   .replaceAll(regex, replacement)
+                   .replaceAll("([a-z])([A-Z]+)", "$1_$2")
                    .toUpperCase();
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/DetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/DetectorResult.java
@@ -28,10 +28,12 @@ public class DetectorResult {
     private final boolean passed;
     @NotNull
     private final String description;
+    private final String resultName;
 
-    public DetectorResult(final boolean passed, @NotNull final String description) {
+    public DetectorResult(final boolean passed, @NotNull final String description, final String resultName) {
         this.passed = passed;
         this.description = description;
+        this.resultName = resultName;
     }
 
     public boolean getPassed() {
@@ -41,5 +43,28 @@ public class DetectorResult {
     @NotNull
     public String getDescription() {
         return description;
+    }
+
+    public String getStatusCode() {
+        if (!passed) {
+            return formatResultNameToStatusCode(resultName);
+        }
+        return "PASSED";
+    }
+
+    private String formatResultNameToStatusCode(String resultName) {
+        // Regular Expression
+        String regex = "([a-z])([A-Z]+)";
+
+        // Replacement string
+        String replacement = "$1_$2";
+
+        // Strip fully qualified class name
+        String[] classnamePieces = resultName.split("\\.");
+        String actualResultName = classnamePieces[classnamePieces.length-1].replace("DetectResult", "");
+
+        return actualResultName
+                   .replaceAll(regex, replacement)
+                   .toUpperCase();
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/ExcludedDetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/ExcludedDetectorResult.java
@@ -24,6 +24,6 @@ package com.synopsys.integration.detector.result;
 
 public class ExcludedDetectorResult extends FailedDetectorResult {
     public ExcludedDetectorResult() {
-        super("Detector type was excluded.");
+        super("Detector type was excluded.", "ExcludedDetectorResult");
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/FailedDetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/FailedDetectorResult.java
@@ -25,7 +25,7 @@ package com.synopsys.integration.detector.result;
 import org.jetbrains.annotations.NotNull;
 
 public class FailedDetectorResult extends DetectorResult {
-    public FailedDetectorResult(@NotNull final String description) {
-        super(false, description);
+    public FailedDetectorResult(@NotNull final String description, final String resultName) {
+        super(false, description, resultName);
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/MaxDepthExceededDetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/MaxDepthExceededDetectorResult.java
@@ -24,6 +24,6 @@ package com.synopsys.integration.detector.result;
 
 public class MaxDepthExceededDetectorResult extends FailedDetectorResult {
     public MaxDepthExceededDetectorResult(final int depth, final int maxDepth) {
-        super(String.format("Max depth of %d exceeded by %d", maxDepth, depth));
+        super(String.format("Max depth of %d exceeded by %d", maxDepth, depth), "MaxDepthExceededDetectorResult");
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/NotNestableDetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/NotNestableDetectorResult.java
@@ -24,6 +24,6 @@ package com.synopsys.integration.detector.result;
 
 public class NotNestableDetectorResult extends FailedDetectorResult {
     public NotNestableDetectorResult() {
-        super("Not nestable and a detector already applied in parent directory.");
+        super("Not nestable and a detector already applied in parent directory.", "NotNestableDetectorResult");
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/NotSelfNestableDetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/NotSelfNestableDetectorResult.java
@@ -24,6 +24,6 @@ package com.synopsys.integration.detector.result;
 
 public class NotSelfNestableDetectorResult extends FailedDetectorResult {
     public NotSelfNestableDetectorResult() {
-        super("Nestable but this detector already applied in a parent directory.");
+        super("Nestable but this detector already applied in a parent directory.", "NotSelfNestableDetectorResult");
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/PassedDetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/PassedDetectorResult.java
@@ -26,10 +26,14 @@ import org.jetbrains.annotations.NotNull;
 
 public class PassedDetectorResult extends DetectorResult {
     public PassedDetectorResult() {
-        this("Passed.");
+        this("Passed.", "N/A");
     }
 
     public PassedDetectorResult(@NotNull final String description) {
-        super(true, description);
+        this(description, "N/A");
+    }
+
+    public PassedDetectorResult(@NotNull final String description, final String resultName) {
+        super(true, description, resultName);
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/result/YieldedDetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/YieldedDetectorResult.java
@@ -28,6 +28,6 @@ import org.apache.commons.lang3.StringUtils;
 
 public class YieldedDetectorResult extends FailedDetectorResult {
     public YieldedDetectorResult(final Set<String> yieldedTo) {
-        super(String.format("Yielded to detectors: %s", StringUtils.join(yieldedTo, ",")));
+        super(String.format("Yielded to detectors: %s", StringUtils.join(yieldedTo, ",")), "YieldedDetectorResult");
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedDetectorOutput.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedDetectorOutput.java
@@ -40,29 +40,20 @@ public class FormattedDetectorOutput {
     @SerializedName("descriptiveName")
     public String descriptiveName = "";
 
-    @SerializedName("searchable")
-    public boolean searchable = true;
-
-    @SerializedName("applicable")
-    public boolean applicable = true;
-
-    @SerializedName("extractable")
-    public boolean extractable = true;
-
     @SerializedName("discoverable")
     public boolean discoverable = true;
 
     @SerializedName("extracted")
     public boolean extracted = true;
 
-    @SerializedName("searchableReason")
-    public String searchableReason = "";
+    @SerializedName("status")
+    public String status = "";
 
-    @SerializedName("applicableReason")
-    public String applicableReason = "";
+    @SerializedName("statusCode")
+    public String statusCode = "";
 
-    @SerializedName("extractableReason")
-    public String extractableReason = "";
+    @SerializedName("statusReason")
+    public String statusReason = "";
 
     @SerializedName("discoveryReason")
     public String discoveryReason = "";

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedOutputManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedOutputManager.java
@@ -112,15 +112,12 @@ public class FormattedOutputManager {
         detectorOutput.detectorName = evaluation.getDetectorRule().getName();
         detectorOutput.detectorType = evaluation.getDetectorRule().getDetectorType().toString();
 
-        detectorOutput.searchable = evaluation.isSearchable();
-        detectorOutput.applicable = evaluation.isApplicable();
-        detectorOutput.extractable = evaluation.isExtractable();
         detectorOutput.extracted = evaluation.wasExtractionSuccessful();
         detectorOutput.discoverable = evaluation.wasDiscoverySuccessful();
+        detectorOutput.status = evaluation.getStatus().name();
+        detectorOutput.statusCode = evaluation.getStatusCode();
+        detectorOutput.statusReason = evaluation.getStatusReason();
 
-        detectorOutput.searchableReason = evaluation.getSearchabilityMessage();
-        detectorOutput.applicableReason = evaluation.getApplicabilityMessage();
-        detectorOutput.extractableReason = evaluation.getExtractabilityMessage();
         if (evaluation.getDiscovery() != null) {
             detectorOutput.discoveryReason = evaluation.getDiscovery().getDescription();
         }

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedOutputManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedOutputManager.java
@@ -41,6 +41,7 @@ import com.synopsys.integration.detect.workflow.result.DetectResult;
 import com.synopsys.integration.detect.workflow.status.DetectIssue;
 import com.synopsys.integration.detect.workflow.status.Status;
 import com.synopsys.integration.detect.workflow.status.UnrecognizedPaths;
+import com.synopsys.integration.detectable.Extraction;
 import com.synopsys.integration.detector.base.DetectorEvaluation;
 import com.synopsys.integration.detector.base.DetectorEvaluationTree;
 import com.synopsys.integration.util.NameVersion;
@@ -115,7 +116,7 @@ public class FormattedOutputManager {
         detectorOutput.extracted = evaluation.wasExtractionSuccessful();
         detectorOutput.discoverable = evaluation.wasDiscoverySuccessful();
         detectorOutput.status = evaluation.getStatus().name();
-        detectorOutput.statusCode = evaluation.getStatusCode();
+        detectorOutput.statusCode = formatResultNameToStatusCode(evaluation.getResultClassName());
         detectorOutput.statusReason = evaluation.getStatusReason();
 
         if (evaluation.getDiscovery() != null) {
@@ -132,6 +133,15 @@ public class FormattedOutputManager {
         }
 
         return detectorOutput;
+    }
+
+    private String formatResultNameToStatusCode(String resultName) {
+        String[] classnamePieces = resultName.split("\\.");
+        String actualResultName = classnamePieces[classnamePieces.length-1].replace("DetectResult", "").replace("DetectorResult", "").replace("DetectableResult", "");
+
+        return actualResultName
+                   .replaceAll("([a-z])([A-Z]+)", "$1_$2")
+                   .toUpperCase();
     }
 
     private void detectorsComplete(final DetectorToolResult detectorToolResult) {

--- a/src/test/java/com/synopsys/integration/detect/workflow/report/FormattedOutputManagerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/report/FormattedOutputManagerTest.java
@@ -1,0 +1,66 @@
+package com.synopsys.integration.detect.workflow.report;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.detect.DetectInfo;
+import com.synopsys.integration.detect.tool.detector.DetectorToolResult;
+import com.synopsys.integration.detect.workflow.event.Event;
+import com.synopsys.integration.detect.workflow.event.EventSystem;
+import com.synopsys.integration.detect.workflow.report.output.FormattedDetectorOutput;
+import com.synopsys.integration.detect.workflow.report.output.FormattedOutput;
+import com.synopsys.integration.detect.workflow.report.output.FormattedOutputManager;
+import com.synopsys.integration.detectable.Detectable;
+import com.synopsys.integration.detectable.DetectableEnvironment;
+import com.synopsys.integration.detectable.detectable.result.ExecutableNotFoundDetectableResult;
+import com.synopsys.integration.detector.base.DetectorEvaluation;
+import com.synopsys.integration.detector.base.DetectorEvaluationTree;
+import com.synopsys.integration.detector.base.DetectorType;
+import com.synopsys.integration.detector.result.DetectorResult;
+import com.synopsys.integration.detector.rule.DetectorRule;
+
+public class FormattedOutputManagerTest {
+
+    @Test
+    public <T extends Detectable> void detectorOutputStatusDataTest() {
+        EventSystem eventSystem = new EventSystem();
+        FormattedOutputManager formattedOutputManager = new FormattedOutputManager(eventSystem);
+
+        DetectorRule rule = Mockito.mock(DetectorRule.class);
+        Mockito.when(rule.getDescriptiveName()).thenReturn("");
+        Mockito.when(rule.getName()).thenReturn("");
+        Mockito.when(rule.getDetectorType()).thenReturn(DetectorType.GO_MOD);
+
+        DetectorEvaluation detectorEvaluation = new DetectorEvaluation(rule);
+        ExecutableNotFoundDetectableResult result = new ExecutableNotFoundDetectableResult("go");
+        final DetectorResult extractableResult = new DetectorResult(result.getPassed(), result.toDescription(), result.getClass().getName());
+        detectorEvaluation.setExtractable(extractableResult);
+        detectorEvaluation.setApplicable(new DetectorResult(true, "", ""));
+        detectorEvaluation.setSearchable(new DetectorResult(true, "", ""));
+        detectorEvaluation.setDetectableEnvironment(new DetectableEnvironment(new File("")));
+
+        final DetectorToolResult detectorToolResult = new DetectorToolResult(
+            null,
+            null,
+            null,
+            new HashSet<>(),
+            new DetectorEvaluationTree(null, 0, null, Collections.singletonList(detectorEvaluation), new HashSet<>()),
+            null
+        );
+        eventSystem.publishEvent(Event.DetectorsComplete, detectorToolResult);
+
+        DetectInfo detectInfo = new DetectInfo("", 0, null);
+        FormattedOutput formattedOutput = formattedOutputManager.createFormattedOutput(detectInfo);
+        FormattedDetectorOutput detectorOutput = formattedOutput.detectors.get(0);
+
+        Assertions.assertEquals( "FAILURE", detectorOutput.status);
+        Assertions.assertEquals("EXECUTABLE_NOT_FOUND", detectorOutput.statusCode);
+        Assertions.assertEquals("No go executable was found.", detectorOutput.statusReason);
+    }
+}


### PR DESCRIPTION
… expressive codes and messages (IDETECT-2188)

Improving how we display detector results in status.json, as per IDETECT-2188.
Slimmed fields in "detectors" section, provide a status, status code (derived from runtime class of the returned DetectResult), and status reason (an explanation for the code).
<img width="505" alt="SUCCESS" src="https://user-images.githubusercontent.com/51929980/91328201-96d5ee00-e794-11ea-9111-27f49ab6184c.png">
<img width="613" alt="FAILURE" src="https://user-images.githubusercontent.com/51929980/91328224-9d646580-e794-11ea-93b4-b4f3d3f7ebaf.png">
<img width="472" alt="old format" src="https://user-images.githubusercontent.com/51929980/91328342-ca187d00-e794-11ea-8a6b-d41120ceb8f9.png">



