### PR TITLE
add support for git packages and remove broad excepts

### DIFF
--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -80,18 +80,23 @@ class PipInspector:
         with open(self.requirements_path) as reqs_file:
             requirements = reqs_file.readlines()
 
+        parse_error = False
         for package_name in requirements:
             if package_name.startswith("git+"):
                 requirement = self.resolve_git_package(package_name)
             else:
-                pkg = re.split("==|>=|<=|>|<", package_name)[0]
+                pkg = re.split("==|>=|<=|>|<", package_name)[0].strip()
                 requirement = resolve_package_by_name(pkg, [])
 
             if requirement is None:
-                print("-- unknown requirement: %s" % package_name)
+                print("--" + package_name)
+                parse_error = True
                 continue
+
             self.project.children = self.project.children + [requirement]
 
+        if parse_error:
+            print("p?" + self.requirements_path)
         print(self.project.render())
 
 
@@ -148,9 +153,7 @@ def resolve_package_by_name(package_name, history):
 
 def main():
     try:
-        opts, args = getopt.getopt(
-            sys.argv[1:], "p:r", ["projectname=", "requirements="]
-        )
+        opts, _ = getopt.getopt(sys.argv[1:], "p:r", ["projectname=", "requirements="])
     except getopt.GetoptError as error:
         print(str(error))
         print(

--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -77,26 +77,25 @@ class PipInspector:
             print(self.project.render())
             return
 
+        requirements = []
         with open(self.requirements_path) as reqs_file:
-            requirements = reqs_file.readlines()
+            for req in reqs_file.readlines():
+                if req.strip():
+                    requirements.append(req.strip())
 
-        parse_error = False
         for package_name in requirements:
             if package_name.startswith("git+"):
                 requirement = self.resolve_git_package(package_name)
             else:
-                pkg = re.split("==|>=|<=|>|<", package_name)[0].strip()
-                requirement = resolve_package_by_name(pkg, [])
+                package_name = re.split("==|>=|<=|>|<", package_name)[0]
+                requirement = resolve_package_by_name(package_name, [])
 
             if requirement is None:
                 print("--" + package_name)
-                parse_error = True
                 continue
 
             self.project.children = self.project.children + [requirement]
 
-        if parse_error:
-            print("p?" + self.requirements_path)
         print(self.project.render())
 
 
@@ -171,7 +170,11 @@ def main():
         elif opt in "--requirements":
             requirements_path = arg
 
-    inspector = PipInspector(project_name, requirements_path)
+    try:
+        inspector = PipInspector(project_name, requirements_path)
+    except FileNotFoundError:
+        print("r?" + requirements_path)
+
     inspector.inspect()
 
 


### PR DESCRIPTION
# Description

This PR fixes an issue where python packages referenced by git (i.e. `git+git://github.com/path/to/package@0.0.1`) caused `pip-inspector` to fail. Additionally, the failure was swallowed by many broad excepts which were removed. If pip-inspector does not complete successfully then synopsis-detect should not report a successful run.

