### PR TITLE
Sb clang canonicalize dep paths

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
@@ -66,9 +66,7 @@ public class DependenyListFileParser {
         final List<String> depsList = new ArrayList<>(deps.length);
         for (final String includeFile : deps) {
             if (StringUtils.isNotBlank(includeFile)) {
-                final String canonicalIncludeFile = toCanonical(includeFile);
-                logger.trace(String.format("\t%s", canonicalIncludeFile));
-                depsList.add(canonicalIncludeFile);
+                depsList.add(toCanonical(includeFile));
             }
         }
         return depsList;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
@@ -23,8 +23,8 @@
 package com.synopsys.integration.detectable.detectables.clang.dependencyfile;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -66,22 +66,15 @@ public class DependenyListFileParser {
         final List<String> depsList = new ArrayList<>(deps.length);
         for (final String includeFile : deps) {
             if (StringUtils.isNotBlank(includeFile)) {
-                depsList.add(toCanonical(includeFile));
+                depsList.add(normalize(includeFile));
             }
         }
         return depsList;
     }
 
-    private String toCanonical(final String rawPath) {
-        final File targetFile = new File(rawPath);
-        final String canonicalPath;
-        try {
-            canonicalPath = targetFile.getCanonicalPath();
-        } catch (final IOException e) {
-            logger.warn(String.format("Unable to convert %s to canonical path", rawPath));
-            return rawPath;
-        }
-        logger.trace(String.format("Canonicalized %s to %s", rawPath, canonicalPath));
-        return canonicalPath;
+    private String normalize(final String rawPath) {
+        final String normalizedPath = Paths.get(rawPath).normalize().toString();
+        logger.trace(String.format("Normalized %s to %s", rawPath, normalizedPath));
+        return normalizedPath;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
@@ -25,9 +25,10 @@ package com.synopsys.integration.detectable.detectables.clang.dependencyfile;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -63,12 +64,10 @@ public class DependenyListFileParser {
         logger.trace(String.format("dependencies, backslashes removed: %s", depsListString));
 
         final String[] deps = depsListString.split("\\s+");
-        final List<String> depsList = new ArrayList<>(deps.length);
-        for (final String includeFile : deps) {
-            if (StringUtils.isNotBlank(includeFile)) {
-                depsList.add(normalize(includeFile));
-            }
-        }
+        final List<String> depsList = Arrays.stream(deps)
+                                          .filter(StringUtils::isNotBlank)
+                                          .map(this::normalize)
+                                          .collect(Collectors.toList());
         return depsList;
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
@@ -23,8 +23,9 @@
 package com.synopsys.integration.detectable.detectables.clang.dependencyfile;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -61,9 +62,25 @@ public class DependenyListFileParser {
         logger.trace(String.format("dependencies, backslashes removed: %s", depsListString));
 
         final String[] deps = depsListString.split("\\s+");
+        final List<String> depsList = new ArrayList<>(deps.length);
         for (final String includeFile : deps) {
-            logger.trace(String.format("\t%s", includeFile));
+            final String canonicalIncludeFile = toCanonical(includeFile);
+            logger.trace(String.format("\t%s", canonicalIncludeFile));
+            depsList.add(canonicalIncludeFile);
         }
-        return Arrays.asList(deps);
+        return depsList;
+    }
+
+    private String toCanonical(final String rawPath) {
+        final File targetFile = new File(rawPath);
+        final String canonicalPath;
+        try {
+            canonicalPath = targetFile.getCanonicalPath();
+        } catch (final IOException e) {
+            logger.warn(String.format("Unable to convert %s to canonical path", rawPath));
+            return rawPath;
+        }
+        logger.trace(String.format("Canonicalized %s to %s", rawPath, canonicalPath));
+        return canonicalPath;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/dependencyfile/DependenyListFileParser.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,9 +65,11 @@ public class DependenyListFileParser {
         final String[] deps = depsListString.split("\\s+");
         final List<String> depsList = new ArrayList<>(deps.length);
         for (final String includeFile : deps) {
-            final String canonicalIncludeFile = toCanonical(includeFile);
-            logger.trace(String.format("\t%s", canonicalIncludeFile));
-            depsList.add(canonicalIncludeFile);
+            if (StringUtils.isNotBlank(includeFile)) {
+                final String canonicalIncludeFile = toCanonical(includeFile);
+                logger.trace(String.format("\t%s", canonicalIncludeFile));
+                depsList.add(canonicalIncludeFile);
+            }
         }
         return depsList;
     }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/functional/DependencyListFileParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/functional/DependencyListFileParserTest.java
@@ -17,16 +17,16 @@ public class DependencyListFileParserTest {
 
     @Test
     @ExtendWith(TempDirectory.class)
-    public void testSimple(@TempDirectory.TempDir final Path tempOutputDirectory) throws IOException {
-        final File baseDir = tempOutputDirectory.toFile();
-        final File sourceFile = new File(baseDir, "src/test/resources/detectables/functional/clang/src/process.c");
-        final File includeFile1 = new File(baseDir, "src/test/resources/detectables/functional/clang/include/stdc-predef.h");
-        final File includeFile2 = new File(baseDir, "src/test/resources/detectables/functional/clang/include/assert.h");
-        final String fileContents = String.format("dependencies: %s \\\n %s %s\\\n",
+    public void testSimple(@TempDirectory.TempDir Path tempOutputDirectory) throws IOException {
+        File baseDir = tempOutputDirectory.toFile();
+        File sourceFile = new File(baseDir, "src/test/resources/detectables/functional/clang/src/process.c");
+        File includeFile1 = new File(baseDir, "src/test/resources/detectables/functional/clang/include/stdc-predef.h");
+        File includeFile2 = new File(baseDir, "src/test/resources/detectables/functional/clang/include/assert.h");
+        String fileContents = String.format("dependencies: %s \\\n %s %s\\\n",
             sourceFile.getAbsolutePath(), includeFile1.getAbsolutePath(), includeFile2.getAbsolutePath());
 
-        final DependenyListFileParser parser = new DependenyListFileParser();
-        final List<String> deps = parser.parseDepsMk(fileContents);
+        DependenyListFileParser parser = new DependenyListFileParser();
+        List<String> deps = parser.parseDepsMk(fileContents);
 
         assertTrue(deps.contains(sourceFile.toPath().normalize().toString()));
         assertTrue(deps.contains(includeFile1.toPath().normalize().toString()));
@@ -35,17 +35,17 @@ public class DependencyListFileParserTest {
 
     @Test
     @ExtendWith(TempDirectory.class)
-    public void testNonCanonical(@TempDirectory.TempDir final Path tempOutputDirectory) throws IOException {
-        final File baseDir = tempOutputDirectory.toFile();
-        final File sourceFile = new File(baseDir, "src/test/resources/detectables/functional/clang/src/process.c");
-        final File includeFile1 = new File(baseDir, "src/test/resources/detectables/functional/clang/include/stdc-predef.h");
-        final File includeFile2 = new File(baseDir, "src/test/resources/../../test/resources/detectables/functional/clang/include/assert.h");
-        final String fileContents = String.format("dependencies: %s \\\n %s %s\\\n",
+    public void testNonCanonical(@TempDirectory.TempDir Path tempOutputDirectory) throws IOException {
+        File baseDir = tempOutputDirectory.toFile();
+        File sourceFile = new File(baseDir, "src/test/resources/detectables/functional/clang/src/process.c");
+        File includeFile1 = new File(baseDir, "src/test/resources/detectables/functional/clang/include/stdc-predef.h");
+        File includeFile2 = new File(baseDir, "src/test/resources/../../test/resources/detectables/functional/clang/include/assert.h");
+        String fileContents = String.format("dependencies: %s \\\n %s %s\\\n",
             sourceFile.getAbsolutePath(), includeFile1.getAbsolutePath(), includeFile2.getAbsolutePath());
 
-        final DependenyListFileParser parser = new DependenyListFileParser();
-        final List<String> deps = parser.parseDepsMk(fileContents);
-        
+        DependenyListFileParser parser = new DependenyListFileParser();
+        List<String> deps = parser.parseDepsMk(fileContents);
+
         assertTrue(deps.contains(sourceFile.toPath().normalize().toString()));
         assertTrue(deps.contains(includeFile1.toPath().normalize().toString()));
         assertTrue(deps.contains(includeFile2.toPath().normalize().toString()));

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/functional/DependencyListFileParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/functional/DependencyListFileParserTest.java
@@ -1,0 +1,56 @@
+package com.synopsys.integration.detectable.detectables.clang.functional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detectable.detectables.clang.dependencyfile.DependenyListFileParser;
+
+public class DependencyListFileParserTest {
+
+    @Test
+    public void testSimple() {
+        final String curDirPath = System.getProperty("user.dir");
+        final File curDir = new File(curDirPath);
+        final File sourceFile = new File(curDir, "src/test/resources/detectables/functional/clang/src/process.c");
+        final File includeFile1 = new File(curDir, "src/test/resources/detectables/functional/clang/include/stdc-predef.h");
+        final File includeFile2 = new File(curDir, "src/test/resources/detectables/functional/clang/include/assert.h");
+        final String fileContents = String.format("dependencies: %s \\\n %s %s\\\n",
+            sourceFile.getAbsolutePath(), includeFile1.getAbsolutePath(), includeFile2.getAbsolutePath());
+
+        final DependenyListFileParser parser = new DependenyListFileParser();
+        final List<String> deps = parser.parseDepsMk(fileContents);
+
+        for (final String dep : deps) {
+            System.out.printf("dep: %s\n", dep);
+        }
+        assertTrue(deps.contains(sourceFile.getAbsolutePath()));
+        assertTrue(deps.contains(includeFile1.getAbsolutePath()));
+        assertTrue(deps.contains(includeFile2.getAbsolutePath()));
+    }
+
+    @Test
+    public void testNonCanonical() throws IOException {
+        final String curDirPath = System.getProperty("user.dir");
+        final File curDir = new File(curDirPath);
+        final File sourceFile = new File(curDir, "src/test/resources/detectables/functional/clang/src/process.c");
+        final File includeFile1 = new File(curDir, "src/test/resources/detectables/functional/clang/include/stdc-predef.h");
+        final File includeFile2 = new File(curDir, "src/test/resources/../../test/resources/detectables/functional/clang/include/assert.h");
+        final String fileContents = String.format("dependencies: %s \\\n %s %s\\\n",
+            sourceFile.getAbsolutePath(), includeFile1.getAbsolutePath(), includeFile2.getAbsolutePath());
+
+        final DependenyListFileParser parser = new DependenyListFileParser();
+        final List<String> deps = parser.parseDepsMk(fileContents);
+
+        for (final String dep : deps) {
+            System.out.printf("dep: %s\n", dep);
+        }
+        assertTrue(deps.contains(sourceFile.getCanonicalPath()));
+        assertTrue(deps.contains(includeFile1.getCanonicalPath()));
+        assertTrue(deps.contains(includeFile2.getCanonicalPath()));
+    }
+}

--- a/docs/templates/content/90-releasenotes.ftl
+++ b/docs/templates/content/90-releasenotes.ftl
@@ -4,6 +4,7 @@
 ### Resolved issues
 * (IDETECT-2221) Resolved an issue where the Docker Inspector logging level was not set correctly when property logging.level.detect was used.
 * (IDETECT-2213) Resolved an issue that could cause the CLANG detector to omit some components on Debian-based Linux systems.
+* (IDETECT-2284) Resolved an issue that could cause the CLANG detector to omit some components for projects using the clang/clang++ compiler when source files referenced include files using non-canonical paths.
 * (IDETECT-2216) Resolved an issue that caused non-ASCII characters in binary scan metadata (filename, code location name, project name, and version name) to be converted to '?' characters when submitted to Black Duck.
 
 ## Version 6.6.0

--- a/docs/templates/content/90-releasenotes.ftl
+++ b/docs/templates/content/90-releasenotes.ftl
@@ -4,7 +4,7 @@
 ### Resolved issues
 * (IDETECT-2221) Resolved an issue where the Docker Inspector logging level was not set correctly when property logging.level.detect was used.
 * (IDETECT-2213) Resolved an issue that could cause the CLANG detector to omit some components on Debian-based Linux systems.
-* (IDETECT-2284) Resolved an issue that could cause the CLANG detector to omit some components for projects using the clang/clang++ compiler when source files referenced include files using non-canonical paths.
+* (IDETECT-2284) Resolved an issue that could cause the CLANG detector to omit some components for projects using the clang/clang++ compiler when source files reference include files using non-canonical paths.
 * (IDETECT-2216) Resolved an issue that caused non-ASCII characters in binary scan metadata (filename, code location name, project name, and version name) to be converted to '?' characters when submitted to Black Duck.
 
 ## Version 6.6.0


### PR DESCRIPTION
Some C compilers (not all) write non-canonical paths to the dependency list file when source files reference include files in a non-canonical way, like /usr/share/../lib/stdclib.h. The linux package manager won't recognize these files unless the paths are made canonical. This fix makes the dependency file paths canonical before they are queried using the package manager.
