### PR TITLE
Sb clang multi arch pkgs

### DIFF
--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/RpmPackageManagerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/RpmPackageManagerTest.java
@@ -23,6 +23,7 @@
 package com.synopsys.integration.detectable.detectables.clang.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -142,5 +143,15 @@ public class RpmPackageManagerTest {
         assertTrue(pkg.isPresent());
         assertEquals("glibc-headers", pkg.get().getPackageName());
         assertEquals("2.28-101.el8", pkg.get().getPackageVersion());
+    }
+
+    @Test
+    public void testParseBogusLine() throws NotOwnedByAnyPkgException {
+        RpmPackageManagerResolver resolver = new RpmPackageManagerResolver(new Gson());
+        final String queryPackageOutputLine = "{ epoch: \"(none)\", name: \"glibc-headers\", version: \"2.28-101.el8\", arch: \"x86_64{{{{{{\"  }";
+
+        Optional<PackageDetails> pkg = resolver.generatePackageFromQueryOutputLine(queryPackageOutputLine);
+
+        assertFalse(pkg.isPresent());
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/RpmPackageManagerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/RpmPackageManagerTest.java
@@ -121,24 +121,24 @@ public class RpmPackageManagerTest {
     }
 
     @Test
-    public void testParseSingleArch() throws ExecutableRunnerException, NotOwnedByAnyPkgException {
-
+    public void testParseSingleVariant() throws NotOwnedByAnyPkgException {
         RpmPackageManagerResolver resolver = new RpmPackageManagerResolver(new Gson());
         final String queryPackageOutputLine = "{ epoch: \"(none)\", name: \"glibc-headers\", version: \"2.28-101.el8\", arch: \"x86_64\" }";
 
         Optional<PackageDetails> pkg = resolver.generatePackageFromQueryOutputLine(queryPackageOutputLine);
+
         assertTrue(pkg.isPresent());
         assertEquals("glibc-headers", pkg.get().getPackageName());
         assertEquals("2.28-101.el8", pkg.get().getPackageVersion());
     }
 
     @Test
-    public void testParseMultiArch() throws ExecutableRunnerException, NotOwnedByAnyPkgException {
-
+    public void testParseMultipleVariants() throws NotOwnedByAnyPkgException {
         RpmPackageManagerResolver resolver = new RpmPackageManagerResolver(new Gson());
         final String queryPackageOutputLine = "{ epoch: \"(none)\", name: \"glibc-headers\", version: \"2.28-101.el8\", arch: \"x86_64\" }{ epoch: \"(none)\", name: \"glibc-headers\", version: \"2.28-101.el8\", arch: \"i686\" }";
 
         Optional<PackageDetails> pkg = resolver.generatePackageFromQueryOutputLine(queryPackageOutputLine);
+
         assertTrue(pkg.isPresent());
         assertEquals("glibc-headers", pkg.get().getPackageName());
         assertEquals("2.28-101.el8", pkg.get().getPackageVersion());


### PR DESCRIPTION
In rare cases the RPM "who owns this file?" query can return multiple variants (architectures) of the owning package. Detect used to assume just one, and threw an exception when it encountered >1. This change fixes that (it picks the first one).
