### PR TITLE
 detector tool test

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorTool.java
@@ -70,8 +70,8 @@ public class DetectorTool {
     private final CodeLocationConverter codeLocationConverter;
     private final DetectorIssuePublisher detectorIssuePublisher;
 
-    public DetectorTool(final DetectorFinder detectorFinder, final ExtractionEnvironmentProvider extractionEnvironmentProvider, final EventSystem eventSystem, final CodeLocationConverter codeLocationConverter,
-        final DetectorIssuePublisher detectorIssuePublisher) {
+    public DetectorTool(DetectorFinder detectorFinder, ExtractionEnvironmentProvider extractionEnvironmentProvider, EventSystem eventSystem, CodeLocationConverter codeLocationConverter,
+        DetectorIssuePublisher detectorIssuePublisher) {
         this.detectorFinder = detectorFinder;
         this.extractionEnvironmentProvider = extractionEnvironmentProvider;
         this.eventSystem = eventSystem;
@@ -79,16 +79,16 @@ public class DetectorTool {
         this.detectorIssuePublisher = detectorIssuePublisher;
     }
 
-    public DetectorToolResult performDetectors(final File directory, final DetectorRuleSet detectorRuleSet, final DetectorFinderOptions detectorFinderOptions, final DetectorEvaluationOptions evaluationOptions, final String projectDetector,
-        final List<DetectorType> requiredDetectors)
+    public DetectorToolResult performDetectors(File directory, DetectorRuleSet detectorRuleSet, DetectorFinderOptions detectorFinderOptions, DetectorEvaluationOptions evaluationOptions, String projectDetector,
+        List<DetectorType> requiredDetectors)
         throws DetectUserFriendlyException {
         logger.debug("Initializing detector system.");
-        final Optional<DetectorEvaluationTree> possibleRootEvaluation;
+        Optional<DetectorEvaluationTree> possibleRootEvaluation;
         try {
             logger.debug("Starting detector file system traversal.");
             possibleRootEvaluation = detectorFinder.findDetectors(directory, detectorRuleSet, detectorFinderOptions);
 
-        } catch (final DetectorFinderDirectoryListException e) {
+        } catch (DetectorFinderDirectoryListException e) {
             throw new DetectUserFriendlyException("Detect was unable to list a directory while searching for detectors.", e, ExitCodeType.FAILURE_DETECTOR);
         }
 
@@ -99,18 +99,18 @@ public class DetectorTool {
             return new DetectorToolResult();
         }
 
-        final DetectorEvaluationTree rootEvaluation = possibleRootEvaluation.get();
-        final List<DetectorEvaluation> detectorEvaluations = rootEvaluation.allDescendentEvaluations();
+        DetectorEvaluationTree rootEvaluation = possibleRootEvaluation.get();
+        List<DetectorEvaluation> detectorEvaluations = rootEvaluation.allDescendentEvaluations();
 
         logger.trace("Setting up detector events.");
-        final DetectorEvaluatorBroadcaster eventBroadcaster = new DetectorEvaluatorBroadcaster(eventSystem);
-        final DetectorEvaluator detectorEvaluator = new DetectorEvaluator(evaluationOptions);
+        DetectorEvaluatorBroadcaster eventBroadcaster = new DetectorEvaluatorBroadcaster(eventSystem);
+        DetectorEvaluator detectorEvaluator = new DetectorEvaluator(evaluationOptions);
         detectorEvaluator.setDetectorEvaluatorListener(eventBroadcaster);
 
         logger.info("Searching for detectors. This may take a while.");
         detectorEvaluator.searchAndApplicableEvaluation(rootEvaluation, new HashSet<>());
 
-        final Set<DetectorType> applicable = detectorEvaluations.stream()
+        Set<DetectorType> applicable = detectorEvaluations.stream()
                                                  .filter(DetectorEvaluation::isApplicable)
                                                  .map(DetectorEvaluation::getDetectorRule)
                                                  .map(DetectorRule::getDetectorType)
@@ -129,7 +129,7 @@ public class DetectorTool {
         detectorEvaluator.setupDiscoveryAndExtractions(rootEvaluation, extractionEnvironmentProvider::createExtractionEnvironment);
 
         logger.debug("Counting detectors that will be evaluated.");
-        final Integer extractionCount = Math.toIntExact(detectorEvaluations.stream()
+        Integer extractionCount = Math.toIntExact(detectorEvaluations.stream()
                                                             .filter(DetectorEvaluation::isExtractable)
                                                             .count());
         eventSystem.publishEvent(Event.ExtractionCount, extractionCount);
@@ -143,7 +143,7 @@ public class DetectorTool {
             preferredProjectDetector = preferredDetectorTypeFromString(projectDetector);
         }
 
-        final DetectorNameVersionHandler detectorNameVersionHandler;
+        DetectorNameVersionHandler detectorNameVersionHandler;
         if (preferredProjectDetector.isPresent()) {
             detectorNameVersionHandler = new PreferredDetectorNameVersionHandler(preferredProjectDetector.get());
         } else {
@@ -158,21 +158,21 @@ public class DetectorTool {
         eventSystem.publishEvent(Event.ExtractionsCompleted, rootEvaluation);
 
         logger.debug("Finished detectors.");
-        final Map<DetectorType, StatusType> statusMap = extractStatus(detectorEvaluations);
+        Map<DetectorType, StatusType> statusMap = extractStatus(detectorEvaluations);
         statusMap.forEach((detectorType, statusType) -> eventSystem.publishEvent(Event.StatusSummary, new DetectorStatus(detectorType, statusType)));
         if (statusMap.containsValue(StatusType.FAILURE)) {
             eventSystem.publishEvent(Event.ExitCode, new ExitCodeRequest(ExitCodeType.FAILURE_DETECTOR, "One or more detectors were not successful."));
         }
 
         logger.debug("Publishing file events.");
-        for (final DetectorEvaluation detectorEvaluation : detectorEvaluations) {
+        for (DetectorEvaluation detectorEvaluation : detectorEvaluations) {
             if (detectorEvaluation.getDetectable() != null) {
-                for (final File file : detectorEvaluation.getDetectable().getFoundRelevantFiles()) {
+                for (File file : detectorEvaluation.getDetectable().getFoundRelevantFiles()) {
                     eventSystem.publishEvent(Event.CustomerFileOfInterest, file);
                 }
             }
             if (detectorEvaluation.getExtraction() != null) {
-                for (final File file : detectorEvaluation.getExtraction().getRelevantFiles()) {
+                for (File file : detectorEvaluation.getExtraction().getRelevantFiles()) {
                     eventSystem.publishEvent(Event.CustomerFileOfInterest, file);
                 }
                 List<File> paths = detectorEvaluation.getExtraction().getUnrecognizedPaths();
@@ -186,7 +186,7 @@ public class DetectorTool {
 
         Map<CodeLocation, DetectCodeLocation> codeLocationMap = createCodeLocationMap(detectorEvaluations, directory);
 
-        final DetectorToolResult detectorToolResult = new DetectorToolResult(
+        DetectorToolResult detectorToolResult = new DetectorToolResult(
             detectorNameVersionHandler.finalDecision().getChosenNameVersion().orElse(null),
             new ArrayList<>(codeLocationMap.values()),
             applicable,
@@ -196,11 +196,11 @@ public class DetectorTool {
         );
 
         //Check required detector types
-        final Set<DetectorType> missingDetectors = requiredDetectors.stream()
+        Set<DetectorType> missingDetectors = requiredDetectors.stream()
                                                        .filter(it -> !applicable.contains(it))
                                                        .collect(Collectors.toSet());
         if (missingDetectors.size() > 0) {
-            final String missingDetectorDisplay = missingDetectors.stream().map(Enum::toString).collect(Collectors.joining(","));
+            String missingDetectorDisplay = missingDetectors.stream().map(Enum::toString).collect(Collectors.joining(","));
             logger.error("One or more required detector types were not found: " + missingDetectorDisplay);
             eventSystem.publishEvent(Event.ExitCode, new ExitCodeRequest(ExitCodeType.FAILURE_DETECTOR_REQUIRED));
         }
@@ -212,12 +212,12 @@ public class DetectorTool {
         return detectorToolResult;
     }
 
-    private Map<DetectorType, StatusType> extractStatus(final List<DetectorEvaluation> detectorEvaluations) {
-        final Map<DetectorType, StatusType> statusMap = new HashMap<>();
-        for (final DetectorEvaluation detectorEvaluation : detectorEvaluations) {
-            final DetectorType detectorType = detectorEvaluation.getDetectorRule().getDetectorType();
+    private Map<DetectorType, StatusType> extractStatus(List<DetectorEvaluation> detectorEvaluations) {
+        Map<DetectorType, StatusType> statusMap = new HashMap<>();
+        for (DetectorEvaluation detectorEvaluation : detectorEvaluations) {
+            DetectorType detectorType = detectorEvaluation.getDetectorRule().getDetectorType();
             if (detectorEvaluation.isApplicable()) {
-                final StatusType statusType;
+                StatusType statusType;
                 if (detectorEvaluation.isExtractable()) {
                     if (detectorEvaluation.wasExtractionSuccessful()) {
                         statusType = StatusType.SUCCESS;
@@ -251,8 +251,8 @@ public class DetectorTool {
                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private Optional<DetectorType> preferredDetectorTypeFromString(final String detectorTypeRaw) {
-        final String detectorType = detectorTypeRaw.trim().toUpperCase();
+    private Optional<DetectorType> preferredDetectorTypeFromString(String detectorTypeRaw) {
+        String detectorType = detectorTypeRaw.trim().toUpperCase();
         if (StringUtils.isNotBlank(detectorType)) {
             if (DetectorType.getPossibleNames().contains(detectorType)) {
                 return Optional.of(DetectorType.valueOf(detectorType));

--- a/src/test/java/com/synopsys/integration/detect/tool/detector/DetectorToolTest.java
+++ b/src/test/java/com/synopsys/integration/detect/tool/detector/DetectorToolTest.java
@@ -22,42 +22,66 @@
  */
 package com.synopsys.integration.detect.tool.detector;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.configuration.property.types.enumfilterable.FilterableEnumValue;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
+import com.synopsys.integration.detect.configuration.ExcludeIncludeEnumFilter;
 import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 import com.synopsys.integration.detect.lifecycle.shutdown.ExitCodeRequest;
 import com.synopsys.integration.detect.tool.detector.extraction.ExtractionEnvironmentProvider;
 import com.synopsys.integration.detect.workflow.event.EventSystem;
 import com.synopsys.integration.detect.workflow.event.EventType;
+import com.synopsys.integration.detectable.DetectableEnvironment;
+import com.synopsys.integration.detectable.detectable.exception.DetectableException;
+import com.synopsys.integration.detectable.detectable.result.ExecutableNotFoundDetectableResult;
+import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
+import com.synopsys.integration.detectable.detectables.go.gomod.GoModCliDetectable;
+import com.synopsys.integration.detector.base.DetectorEvaluation;
+import com.synopsys.integration.detector.base.DetectorEvaluationTree;
+import com.synopsys.integration.detector.base.DetectorType;
 import com.synopsys.integration.detector.evaluation.DetectorEvaluationOptions;
 import com.synopsys.integration.detector.finder.DetectorFinder;
+import com.synopsys.integration.detector.finder.DetectorFinderDirectoryListException;
 import com.synopsys.integration.detector.finder.DetectorFinderOptions;
+import com.synopsys.integration.detector.result.DetectorResult;
+import com.synopsys.integration.detector.rule.DetectorRule;
+import com.synopsys.integration.detector.rule.DetectorRuleBuilder;
 import com.synopsys.integration.detector.rule.DetectorRuleSet;
+import com.synopsys.integration.detector.rule.DetectorRuleSetBuilder;
 
 public class DetectorToolTest {
 
     @Test
     public void testFailWhenMisConfigured() throws DetectUserFriendlyException {
 
-        final ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
-        final DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
-        final EventSystem eventSystem = Mockito.mock(EventSystem.class);
-        final CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
-        final DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
+        ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
+        DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
+        EventSystem eventSystem = Mockito.mock(EventSystem.class);
+        CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
+        DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
 
-        final DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
+        DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
 
-        final File directory = new File(".");
-        final DetectorRuleSet detectorRuleSet = Mockito.mock(DetectorRuleSet.class);
-        final DetectorFinderOptions detectorFinderOptions = Mockito.mock(DetectorFinderOptions.class);
-        final DetectorEvaluationOptions evaluationOptions = Mockito.mock(DetectorEvaluationOptions.class);
+        File directory = new File(".");
+        DetectorRuleSet detectorRuleSet = Mockito.mock(DetectorRuleSet.class);
+        DetectorFinderOptions detectorFinderOptions = Mockito.mock(DetectorFinderOptions.class);
+        DetectorEvaluationOptions evaluationOptions = Mockito.mock(DetectorEvaluationOptions.class);
         final String projectBomTool = "testBomTool";
 
         tool.performDetectors(directory, detectorRuleSet, detectorFinderOptions, evaluationOptions, projectBomTool, new ArrayList<>());
@@ -65,11 +89,110 @@ public class DetectorToolTest {
         Mockito.verify(eventSystem).publishEvent(Mockito.any(EventType.class), Mockito.argThat(new FailureExitCodeRequestMatcher()));
     }
 
+    @Test
+    public void testDetectorFinderException() throws DetectorFinderDirectoryListException {
+
+        ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
+        DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
+        Mockito.when(detectorFinder.findDetectors(Mockito.any(), Mockito.any(), Mockito.any())).thenThrow(DetectorFinderDirectoryListException.class);
+        EventSystem eventSystem = Mockito.mock(EventSystem.class);
+        CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
+        DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
+
+        DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
+
+        File directory = new File(".");
+        DetectorRuleSet detectorRuleSet = Mockito.mock(DetectorRuleSet.class);
+        DetectorFinderOptions detectorFinderOptions = Mockito.mock(DetectorFinderOptions.class);
+        DetectorEvaluationOptions evaluationOptions = Mockito.mock(DetectorEvaluationOptions.class);
+        final String projectBomTool = "testBomTool";
+        try {
+            tool.performDetectors(directory, detectorRuleSet, detectorFinderOptions, evaluationOptions, projectBomTool, new ArrayList<>());
+            fail();
+        } catch (DetectUserFriendlyException ex) {
+            //pass
+        }
+    }
+
+    @Test
+    public void testSuccess() throws DetectUserFriendlyException, DetectorFinderDirectoryListException, DetectableException {
+        ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
+        DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
+        EventSystem eventSystem = Mockito.mock(EventSystem.class);
+        CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
+        DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
+
+        DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
+
+        File directory = new File(".");
+        GoModCliDetectable detectable = createDetectable();
+        DetectorRule<GoModCliDetectable> rule = createRule(detectable);
+        DetectorRuleSet detectorRuleSet = createRuleSet(rule);
+        DetectorFinderOptions detectorFinderOptions = createFinderOptions();
+        DetectorEvaluationOptions evaluationOptions = createEvaluationOptions();
+        final String projectBomTool = "testBomTool";
+        DetectorEvaluationTree evaluationTree = createEvaluationTree(directory, rule, detectorRuleSet);
+        Mockito.when(detectorFinder.findDetectors(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Optional.of(evaluationTree));
+
+        DetectorToolResult result = tool.performDetectors(directory, detectorRuleSet, detectorFinderOptions, evaluationOptions, projectBomTool, new ArrayList<>());
+        assertFalse(result.getApplicableDetectorTypes().isEmpty());
+        assertTrue(result.getBomToolCodeLocations().isEmpty());
+        assertFalse(result.getBomToolProjectNameVersion().isPresent());
+        assertTrue(result.getCodeLocationMap().isEmpty());
+        assertTrue(result.getFailedDetectorTypes().isEmpty());
+        assertTrue(result.getRootDetectorEvaluationTree().isPresent());
+    }
+
     private static class FailureExitCodeRequestMatcher implements ArgumentMatcher<ExitCodeRequest> {
         @Override
-        public boolean matches(final ExitCodeRequest actualExitCodeRequest) {
+        public boolean matches(ExitCodeRequest actualExitCodeRequest) {
             System.out.printf("custom matcher called: %d: %s\n", actualExitCodeRequest.getExitCodeType().getExitCode(), actualExitCodeRequest.getReason());
             return (actualExitCodeRequest.getExitCodeType() == ExitCodeType.FAILURE_CONFIGURATION) && (StringUtils.isNotBlank(actualExitCodeRequest.getReason()));
         }
+    }
+
+    private GoModCliDetectable createDetectable() throws DetectableException {
+        GoModCliDetectable detectable = Mockito.mock(GoModCliDetectable.class);
+        Mockito.when(detectable.applicable()).thenReturn(new PassedDetectableResult());
+        Mockito.when(detectable.extractable()).thenReturn(new PassedDetectableResult());
+        //Mockito.when(detectable.extract(Mockito.any())).thenReturn();
+        return detectable;
+    }
+
+    private DetectorRule<GoModCliDetectable> createRule(GoModCliDetectable detectable) {
+        DetectorRuleBuilder<GoModCliDetectable> ruleBuilder = new DetectorRuleBuilder<>("GoMod", DetectorType.GO_MOD, GoModCliDetectable.class, (e) -> detectable);
+        return ruleBuilder.build();
+    }
+
+    private DetectorRuleSet createRuleSet(DetectorRule<GoModCliDetectable> rule) {
+        DetectorRuleSetBuilder ruleSetBuilder = new DetectorRuleSetBuilder();
+        ruleSetBuilder.add(rule);
+        return ruleSetBuilder.build();
+    }
+
+    private DetectorFinderOptions createFinderOptions() {
+        Predicate<File> fileFilter = f -> true;
+        final int maximumDepth = 10;
+        return new DetectorFinderOptions(fileFilter, maximumDepth);
+    }
+
+    private DetectorEvaluationOptions createEvaluationOptions() {
+        List<FilterableEnumValue<DetectorType>> excluded = Collections.emptyList();
+        List<FilterableEnumValue<DetectorType>> included = Collections.singletonList(FilterableEnumValue.value(DetectorType.GO_MOD));
+        ExcludeIncludeEnumFilter detectorFilter = new ExcludeIncludeEnumFilter(excluded, included);
+
+        return new DetectorEvaluationOptions(false, (rule -> detectorFilter.shouldInclude(rule.getDetectorType())));
+
+    }
+
+    private DetectorEvaluationTree createEvaluationTree(File directory, DetectorRule<GoModCliDetectable> rule, DetectorRuleSet detectorRuleSet) {
+        DetectorEvaluation detectorEvaluation = new DetectorEvaluation(rule);
+        ExecutableNotFoundDetectableResult result = new ExecutableNotFoundDetectableResult("go");
+        DetectorResult extractableResult = new DetectorResult(result.getPassed(), result.toDescription(), result.getClass());
+        detectorEvaluation.setExtractable(extractableResult);
+        detectorEvaluation.setApplicable(new DetectorResult(true, "", null));
+        detectorEvaluation.setSearchable(new DetectorResult(true, "", null));
+        detectorEvaluation.setDetectableEnvironment(new DetectableEnvironment(new File("")));
+        return new DetectorEvaluationTree(directory, 0, detectorRuleSet, Collections.singletonList(detectorEvaluation), new HashSet<>());
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/tool/detector/DetectorToolTest.java
+++ b/src/test/java/com/synopsys/integration/detect/tool/detector/DetectorToolTest.java
@@ -51,8 +51,7 @@ import com.synopsys.integration.detect.workflow.event.EventType;
 import com.synopsys.integration.detectable.DetectableEnvironment;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
-import com.synopsys.integration.detectable.detectable.result.ExecutableNotFoundDetectableResult;
-import com.synopsys.integration.detectable.detectable.result.FailedDetectableResult;
+import com.synopsys.integration.detectable.detectable.result.DetectableResult;
 import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
 import com.synopsys.integration.detectable.detectables.go.gomod.GoModCliDetectable;
 import com.synopsys.integration.detectable.extraction.Extraction;
@@ -120,26 +119,12 @@ public class DetectorToolTest {
 
     @Test
     public void testSuccess() throws DetectUserFriendlyException, DetectorFinderDirectoryListException, DetectableException {
-        ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
-        DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
-        EventSystem eventSystem = Mockito.mock(EventSystem.class);
-        CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
-        DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
-
-        DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
-
-        File directory = new File(".");
         Extraction extraction = createSuccessExtraction();
-        GoModCliDetectable detectable = createDetectable(extraction);
-        DetectorRule<GoModCliDetectable> rule = createRule(detectable);
-        DetectorRuleSet detectorRuleSet = createRuleSet(rule);
-        DetectorFinderOptions detectorFinderOptions = createFinderOptions();
-        DetectorEvaluationOptions evaluationOptions = createEvaluationOptions();
+        DetectableResult extractionResult = new PassedDetectableResult();
         String projectBomTool = DetectorType.GO_MOD.name();
-        DetectorEvaluationTree evaluationTree = createEvaluationTree(extraction, directory, rule, detectorRuleSet);
-        Mockito.when(detectorFinder.findDetectors(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Optional.of(evaluationTree));
 
-        DetectorToolResult result = tool.performDetectors(directory, detectorRuleSet, detectorFinderOptions, evaluationOptions, projectBomTool, new ArrayList<>());
+        DetectorToolResult result = executeToolTest(extraction, extractionResult, projectBomTool);
+        
         assertFalse(result.getApplicableDetectorTypes().isEmpty());
         assertTrue(result.getBomToolCodeLocations().isEmpty());
         assertFalse(result.getBomToolProjectNameVersion().isPresent());
@@ -150,26 +135,12 @@ public class DetectorToolTest {
 
     @Test
     public void testPreferredDetectorMissingSuccess() throws DetectUserFriendlyException, DetectorFinderDirectoryListException, DetectableException {
-        ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
-        DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
-        EventSystem eventSystem = Mockito.mock(EventSystem.class);
-        CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
-        DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
-
-        DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
-
-        File directory = new File(".");
         Extraction extraction = createSuccessExtraction();
-        GoModCliDetectable detectable = createDetectable(extraction);
-        DetectorRule<GoModCliDetectable> rule = createRule(detectable);
-        DetectorRuleSet detectorRuleSet = createRuleSet(rule);
-        DetectorFinderOptions detectorFinderOptions = createFinderOptions();
-        DetectorEvaluationOptions evaluationOptions = createEvaluationOptions();
-        final String projectBomTool = "testBomTool";
-        DetectorEvaluationTree evaluationTree = createEvaluationTree(extraction, directory, rule, detectorRuleSet);
-        Mockito.when(detectorFinder.findDetectors(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Optional.of(evaluationTree));
+        DetectableResult extractionResult = new PassedDetectableResult();
+        String projectBomTool = "testBomTool";
 
-        DetectorToolResult result = tool.performDetectors(directory, detectorRuleSet, detectorFinderOptions, evaluationOptions, projectBomTool, new ArrayList<>());
+        DetectorToolResult result = executeToolTest(extraction, extractionResult, projectBomTool);
+
         assertFalse(result.getApplicableDetectorTypes().isEmpty());
         assertTrue(result.getBomToolCodeLocations().isEmpty());
         assertFalse(result.getBomToolProjectNameVersion().isPresent());
@@ -180,26 +151,11 @@ public class DetectorToolTest {
 
     @Test
     public void testExtractionFailed() throws DetectUserFriendlyException, DetectorFinderDirectoryListException, DetectableException {
-        ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
-        DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
-        EventSystem eventSystem = Mockito.mock(EventSystem.class);
-        CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
-        DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
-
-        DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
-
-        File directory = new File(".");
         Extraction extraction = createFailExtraction();
-        GoModCliDetectable detectable = createDetectable(extraction);
-        DetectorRule<GoModCliDetectable> rule = createRule(detectable);
-        DetectorRuleSet detectorRuleSet = createRuleSet(rule);
-        DetectorFinderOptions detectorFinderOptions = createFinderOptions();
-        DetectorEvaluationOptions evaluationOptions = createEvaluationOptions();
-        final String projectBomTool = "testBomTool";
-        DetectorEvaluationTree evaluationTree = createEvaluationTree(extraction, directory, rule, detectorRuleSet);
-        Mockito.when(detectorFinder.findDetectors(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Optional.of(evaluationTree));
+        DetectableResult extractionResult = new PassedDetectableResult();
+        String projectBomTool = DetectorType.GO_MOD.name();
 
-        DetectorToolResult result = tool.performDetectors(directory, detectorRuleSet, detectorFinderOptions, evaluationOptions, projectBomTool, new ArrayList<>());
+        DetectorToolResult result = executeToolTest(extraction, extractionResult, projectBomTool);
         assertFalse(result.getApplicableDetectorTypes().isEmpty());
         assertTrue(result.getBomToolCodeLocations().isEmpty());
         assertFalse(result.getBomToolProjectNameVersion().isPresent());
@@ -210,26 +166,11 @@ public class DetectorToolTest {
 
     @Test
     public void testExtractionException() throws DetectUserFriendlyException, DetectorFinderDirectoryListException, DetectableException {
-        ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
-        DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
-        EventSystem eventSystem = Mockito.mock(EventSystem.class);
-        CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
-        DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
-
-        DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
-
-        File directory = new File(".");
         Extraction extraction = createExceptionExtraction();
-        GoModCliDetectable detectable = createDetectable(extraction);
-        DetectorRule<GoModCliDetectable> rule = createRule(detectable);
-        DetectorRuleSet detectorRuleSet = createRuleSet(rule);
-        DetectorFinderOptions detectorFinderOptions = createFinderOptions();
-        DetectorEvaluationOptions evaluationOptions = createEvaluationOptions();
-        final String projectBomTool = "testBomTool";
-        DetectorEvaluationTree evaluationTree = createEvaluationTree(extraction, directory, rule, detectorRuleSet);
-        Mockito.when(detectorFinder.findDetectors(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Optional.of(evaluationTree));
+        DetectableResult extractionResult = new PassedDetectableResult();
+        String projectBomTool = DetectorType.GO_MOD.name();
 
-        DetectorToolResult result = tool.performDetectors(directory, detectorRuleSet, detectorFinderOptions, evaluationOptions, projectBomTool, new ArrayList<>());
+        DetectorToolResult result = executeToolTest(extraction, extractionResult, projectBomTool);
         assertFalse(result.getApplicableDetectorTypes().isEmpty());
         assertTrue(result.getBomToolCodeLocations().isEmpty());
         assertFalse(result.getBomToolProjectNameVersion().isPresent());
@@ -246,15 +187,33 @@ public class DetectorToolTest {
         }
     }
 
-    private GoModCliDetectable createDetectable(Extraction extraction) throws DetectableException {
+    private DetectorToolResult executeToolTest(Extraction extraction, DetectableResult extractionResult, String projectBomTool) throws DetectUserFriendlyException, DetectorFinderDirectoryListException, DetectableException {
+        ExtractionEnvironmentProvider extractionEnvironmentProvider = Mockito.mock(ExtractionEnvironmentProvider.class);
+        DetectorFinder detectorFinder = Mockito.mock(DetectorFinder.class);
+        EventSystem eventSystem = Mockito.mock(EventSystem.class);
+        CodeLocationConverter codeLocationConverter = Mockito.mock(CodeLocationConverter.class);
+        DetectorIssuePublisher detectorIssuePublisher = Mockito.mock(DetectorIssuePublisher.class);
+
+        DetectorTool tool = new DetectorTool(detectorFinder, extractionEnvironmentProvider, eventSystem, codeLocationConverter, detectorIssuePublisher);
+        File directory = new File(".");
+        GoModCliDetectable detectable = createDetectable(extraction, extractionResult);
+        DetectorRule<GoModCliDetectable> rule = createRule(detectable);
+        DetectorRuleSet detectorRuleSet = createRuleSet(rule);
+        DetectorFinderOptions detectorFinderOptions = createFinderOptions();
+        DetectorEvaluationOptions evaluationOptions = createEvaluationOptions();
+
+        DetectorEvaluationTree evaluationTree = createEvaluationTree(extraction, extractionResult, directory, rule, detectorRuleSet);
+        Mockito.when(detectorFinder.findDetectors(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(Optional.of(evaluationTree));
+
+        return tool.performDetectors(directory, detectorRuleSet, detectorFinderOptions, evaluationOptions, projectBomTool, new ArrayList<>());
+    }
+
+    private GoModCliDetectable createDetectable(Extraction extraction, DetectableResult extractionResult) throws DetectableException {
         File relevantFile = new File("go.mod");
         List<File> relevantFiles = Collections.singletonList(relevantFile);
         GoModCliDetectable detectable = Mockito.mock(GoModCliDetectable.class);
-        if (extraction.isSuccess()) {
-            Mockito.when(detectable.extractable()).thenReturn(new PassedDetectableResult());
-        } else {
-            Mockito.when(detectable.extractable()).thenReturn(new FailedDetectableResult());
-        }
+        Mockito.when(detectable.extractable()).thenReturn(extractionResult);
+
         Mockito.when(detectable.applicable()).thenReturn(new PassedDetectableResult());
         Mockito.when(detectable.getFoundRelevantFiles()).thenReturn(relevantFiles);
         Mockito.when(detectable.extract(Mockito.any())).thenReturn(extraction);
@@ -318,14 +277,14 @@ public class DetectorToolTest {
 
     }
 
-    private DetectorEvaluationTree createEvaluationTree(Extraction extraction, File directory, DetectorRule<GoModCliDetectable> rule, DetectorRuleSet detectorRuleSet) {
+    private DetectorEvaluationTree createEvaluationTree(Extraction extraction, DetectableResult extractionResult, File directory, DetectorRule<GoModCliDetectable> rule, DetectorRuleSet detectorRuleSet) {
         DetectorEvaluation detectorEvaluation = new DetectorEvaluation(rule);
-        ExecutableNotFoundDetectableResult result = new ExecutableNotFoundDetectableResult("go");
-        DetectorResult extractableResult = new DetectorResult(result.getPassed(), result.toDescription(), result.getClass());
+
+        DetectorResult extractableResult = new DetectorResult(extractionResult.getPassed(), extractionResult.toDescription(), extractionResult.getClass());
         detectorEvaluation.setExtractable(extractableResult);
         detectorEvaluation.setExtraction(extraction);
-        detectorEvaluation.setApplicable(new DetectorResult(extraction.isSuccess(), "", null));
-        detectorEvaluation.setSearchable(new DetectorResult(extraction.isSuccess(), "", null));
+        detectorEvaluation.setApplicable(new DetectorResult(true, "", null));
+        detectorEvaluation.setSearchable(new DetectorResult(true, "", null));
         detectorEvaluation.setDetectableEnvironment(new DetectableEnvironment(new File("")));
         return new DetectorEvaluationTree(directory, 0, detectorRuleSet, Collections.singletonList(detectorEvaluation), new HashSet<>());
     }


### PR DESCRIPTION
# Description

Increase the line coverage within the tests of the DetectorTool.  Also clean up the formatting.
The problem is that right now the tests for success, failure, and exception produce the same result.  It's difficult to assert between the different cases.
