### PR TITLE
Update bd common api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import com.synopsys.integration.detect.verification.VerifyBlackDuckDetectTask
 buildscript {
     ext {
         springBootVersion = '2.2.4.RELEASE'
-        blackDuckCommonVersion = '50.2.0-SNAPSHOT' //TODO - remove SNAPSHOT
+        blackDuckCommonVersion = '50.2.0'
         junitPlatformDefaultTestTags = 'integration, performance, battery'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import com.synopsys.integration.detect.verification.VerifyBlackDuckDetectTask
 buildscript {
     ext {
         springBootVersion = '2.2.4.RELEASE'
-        blackDuckCommonVersion = '50.0.4'
+        blackDuckCommonVersion = '50.2.0-SNAPSHOT' //TODO - remove SNAPSHOT
         junitPlatformDefaultTestTags = 'integration, performance, battery'
     }
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -40,10 +40,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.Nullable;
 
-import com.synopsys.integration.blackduck.api.generated.enumeration.LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionDistributionType;
 import com.synopsys.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectCloneCategoriesType;
-import com.synopsys.integration.blackduck.api.manual.throwaway.generated.enumeration.ProjectVersionPhaseType;
+import com.synopsys.integration.blackduck.api.manual.temporary.enumeration.ProjectVersionPhaseType;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.IndividualFileMatching;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfigBuilder;
@@ -356,7 +356,7 @@ public class DetectConfigurationFactory {
 
     public DetectProjectServiceOptions createDetectProjectServiceOptions() throws DetectUserFriendlyException {
         ProjectVersionPhaseType projectVersionPhase = getValue(DetectProperties.DETECT_PROJECT_VERSION_PHASE);
-        LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType projectVersionDistribution = getValue(DetectProperties.DETECT_PROJECT_VERSION_DISTRIBUTION);
+        ProjectVersionDistributionType projectVersionDistribution = getValue(DetectProperties.DETECT_PROJECT_VERSION_DISTRIBUTION);
         Integer projectTier = getNullableValue(DetectProperties.DETECT_PROJECT_TIER);
         String projectDescription = getNullableValue(DetectProperties.DETECT_PROJECT_DESCRIPTION);
         String projectVersionNotes = getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NOTES);

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -30,10 +30,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.synopsys.integration.blackduck.api.generated.enumeration.LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionDistributionType;
 import com.synopsys.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectCloneCategoriesType;
-import com.synopsys.integration.blackduck.api.manual.throwaway.generated.enumeration.ProjectVersionPhaseType;
+import com.synopsys.integration.blackduck.api.manual.temporary.enumeration.ProjectVersionPhaseType;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.IndividualFileMatching;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.synopsys.integration.configuration.property.Property;
@@ -1097,8 +1097,8 @@ public class DetectProperties {
             .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
             .setCategory(DetectCategory.Advanced);
 
-    public static final DetectProperty<EnumProperty<LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType>> DETECT_PROJECT_VERSION_DISTRIBUTION =
-        new DetectProperty<>(new EnumProperty<>("detect.project.version.distribution", LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType.EXTERNAL, LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType.class))
+    public static final DetectProperty<EnumProperty<ProjectVersionDistributionType>> DETECT_PROJECT_VERSION_DISTRIBUTION =
+        new DetectProperty<>(new EnumProperty<>("detect.project.version.distribution", ProjectVersionDistributionType.EXTERNAL, ProjectVersionDistributionType.class))
             .setInfo("Version Distribution", DetectPropertyFromVersion.VERSION_3_0_0)
             .setHelp("An override for the Project Version distribution")
             .setGroups(DetectGroup.PROJECT, DetectGroup.PROJECT_SETTING)

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/DetectProjectServiceOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/DetectProjectServiceOptions.java
@@ -24,13 +24,13 @@ package com.synopsys.integration.detect.workflow.blackduck;
 
 import java.util.List;
 
-import com.synopsys.integration.blackduck.api.generated.enumeration.LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionDistributionType;
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectCloneCategoriesType;
-import com.synopsys.integration.blackduck.api.manual.throwaway.generated.enumeration.ProjectVersionPhaseType;
+import com.synopsys.integration.blackduck.api.manual.temporary.enumeration.ProjectVersionPhaseType;
 
 public class DetectProjectServiceOptions {
     private final ProjectVersionPhaseType projectVersionPhase;
-    private final LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType projectVersionDistribution;
+    private final ProjectVersionDistributionType projectVersionDistribution;
     private final Integer projectTier;
     private final String projectDescription;
     private final String projectVersionNotes;
@@ -47,7 +47,7 @@ public class DetectProjectServiceOptions {
     private final Boolean cloneLatestProjectVersion;
     private final CustomFieldDocument customFields;
 
-    public DetectProjectServiceOptions(final ProjectVersionPhaseType projectVersionPhase, final LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType projectVersionDistribution, final Integer projectTier,
+    public DetectProjectServiceOptions(final ProjectVersionPhaseType projectVersionPhase, final ProjectVersionDistributionType projectVersionDistribution, final Integer projectTier,
         final String projectDescription, final String projectVersionNotes,
         final List<ProjectCloneCategoriesType> cloneCategories, final Boolean projectLevelAdjustments, final Boolean forceProjectVersionUpdate, final String cloneVersionName, final String projectVersionNickname, final String applicationId,
         final List<String> tags, final List<String> groups, final String parentProjectName, final String parentProjectVersion, final Boolean cloneLatestProjectVersion, final CustomFieldDocument customFields) {
@@ -74,7 +74,7 @@ public class DetectProjectServiceOptions {
         return projectVersionPhase;
     }
 
-    public LicenseFamilyLicenseFamilyRiskRulesReleaseDistributionType getProjectVersionDistribution() {
+    public ProjectVersionDistributionType getProjectVersionDistribution() {
         return projectVersionDistribution;
     }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/policy/PolicyChecker.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/policy/PolicyChecker.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
-import com.synopsys.integration.blackduck.api.generated.enumeration.PolicyStatusType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType;
 import com.synopsys.integration.blackduck.api.generated.view.ComponentPolicyRulesView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
@@ -85,7 +85,7 @@ public class PolicyChecker {
 
         final List<ProjectVersionComponentView> bomComponents = projectBomService.getComponentsForProjectVersion(projectVersionView);
         for (final ProjectVersionComponentView projectVersionComponentView : bomComponents) {
-            if (projectVersionComponentView.getPolicyStatus().equals(PolicyStatusType.NOT_IN_VIOLATION)) {
+            if (projectVersionComponentView.getPolicyStatus().equals(ProjectVersionComponentPolicyStatusType.NOT_IN_VIOLATION)) {
                 continue;
             }
 


### PR DESCRIPTION
Updating blackduck-common version to expose changes necessary for IDETECT-2332.  Exposes blackduck-common-api:2020.8.0.4 which required a few class name changes.