### PR TITLE
Ac battery executables

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/battery/BatteryTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/BatteryTest.java
@@ -109,6 +109,11 @@ public final class BatteryTest {
                    .collect(Collectors.toList());
     }
 
+    /**
+     * NOTE: The order in which you provide the names of executable output resource files must match the order in which their corresponding commands are invoked at runtime.
+     *      ex) The GoModCliExtractor invokes the command 'go list' before the command 'go version', so go-list.xout must be before go-version.xout in resourceFiles when constructing
+     *          a battery test for the go mod.
+     */
     public void executableFromResourceFiles(Property detectProperty, String... resourceFiles) {
         ResourceTypingExecutableCreator creator = new ResourceTypingExecutableCreator(prefixResources(resourceFiles));
         executables.add(BatteryExecutable.propertyOverrideExecutable(detectProperty, creator));

--- a/src/test/java/com/synopsys/integration/detect/battery/BatteryTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/BatteryTest.java
@@ -111,8 +111,8 @@ public final class BatteryTest {
 
     /**
      * NOTE: The order in which you provide the names of executable output resource files must match the order in which their corresponding commands are invoked at runtime.
-     *      ex) The GoModCliExtractor invokes the command 'go list' before the command 'go version', so go-list.xout must be before go-version.xout in resourceFiles when constructing
-     *          a battery test for the go mod.
+     *      ex) The GoModCliExtractor invokes the command 'go list' before the command 'go version', so go-list.xout must be ordered before go-version.xout in resourceFiles when constructing
+     *          a battery test for the go mod detectable.
      */
     public void executableFromResourceFiles(Property detectProperty, String... resourceFiles) {
         ResourceTypingExecutableCreator creator = new ResourceTypingExecutableCreator(prefixResources(resourceFiles));


### PR DESCRIPTION
Adding comment to help mitigate future confusion surrounding ordering of mock executable resource files in battery tests (IDETECT-2337).
