### PR TITLE
fix: Move the logging of the DetectorTool on a failure.

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorTool.java
@@ -215,10 +215,11 @@ public class DetectorTool {
                     statusType = StatusType.SUCCESS;
                 } else {
                     statusType = StatusType.FAILURE;
-                }
-                boolean extractionUnknownFailure = !detectorEvaluation.wasExtractionFailure() && !detectorEvaluation.wasExtractionException();
-                if (extractionUnknownFailure) {
-                    logger.warn("An issue occurred in the detector system, an unknown evaluation status was created. Please contact support.");
+
+                    boolean extractionUnknownFailure = !detectorEvaluation.wasExtractionFailure() && !detectorEvaluation.wasExtractionException();
+                    if (extractionUnknownFailure) {
+                        logger.warn("An issue occurred in the detector system, an unknown evaluation status was created. Please contact support.");
+                    }
                 }
             } else if (detectorEvaluation.isFallbackExtractable() || detectorEvaluation.isPreviousExtractable()) {
                 statusType = StatusType.SUCCESS;


### PR DESCRIPTION
Put the warning logging into the else case when the DetectorEvaluation is not successfully extracted.
