### PR TITLE
Sb clang mult arch dpkg

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/DpkgPackageManagerResolver.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/DpkgPackageManagerResolver.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,8 +57,13 @@ public class DpkgPackageManagerResolver implements ClangPackageManagerResolver {
             String[] queryPackageOutputParts = packageLine.split("\\s+");
             String[] packageNameArchParts = queryPackageOutputParts[0].split(":");
             String packageName = packageNameArchParts[0].trim();
-            logger.debug(String.format("File ownership query results: package name: %s", packageName));
-            Optional<PackageDetails> pkg = versionResolver.resolvePackageDetails(currentPackageManager, executableRunner, workingDirectory, packageName);
+            String packageArch = null;
+            if (packageNameArchParts.length > 1) {
+                packageArch = packageNameArchParts[1].trim();
+                packageArch = StringUtils.substringBefore(packageArch, ",");
+            }
+            logger.debug(String.format("File ownership query results: package name: %s, arch: %s", packageName, packageArch));
+            Optional<PackageDetails> pkg = versionResolver.resolvePackageDetails(currentPackageManager, executableRunner, workingDirectory, packageName, packageArch);
             if (pkg.isPresent()) {
                 logger.debug(String.format("Adding package: %s", pkg.get()));
                 packageDetailsList.add(pkg.get());

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/DpkgPackageManagerResolver.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/DpkgPackageManagerResolver.java
@@ -58,7 +58,7 @@ public class DpkgPackageManagerResolver implements ClangPackageManagerResolver {
             String[] queryPackageOutputParts = packageLine.split("\\s+");
             String[] packageNameArchParts = queryPackageOutputParts[0].split(":");
             String packageName = packageNameArchParts[0].trim();
-            String packageArch = parseArchitecture(packageNameArchParts);
+            String packageArch = parseArchitectureIfPresent(packageNameArchParts);
             logger.debug("File ownership query results: package name: {}, arch: {}", packageName, packageArch);
             Optional<PackageDetails> pkg = versionResolver.resolvePackageDetails(currentPackageManager, executableRunner, workingDirectory, packageName, packageArch);
             if (pkg.isPresent()) {
@@ -70,13 +70,13 @@ public class DpkgPackageManagerResolver implements ClangPackageManagerResolver {
     }
 
     @Nullable
-    private String parseArchitecture(String[] packageNameArchParts) {
-        String packageArch = null;
+    private String parseArchitectureIfPresent(String[] packageNameArchParts) {
         if (packageNameArchParts.length > 1) {
-            packageArch = packageNameArchParts[1].trim();
-            packageArch = StringUtils.substringBefore(packageArch, ",");
+            String packageArch = packageNameArchParts[1].trim();
+            return StringUtils.substringBefore(packageArch, ",");
+        } else {
+            return null;
         }
-        return packageArch;
     }
 
     private boolean valid(String packageLine) throws NotOwnedByAnyPkgException {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/DpkgPkgDetailsResolver.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/DpkgPkgDetailsResolver.java
@@ -43,12 +43,12 @@ public class DpkgPkgDetailsResolver {
     private static final int PKG_INFO_LINE_LABEL_POSITION = 0;
     private static final int PKG_INFO_LINE_VALUE_POSITION = 1;
 
-    public Optional<PackageDetails> resolvePackageDetails(ClangPackageManagerInfo currentPackageManager, DetectableExecutableRunner executableRunner, File workingDirectory, String packageName, @Nullable String packageArch) {
+    public Optional<PackageDetails> resolvePackageDetails(ClangPackageManagerInfo currentPackageManager, DetectableExecutableRunner executableRunner, File workingDirectory, NameArchitecture packageNameArchitecture) {
         try {
             List<String> args = new ArrayList<>(currentPackageManager.getPkgInfoArgs().get());
-            args.add(constructPackageArg(packageName, packageArch));
+            args.add(constructPackageArg(packageNameArchitecture.getName(), packageNameArchitecture.getArchitecture().orElse(null)));
             ExecutableOutput packageInfoOutput = executableRunner.execute(workingDirectory, currentPackageManager.getPkgMgrCmdString(), args);
-            return parsePackageDetailsFromInfoOutput(packageName, packageInfoOutput.getStandardOutput());
+            return parsePackageDetailsFromInfoOutput(packageNameArchitecture.getName(), packageInfoOutput.getStandardOutput());
         } catch (ExecutableRunnerException e) {
             logger.warn(String.format("Error executing %s to get package info: %s", currentPackageManager.getPkgMgrName(), e.getMessage()));
         }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/DpkgPkgDetailsResolver.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/DpkgPkgDetailsResolver.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,10 +43,14 @@ public class DpkgPkgDetailsResolver {
     private static final int PKG_INFO_LINE_LABEL_POSITION = 0;
     private static final int PKG_INFO_LINE_VALUE_POSITION = 1;
 
-    public Optional<PackageDetails> resolvePackageDetails(ClangPackageManagerInfo currentPackageManager, DetectableExecutableRunner executableRunner, File workingDirectory, String packageName) {
+    public Optional<PackageDetails> resolvePackageDetails(ClangPackageManagerInfo currentPackageManager, DetectableExecutableRunner executableRunner, File workingDirectory, String packageName, @Nullable String packageArch) {
         try {
             List<String> args = new ArrayList<>(currentPackageManager.getPkgInfoArgs().get());
-            args.add(packageName);
+            String packageArg = packageName;
+            if (packageArch != null) {
+                packageArg = String.format("%s:%s", packageName, packageArch);
+            }
+            args.add(packageArg);
             ExecutableOutput packageInfoOutput = executableRunner.execute(workingDirectory, currentPackageManager.getPkgMgrCmdString(), args);
             return parsePackageDetailsFromInfoOutput(packageName, packageInfoOutput.getStandardOutput());
         } catch (ExecutableRunnerException e) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/NameArchitecture.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/clang/packagemanager/resolver/NameArchitecture.java
@@ -1,0 +1,46 @@
+/**
+ * detectable
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.detectable.detectables.clang.packagemanager.resolver;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public class NameArchitecture {
+    private final String name;
+    @Nullable
+    private final String architecture;
+
+    public NameArchitecture(String name, @Nullable String architecture) {
+        this.name = name;
+        this.architecture = architecture;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Optional<String> getArchitecture() {
+        return Optional.ofNullable(architecture);
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageManagerRunnerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageManagerRunnerTest.java
@@ -54,7 +54,7 @@ public class ClangPackageManagerRunnerTest {
                                        + "Architecture: amd64\n"
                                        + "Version: 1:1.1.5-1\n"
                                        + "Status: pending\n";
-        testNoResultsCase(packageManagerInfo, packageResolver, "libxt-dev", "amd64", "1:1.1.5-1", pkgOwnerPattern, pkgDetailsPattern);
+        testNoResultsCase(packageManagerInfo, packageResolver, "libxt-dev", "amd64", pkgOwnerPattern, pkgDetailsPattern);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class ClangPackageManagerRunnerTest {
         ClangPackageManagerInfo packageManagerInfo = factory.rpm();
         ClangPackageManagerResolver packageResolver = new RpmPackageManagerResolver(new Gson());
         String pkgOwnerPattern = "%s is not owned by any package";
-        testNonPkgOwnedIncludeFile(packageManagerInfo, packageResolver, pkgOwnerPattern, null);
+        testNonPkgOwnedIncludeFile(packageManagerInfo, packageResolver, pkgOwnerPattern);
     }
 
     @Test
@@ -87,7 +87,7 @@ public class ClangPackageManagerRunnerTest {
         DpkgPkgDetailsResolver versionResolver = new DpkgPkgDetailsResolver();
         ClangPackageManagerResolver packageResolver = new DpkgPackageManagerResolver(versionResolver);
         String pkgOwnerPattern = "dpkg-query: no path found matching pattern %s";
-        testNonPkgOwnedIncludeFile(packageManagerInfo, packageResolver, pkgOwnerPattern, null);
+        testNonPkgOwnedIncludeFile(packageManagerInfo, packageResolver, pkgOwnerPattern);
     }
 
     @Test
@@ -97,15 +97,15 @@ public class ClangPackageManagerRunnerTest {
         ApkArchitectureResolver archResolver = new ApkArchitectureResolver();
         ClangPackageManagerResolver packageResolver = new ApkPackageManagerResolver(archResolver);
         String pkgOwnerPattern = "ERROR: %s: Could not find owner package";
-        testNonPkgOwnedIncludeFile(packageManagerInfo, packageResolver, pkgOwnerPattern, null);
+        testNonPkgOwnedIncludeFile(packageManagerInfo, packageResolver, pkgOwnerPattern);
     }
 
     private void testNonPkgOwnedIncludeFile(ClangPackageManagerInfo packageManagerInfo, ClangPackageManagerResolver packageResolver,
-        String pkgMgrOwnerQueryResultPattern, String pkgMgrDetailsQueryResultPattern) throws ExecutableRunnerException {
+        String pkgMgrOwnerQueryResultPattern) throws ExecutableRunnerException {
 
         // Test
         PackageDetailsResult result = runTest(packageManagerInfo, packageResolver, null, null, false,
-            pkgMgrOwnerQueryResultPattern, pkgMgrDetailsQueryResultPattern, dependencyFile);
+            pkgMgrOwnerQueryResultPattern, null, dependencyFile);
 
         // Verify
         assertEquals(1, result.getUnRecognizedDependencyFiles().size());
@@ -131,7 +131,7 @@ public class ClangPackageManagerRunnerTest {
     }
 
     private void testNoResultsCase(ClangPackageManagerInfo packageManagerInfo, ClangPackageManagerResolver packageResolver,
-        String pkgName, String pkgArchitecture, String pkgVersion,
+        String pkgName, String pkgArchitecture,
         String pkgMgrQueryResultPattern, String pkgMgrDetailsQueryResultPattern) throws ExecutableRunnerException {
 
         // Test
@@ -176,7 +176,6 @@ public class ClangPackageManagerRunnerTest {
         ClangPackageManagerRunner runner = new ClangPackageManagerRunner();
 
         // Test
-        PackageDetailsResult result = runner.getPackages(currentPackageManager, workingDirectory, executableRunner, dependencyFile);
-        return result;
+        return runner.getPackages(currentPackageManager, workingDirectory, executableRunner, dependencyFile);
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageManagerRunnerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageManagerRunnerTest.java
@@ -159,10 +159,12 @@ public class ClangPackageManagerRunnerTest {
 
         if (packageManagerInfo.getPkgInfoArgs().isPresent() && (pkgMgrDetailsQueryResultPattern != null)) {
             List<String> fileSpecificGetDetailsArgs = new ArrayList<>(packageManagerInfo.getPkgInfoArgs().get());
-            if (!archBuried && pkgArch != null) {
-                fileSpecificGetDetailsArgs.add(pkgName + ":" + pkgArch);
-            } else {
+            // Architecture might be available from the initial "who owns this" query, buried in the later-gotten details, or altogether absent
+            // If absent or buried, the detail query should omit arch; otherwise: the detail query should include arch
+            if (archBuried || pkgArch == null) {
                 fileSpecificGetDetailsArgs.add(pkgName);
+            } else {
+                fileSpecificGetDetailsArgs.add(pkgName + ":" + pkgArch);
             }
             String pkgMgrGetDetailsQueryFileOutput = String.format(pkgMgrDetailsQueryResultPattern, dependencyFile);
             ExecutableOutput pkgMgrGetDetailsQueryFileResult = new ExecutableOutput(0, pkgMgrGetDetailsQueryFileOutput, "");

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageManagerRunnerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/ClangPackageManagerRunnerTest.java
@@ -40,7 +40,7 @@ public class ClangPackageManagerRunnerTest {
                                        + "Architecture: amd64\n"
                                        + "Version: 1:1.1.5-1\n"
                                        + "Status: install ok installed\n";
-        testSuccessCase(packageManagerInfo, packageResolver, "libxt-dev", "amd64", "1:1.1.5-1", pkgOwnerPattern, pkgDetailsPattern);
+        testSuccessCase(packageManagerInfo, packageResolver, "libxt-dev", "amd64", false, "1:1.1.5-1", pkgOwnerPattern, pkgDetailsPattern);
     }
 
     @Test
@@ -68,7 +68,7 @@ public class ClangPackageManagerRunnerTest {
                                        + "Architecture: amd64\n"
                                        + "Version: 1:1.1.5-1\n"
                                        + "Status: install ok installed\n";
-        testSuccessCase(packageManagerInfo, packageResolver, "libxt-dev", "amd64", "1:1.1.5-1", pkgOwnerPattern, pkgDetailsPattern);
+        testSuccessCase(packageManagerInfo, packageResolver, "libxt-dev", "amd64", true, "1:1.1.5-1", pkgOwnerPattern, pkgDetailsPattern);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class ClangPackageManagerRunnerTest {
         String pkgMgrOwnerQueryResultPattern, String pkgMgrDetailsQueryResultPattern) throws ExecutableRunnerException {
 
         // Test
-        PackageDetailsResult result = runTest(packageManagerInfo, packageResolver, null,
+        PackageDetailsResult result = runTest(packageManagerInfo, packageResolver, null, null, false,
             pkgMgrOwnerQueryResultPattern, pkgMgrDetailsQueryResultPattern, dependencyFile);
 
         // Verify
@@ -113,11 +113,12 @@ public class ClangPackageManagerRunnerTest {
     }
 
     private void testSuccessCase(ClangPackageManagerInfo packageManagerInfo, ClangPackageManagerResolver packageResolver,
-        String pkgName, String pkgArchitecture, String pkgVersion,
+        String pkgName, String pkgArchitecture, boolean archBuried, String pkgVersion,
         String pkgMgrQueryResultPattern, String pkgMgrDetailsQueryResultPattern) throws ExecutableRunnerException {
 
         // Test
-        PackageDetailsResult result = runTest(packageManagerInfo, packageResolver, pkgName,
+        PackageDetailsResult result = runTest(packageManagerInfo, packageResolver, pkgName, pkgArchitecture,
+            archBuried,
             pkgMgrQueryResultPattern, pkgMgrDetailsQueryResultPattern, dependencyFile);
 
         // Verify
@@ -134,7 +135,7 @@ public class ClangPackageManagerRunnerTest {
         String pkgMgrQueryResultPattern, String pkgMgrDetailsQueryResultPattern) throws ExecutableRunnerException {
 
         // Test
-        PackageDetailsResult result = runTest(packageManagerInfo, packageResolver, pkgName,
+        PackageDetailsResult result = runTest(packageManagerInfo, packageResolver, pkgName, pkgArchitecture, false,
             pkgMgrQueryResultPattern, pkgMgrDetailsQueryResultPattern, dependencyFile);
 
         // Verify
@@ -144,6 +145,7 @@ public class ClangPackageManagerRunnerTest {
 
     private PackageDetailsResult runTest(ClangPackageManagerInfo packageManagerInfo, ClangPackageManagerResolver packageResolver,
         String pkgName,
+        String pkgArch, boolean archBuried,
         String pkgMgrOwnerQueryResultPattern, String pkgMgrDetailsQueryResultPattern,
         File dependencyFile)
         throws ExecutableRunnerException {
@@ -157,7 +159,11 @@ public class ClangPackageManagerRunnerTest {
 
         if (packageManagerInfo.getPkgInfoArgs().isPresent() && (pkgMgrDetailsQueryResultPattern != null)) {
             List<String> fileSpecificGetDetailsArgs = new ArrayList<>(packageManagerInfo.getPkgInfoArgs().get());
-            fileSpecificGetDetailsArgs.add(pkgName);
+            if (!archBuried && pkgArch != null) {
+                fileSpecificGetDetailsArgs.add(pkgName + ":" + pkgArch);
+            } else {
+                fileSpecificGetDetailsArgs.add(pkgName);
+            }
             String pkgMgrGetDetailsQueryFileOutput = String.format(pkgMgrDetailsQueryResultPattern, dependencyFile);
             ExecutableOutput pkgMgrGetDetailsQueryFileResult = new ExecutableOutput(0, pkgMgrGetDetailsQueryFileOutput, "");
             Mockito.when(executableRunner.execute(workingDirectory, packageManagerInfo.getPkgMgrCmdString(), fileSpecificGetDetailsArgs)).thenReturn(pkgMgrGetDetailsQueryFileResult);

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/DpkgPackageManagerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/clang/unit/DpkgPackageManagerTest.java
@@ -76,9 +76,9 @@ public class DpkgPackageManagerTest {
 
         String pkgMgrVersionOutput = sb.toString();
 
-        final String packageName = "libc6-dev";
+        final String packageNameWithArch = "libc6-dev:amd64";
         DetectableExecutableRunner executableRunner = Mockito.mock(DetectableExecutableRunner.class);
-        Mockito.when(executableRunner.execute(null, "dpkg", Arrays.asList("-s", packageName))).thenReturn(new ExecutableOutput(0, pkgMgrVersionOutput, ""));
+        Mockito.when(executableRunner.execute(null, "dpkg", Arrays.asList("-s", packageNameWithArch))).thenReturn(new ExecutableOutput(0, pkgMgrVersionOutput, ""));
 
         DpkgPkgDetailsResolver dpkgVersionResolver = new DpkgPkgDetailsResolver();
         DpkgPackageManagerResolver pkgMgr = new DpkgPackageManagerResolver(dpkgVersionResolver);
@@ -131,9 +131,9 @@ public class DpkgPackageManagerTest {
 
         String pkgMgrVersionOutput = sb.toString();
 
-        final String packageName = "login";
+        final String packageNameWithArch = "login:amd64";
         DetectableExecutableRunner executableRunner = Mockito.mock(DetectableExecutableRunner.class);
-        Mockito.when(executableRunner.execute(null, "dpkg", Arrays.asList("-s", packageName))).thenReturn(new ExecutableOutput(0, pkgMgrVersionOutput, ""));
+        Mockito.when(executableRunner.execute(null, "dpkg", Arrays.asList("-s", packageNameWithArch))).thenReturn(new ExecutableOutput(0, pkgMgrVersionOutput, ""));
 
         DpkgPkgDetailsResolver dpkgVersionResolver = new DpkgPkgDetailsResolver();
         DpkgPackageManagerResolver pkgMgr = new DpkgPackageManagerResolver(dpkgVersionResolver);


### PR DESCRIPTION
CLANG: DPKG: a fix for the scenario where two packages with different architectures own one of the include files. In that scenario, the query for details must be architecture specific. Since the KB does not differentiate by architecture, we just pick the first architecture returned by the "who owns this file" query.
