### PR TITLE
Add Sbt Internal Dependency Tree plugin name to SbtPluginFinder

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/sbt/dot/SbtPluginFinder.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/sbt/dot/SbtPluginFinder.java
@@ -16,6 +16,7 @@ import com.synopsys.integration.executable.ExecutableOutput;
 public class SbtPluginFinder {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     public static final String DEPENDENCY_GRAPH_PLUGIN_NAME = "net.virtualvoid.sbt.graph.DependencyGraphPlugin";
+    public static final String DEPENDENCY_GRAPH_SBT_INTERNAL_PLUGIN_NAME = "sbt.plugins.DependencyTreePlugin";
     private final DetectableExecutableRunner executableRunner;
 
     public SbtPluginFinder(final DetectableExecutableRunner executableRunner) {
@@ -28,7 +29,8 @@ public class SbtPluginFinder {
     }
 
     public boolean determineInstalledPlugin(List<String> pluginOutput) {
-        if (pluginOutput.stream().anyMatch(line -> line.contains(DEPENDENCY_GRAPH_PLUGIN_NAME))) {
+        if (pluginOutput.stream().anyMatch(line ->
+                line.contains(DEPENDENCY_GRAPH_PLUGIN_NAME) || line.contains(DEPENDENCY_GRAPH_SBT_INTERNAL_PLUGIN_NAME))) {
             return true;
         } else {
             return false;

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/sbt/unit/SbtDotOutputParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/sbt/unit/SbtDotOutputParserTest.java
@@ -46,4 +46,21 @@ public class SbtDotOutputParserTest {
         Assertions.assertEquals("C:\\Users\\jordanp\\Downloads\\scalafmt-master\\scalafmt\\scalafmt-dynamic\\target\\dependencies-compile.dot", results.get(2).toString());
     }
 
+    @Test
+    public void parsesMultipleGraphsNIXPaths() {
+        List<String> input = Arrays.asList(
+                "[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
+                "[info] Wrote dependency graph to '/Users/jordanp/scalafmt-master/scalafmt/scalafmt-interfaces/target/dependencies-compile.dot'",
+                "[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
+                "[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.",
+                "[info] Wrote dependency graph to '/Users/jordanp/scalafmt-master/scalafmt/target/dependencies-compile.dot'",
+                "[info] Wrote dependency graph to '/Users/jordanp/scalafmt-master/scalafmt/scalafmt-dynamic/target/dependencies-compile.dot'");
+        SbtDotOutputParser parser = new SbtDotOutputParser();
+        List<File> results = parser.parseGeneratedGraphFiles(input);
+        Assertions.assertEquals(3, results.size());
+        Assertions.assertEquals("/Users/jordanp/scalafmt-master/scalafmt/scalafmt-interfaces/target/dependencies-compile.dot", results.get(0).toString());
+        Assertions.assertEquals("/Users/jordanp/scalafmt-master/scalafmt/target/dependencies-compile.dot", results.get(1).toString());
+        Assertions.assertEquals("/Users/jordanp/scalafmt-master/scalafmt/scalafmt-dynamic/target/dependencies-compile.dot", results.get(2).toString());
+    }
+
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/sbt/unit/SbtPluginFinderTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/sbt/unit/SbtPluginFinderTest.java
@@ -39,6 +39,20 @@ public class SbtPluginFinderTest {
     }
 
     @Test
+    public void pluginInternalFoundNormally() {
+        SbtPluginFinder parser = new SbtPluginFinder(null);
+        List<String> input = Arrays.asList("[info] welcome to sbt 1.4.7 (Oracle Corporation Java 1.8.0_161)", //standard sbt preamble
+            "[info] loading settings for project scalafmt-build from plugins.sbt ...",
+            "[info] loading project definition from C:\\Users\\jordanp\\Downloads\\scalafmt-master\\scalafmt\\project",
+            "[info] loading settings for project scalafmt from build.sbt ...",
+            "[info] set current project to scalafmtRoot (in build file:/C:/Users/jordanp/Downloads/scalafmt-master/scalafmt/)",
+            "In build /C:/Users/jordanp/Downloads/scalafmt-master/scalafmt/:",
+            "  Enabled plugins in benchmarks:",
+            "    sbt.plugins.DependencyTreePlugin"); //plugin we should find.
+        Assertions.assertTrue(parser.determineInstalledPlugin(input), "Plugin should have been found!");
+    }
+
+    @Test
     public void pluginNotFoundNormally() {
         SbtPluginFinder parser = new SbtPluginFinder(null);
         List<String> input = Arrays.asList("[info] welcome to sbt 1.4.7 (Oracle Corporation Java 1.8.0_161)", //standard sbt preamble


### PR DESCRIPTION
# Description

Support for built-in Dependency Tree Plugin that was moved into base `sbt` code since `sbt` 1.4.0 from https://github.com/sbt/sbt-dependency-graph

# Github Issues
#207 
#358 
