### PR TITLE
feat: added "bdio2.enabled=false" to the properties passed to Docker …

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerProperties.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerProperties.java
@@ -40,6 +40,7 @@ public class DockerProperties {
         // DI 8.1.0 and newer will provide both; Detect will prefer squashedimage
         dockerProperties.setProperty("output.include.containerfilesystem", "true");
         dockerProperties.setProperty("output.include.squashedimage", "true");
+        dockerProperties.setProperty("bdio2.enabled", "false"); // soon DI will return BDIO2 by default, which Detect can't consume
         dockerDetectableOptions.getDockerPlatformTopLayerId().ifPresent(id -> dockerProperties.setProperty("docker.platform.top.layer.id", id));
 
         Map<String, String> additionalDockerProperties = dockerDetectableOptions.getAdditionalDockerProperties();


### PR DESCRIPTION
…Inspector, so that when Docker Inspector switches to BDIO2 by default, it will continue to return BDIO1 to Detect. At the moment Detect ignores this property.