### PR TITLE
 Check for the method setConfigurations and setOutputFile.

### DIFF
--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -60,12 +60,26 @@ gradle.allprojects {
                 generateRootProjectMetaData(project, outputDirectoryPath)
 
                 if(projectFilter.shouldInclude(project.name)) {
+                    def dependencyTask = project.tasks.getByName('dependencies')
                     File projectOutputFile = findProjectOutputFile(project, outputDirectoryPath)
                     File projectFile = createProjectOutputFile(projectOutputFile)
 
-                    // modify the configurations for the dependency task and the output file
-                    setConfigurations(filterConfigurations(project, excludedConfigurationNames, includedConfigurationNames))
-                    setOutputFile(projectFile)
+                    if(dependencyTask.metaClass.respondsTo(dependencyTask, "setConfigurations")) {
+                        println "Updating configurations for task"
+                        // modify the configurations for the dependency task
+                        setConfigurations(filterConfigurations(project, excludedConfigurationNames, includedConfigurationNames))
+
+                    } else {
+                        println "Could not find method 'setConfigurations'"
+                    }
+
+                    if(dependencyTask.metaClass.respondsTo(dependencyTask,"setOutputFile")) {
+                        println "Updating output file for task to "+projectFile.getAbsolutePath()
+                        // modify the output file
+                        setOutputFile(projectFile)
+                    } else {
+                        println "Could not find method 'setOutputFile'"
+                    }
                 }
             }
 


### PR DESCRIPTION
If the methods exist update them to set the output file and configurations.  The GoGradle plugin creates a dependencies task that doesn't extend the AbstractDependencyReportTask class.  So it does not implement the methods that are used.
