### PR TITLE
Sb scan image file system

### DIFF
--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerExtractorTest.java
@@ -23,6 +23,7 @@
 package com.synopsys.integration.detectable.detectables.docker.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
@@ -42,9 +43,9 @@ import org.mockito.Mockito;
 import com.google.gson.Gson;
 import com.synopsys.integration.bdio.BdioTransformer;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.common.util.finder.FileFinder;
 import com.synopsys.integration.detectable.ExecutableTarget;
 import com.synopsys.integration.detectable.detectable.executable.DetectableExecutableRunner;
-import com.synopsys.integration.common.util.finder.FileFinder;
 import com.synopsys.integration.detectable.detectables.docker.DockerExtractor;
 import com.synopsys.integration.detectable.detectables.docker.DockerInspectorInfo;
 import com.synopsys.integration.detectable.detectables.docker.DockerProperties;
@@ -83,7 +84,7 @@ public class DockerExtractorTest {
         Extraction extraction = extract(image, imageId, tar, fakeContainerFileSystemFile, null, executableRunner);
 
         assertEquals("ubuntu:latest", extraction.getMetaData(DockerExtractor.DOCKER_IMAGE_NAME_META_DATA).get());
-        assertTrue(extraction.getMetaData(DockerExtractor.DOCKER_TAR_META_DATA).get().getName().endsWith("_containerfilesystem.tar.gz"));
+        assertTrue(extraction.getMetaData(DockerExtractor.CONTAINER_FILESYSTEM_META_DATA).get().getName().endsWith("_containerfilesystem.tar.gz"));
 
         ArgumentCaptor<Executable> executableArgumentCaptor = ArgumentCaptor.forClass(Executable.class);
         Mockito.verify(executableRunner).execute(executableArgumentCaptor.capture());
@@ -109,8 +110,7 @@ public class DockerExtractorTest {
         Extraction extraction = extract(image, imageId, tar, fakeContainerFileSystemFile, fakeSquashedImageFile, executableRunner);
 
         assertEquals("ubuntu:latest", extraction.getMetaData(DockerExtractor.DOCKER_IMAGE_NAME_META_DATA).get());
-        // When Detect gets both .tar.gz files back, should prefer the squashed image
-        assertTrue(extraction.getMetaData(DockerExtractor.DOCKER_TAR_META_DATA).get().getName().endsWith("_squashedimage.tar.gz"));
+        assertTrue(extraction.getMetaData(DockerExtractor.SQUASHED_IMAGE_META_DATA).get().getName().endsWith("_squashedimage.tar.gz"));
 
         ArgumentCaptor<Executable> executableArgumentCaptor = ArgumentCaptor.forClass(Executable.class);
         Mockito.verify(executableRunner).execute(executableArgumentCaptor.capture());
@@ -136,7 +136,7 @@ public class DockerExtractorTest {
         Extraction extraction = extract(image, imageId, tar, fakeContainerFileSystemFile, null, executableRunner);
 
         assertTrue(extraction.getMetaData(DockerExtractor.DOCKER_IMAGE_NAME_META_DATA).get().endsWith("testDockerTarfile.tar"));
-        assertTrue(extraction.getMetaData(DockerExtractor.DOCKER_TAR_META_DATA).get().getName().endsWith("_containerfilesystem.tar.gz"));
+        assertTrue(extraction.getMetaData(DockerExtractor.CONTAINER_FILESYSTEM_META_DATA).get().getName().endsWith("_containerfilesystem.tar.gz"));
 
         ArgumentCaptor<Executable> executableArgumentCaptor = ArgumentCaptor.forClass(Executable.class);
         Mockito.verify(executableRunner).execute(executableArgumentCaptor.capture());

--- a/docs/templates/content/90-releasenotes.ftl
+++ b/docs/templates/content/90-releasenotes.ftl
@@ -9,7 +9,7 @@
 * Added properties [detect.lerna.excluded.packages](../properties/detectors/lerna/#lerna-packages-excluded-advanced) and [detect.lerna.included.packages](../properties/detectors/lerna/#lerna-packages-included-advanced) to exclude and include specific Lerna packages.
 * Added critical security risks to the Black Duck Risk Report pdf.
 * Added detect.target.type to enhance the docker user experience. When set to IMAGE, some tools are automatically disabled and detect optimizes for an image based scan.
-* Added binary scanning of the squashed image (returned by Docker Inspector) to the default Docker image scanning workflow.
+* Added binary scanning of the container filesystem to the default Docker image scanning workflow.
 If you are scanning Docker images and your Black Duck server does not have the binary scanning feature enabled,
 use --detect.tools.exluded=BINARY_SCAN to disable the binary scan step.
 

--- a/docs/templates/content/advanced/package-managers/docker-images.ftl
+++ b/docs/templates/content/advanced/package-managers/docker-images.ftl
@@ -6,12 +6,19 @@ For simple use cases, add either ```--detect.docker.image={repo}:{tag}``` or ```
 The documentation for Docker Inspector is available [here](https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/187596884/Black+Duck+Docker+Inspector).
 
 When passed a value for either detect.docker.image or detect.docker.tar,
-${solution_name} runs Docker Inspector on given image (the "target image"),
-creating one code location. ${solution_name} by default runs
-the ${blackduck_signature_scanner_name} on the "container file system"
-(the file system a container created from the image has at startup time).
+${solution_name} runs Docker Inspector on the given image (the "target image"),
+creating one code location.
+
+${solution_name} by default runs
+the ${blackduck_signature_scanner_name} on an image built from the "container file system".
+This image is referred to as
+the squashed image (because it has only one layer, to eliminate the chance of false positives from lower layers).
+This scan creates another code location.
+
+Finally, ${solution_name} by default
+runs ${blackduck_binary_scan_capability} on the container file system.
 Refer to [${solution_name}'s scan target](#scantarget) for more details.
-This creates a second code location.
+This also creates a code location.
 
 ### File permissions
 
@@ -51,6 +58,10 @@ When a Docker image is run; for example, using a `docker run` command, a contain
 When ${solution_name} invokes both Docker Inspector because either detect.docker.image or detect.docker.tar is set, and the ${blackduck_signature_scanner_name}, as it does by default, the target of that ${blackduck_signature_scan_act} is the initial container file system constructed by Docker Inspector, packaged in a way to optimize results from ${blackduck_product_name}'s matching algorithms. Rather than directly running the ${blackduck_signature_scanner_name} on the initial container file system, ${solution_name} runs the ${blackduck_signature_scanner_name} on a new image; in other words, the squashed image, constructed using the initial container file system built by Docker Inspector. Packaging the initial container file system in a Docker image triggers matching algorithms within ${blackduck_product_name} that optimize match results for Linux file systems.
 
 In earlier versions of ${solution_name} / Docker Inspector, ${solution_name} ran the ${blackduck_signature_scanner_name} directly on the target image. This approach had the disadvantage of potentially producing false positives under certain circumstances. For example, suppose your target image consists of multiple layers. If version 1 of a package is installed in layer 0, and then replaced with a newer version of that package in layer 1, both versions exist in the image, even though the initial container file system only includes version 2. A ${blackduck_signature_scan_act} of the target image shows both versions, even though version 1 has been effectively replaced with version 2. The current ${solution_name} / Docker Inspector functionality avoids this potential for false positives.
+
+By default, ${solution_name} also runs ${blackduck_binary_scan_capability} on the initial container file system.
+If your ${blackduck_product_name} server does not have ${blackduck_binary_scan_capability} enabled, you
+should disable ${blackduck_binary_scan_capability}. For example, you might set: *--detect.tools.excluded=BINARY_SCAN*.
 
 ### Isolating application components
 

--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BlackDuckBinaryScannerTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BlackDuckBinaryScannerTool.java
@@ -106,10 +106,8 @@ public class BlackDuckBinaryScannerTool {
         } else if (dockerTargetData != null && dockerTargetData.getContainerFilesystem().isPresent()) {
             logger.info("Binary Scanner will upload docker container file system.");
             binaryUpload = dockerTargetData.getContainerFilesystem().get();
-        } else if (dockerTargetData != null && dockerTargetData.getProvidedImageTar().isPresent()) {
-            logger.info("Binary upload will docker provided image tar.");
-            binaryUpload = dockerTargetData.getProvidedImageTar().get();
         }
+        // Very important not to binary scan the same Docker output that we sig scanned (=codelocation name collision)
 
         if (binaryUpload == null) {
             logger.info("Binary scanner found nothing to upload.");


### PR DESCRIPTION
Changed the binary scan target in the Docker image workflow from the squashed image to the container file system. The squashed image adds no value over the container file system for binary scanning, and this change avoids a code location name collision by the two scans (signature and binary).
