### PR TITLE
Risk report pdf path

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationFactory.java
@@ -470,15 +470,9 @@ public class OperationFactory { //TODO: OperationRunner
         return auditLog.named("Decide Risk Report Path", () -> {
             if (detectConfigurationFactory.createBlackDuckPostOptions().shouldGenerateRiskReport()) {
                 File customReportLocation = detectConfigurationFactory.createBlackDuckPostOptions().getRiskReportPdfPath().toFile();
-                if (customReportLocation.exists()) {
+                if (customReportLocation.exists() && !customReportLocation.getName().equals(".")) { //TODO- is there a better way to avoid writing to default of .?
                     return Optional.of(customReportLocation);
                 } else {
-                    //TODO- detect.risk.report.path has a default for risk report directory to be current working directory
-                    // should the property determine the default, or should this method?
-                    //      if this method, what should default be:
-                    //          current working directory (behavior before refactor)
-                    //          source directory (what docs claim)
-                    //          report output directory (behavior after refactor)
                     return Optional.of(directoryManager.getSourceDirectory());
                 }
             }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationFactory.java
@@ -352,10 +352,10 @@ public class OperationFactory { //TODO: OperationRunner
         });
     }
 
-    public File createNoticesReportFile(BlackDuckRunData blackDuckRunData, ProjectVersionWrapper projectVersion) throws DetectUserFriendlyException {
+    public File createNoticesReportFile(BlackDuckRunData blackDuckRunData, ProjectVersionWrapper projectVersion, File noticesDirectory) throws DetectUserFriendlyException {
         return auditLog.named("Create Notices Report File", () -> {
             ReportService reportService = creatReportService(blackDuckRunData);
-            return reportService.createNoticesReportFile(directoryManager.getReportOutputDirectory(), projectVersion.getProjectView(), projectVersion.getProjectVersionView());
+            return reportService.createNoticesReportFile(noticesDirectory, projectVersion.getProjectView(), projectVersion.getProjectVersionView());
         });
     }
 
@@ -459,10 +459,14 @@ public class OperationFactory { //TODO: OperationRunner
     public Optional<File> calculateNoticesDirectory() throws DetectUserFriendlyException { //TODO Should be a decision in boot
         return auditLog.named("Decide Notices Report Path", () -> {
             if (detectConfigurationFactory.createBlackDuckPostOptions().shouldGenerateNoticesReport()) {
-                return Optional.of(detectConfigurationFactory.createBlackDuckPostOptions().getNoticesReportPath().toFile());
-            } else {
-                return Optional.empty();
+                File customReportLocation = detectConfigurationFactory.createBlackDuckPostOptions().getNoticesReportPath().toFile();
+                if (customReportLocation.exists() && !customReportLocation.getName().equals(".")) { //TODO- is there a better way to avoid writing to default of .?
+                    return Optional.of(customReportLocation);
+                } else {
+                    return Optional.of(directoryManager.getSourceDirectory());
+                }
             }
+            return Optional.empty();
         });
     }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -201,7 +201,7 @@ public class IntelligentModeStepRunner {
                 logger.warn(String.format("Failed to create notices directory at %s", noticesDirectory));
             }
 
-            File noticesFile = operationFactory.createNoticesReportFile(blackDuckRunData, projectVersion);
+            File noticesFile = operationFactory.createNoticesReportFile(blackDuckRunData, projectVersion, noticesDirectory);
             logger.info(String.format("Created notices report: %s", noticesFile.getCanonicalPath()));
 
             operationFactory.publishReport(new ReportDetectResult("Notices Report", noticesFile.getCanonicalPath()));

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -49,7 +49,7 @@ public class IntelligentModeStepRunner {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private StepHelper stepHelper;
 
-    public IntelligentModeStepRunner(final OperationFactory operationFactory, final StepHelper stepHelper) {
+    public IntelligentModeStepRunner(OperationFactory operationFactory, StepHelper stepHelper) {
         this.operationFactory = operationFactory;
         this.stepHelper = stepHelper;
     }
@@ -184,7 +184,7 @@ public class IntelligentModeStepRunner {
                 logger.warn(String.format("Failed to create risk report pdf directory: %s", reportDirectory));
             }
 
-            File createdPdf = operationFactory.createRiskReportFile(blackDuckRunData, projectVersion);
+            File createdPdf = operationFactory.createRiskReportFile(blackDuckRunData, projectVersion, reportDirectory);
 
             logger.info(String.format("Created risk report pdf: %s", createdPdf.getCanonicalPath()));
             operationFactory.publishReport(new ReportDetectResult("Risk Report", createdPdf.getCanonicalPath()));


### PR DESCRIPTION
Set risk and notices report paths to values provided by their corresponding properties, have them default to source directory (as their documentation states).
