### PR TITLE
Option to disable Go Mod dependency verification

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/GoModDetectableOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/GoModDetectableOptions.java
@@ -1,0 +1,13 @@
+package com.synopsys.integration.detectable.detectables.go;
+
+public class GoModDetectableOptions {
+    private final boolean dependencyVerificationEnabled;
+
+    public GoModDetectableOptions(boolean dependencyVerificationEnabled) {
+        this.dependencyVerificationEnabled = dependencyVerificationEnabled;
+    }
+
+    public boolean isDependencyVerificationEnabled() {
+        return dependencyVerificationEnabled;
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliDetectable.java
@@ -16,7 +16,6 @@ import com.synopsys.integration.detectable.detectable.annotation.DetectableInfo;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.detectable.detectable.executable.resolver.GoResolver;
 import com.synopsys.integration.detectable.detectable.result.DetectableResult;
-import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 
@@ -27,16 +26,16 @@ public class GoModCliDetectable extends Detectable {
     private final FileFinder fileFinder;
     private final GoResolver goResolver;
     private final GoModCliExtractor goModCliExtractor;
-    private final GoModDetectableOptions goModDetectableOptions;
+    private final GoModCliDetectableOptions goModCliDetectableOptions;
 
     private ExecutableTarget goExe;
 
-    public GoModCliDetectable(DetectableEnvironment environment, FileFinder fileFinder, GoResolver goResolver, GoModCliExtractor goModCliExtractor, GoModDetectableOptions goModDetectableOptions) {
+    public GoModCliDetectable(DetectableEnvironment environment, FileFinder fileFinder, GoResolver goResolver, GoModCliExtractor goModCliExtractor, GoModCliDetectableOptions goModCliDetectableOptions) {
         super(environment);
         this.fileFinder = fileFinder;
         this.goResolver = goResolver;
         this.goModCliExtractor = goModCliExtractor;
-        this.goModDetectableOptions = goModDetectableOptions;
+        this.goModCliDetectableOptions = goModCliDetectableOptions;
     }
 
     @Override
@@ -55,6 +54,6 @@ public class GoModCliDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) {
-        return goModCliExtractor.extract(environment.getDirectory(), goExe, goModDetectableOptions.isDependencyVerificationEnabled());
+        return goModCliExtractor.extract(environment.getDirectory(), goExe, goModCliDetectableOptions.isDependencyVerificationEnabled());
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliDetectable.java
@@ -7,15 +7,16 @@
  */
 package com.synopsys.integration.detectable.detectables.go.gomod;
 
+import com.synopsys.integration.common.util.finder.FileFinder;
 import com.synopsys.integration.detectable.Detectable;
 import com.synopsys.integration.detectable.DetectableEnvironment;
-import com.synopsys.integration.detectable.detectable.Requirements;
 import com.synopsys.integration.detectable.ExecutableTarget;
+import com.synopsys.integration.detectable.detectable.Requirements;
 import com.synopsys.integration.detectable.detectable.annotation.DetectableInfo;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.detectable.detectable.executable.resolver.GoResolver;
-import com.synopsys.integration.common.util.finder.FileFinder;
 import com.synopsys.integration.detectable.detectable.result.DetectableResult;
+import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 
@@ -26,14 +27,16 @@ public class GoModCliDetectable extends Detectable {
     private final FileFinder fileFinder;
     private final GoResolver goResolver;
     private final GoModCliExtractor goModCliExtractor;
+    private final GoModDetectableOptions goModDetectableOptions;
 
     private ExecutableTarget goExe;
 
-    public GoModCliDetectable(DetectableEnvironment environment, FileFinder fileFinder, GoResolver goResolver, GoModCliExtractor goModCliExtractor) {
+    public GoModCliDetectable(DetectableEnvironment environment, FileFinder fileFinder, GoResolver goResolver, GoModCliExtractor goModCliExtractor, GoModDetectableOptions goModDetectableOptions) {
         super(environment);
         this.fileFinder = fileFinder;
         this.goResolver = goResolver;
         this.goModCliExtractor = goModCliExtractor;
+        this.goModDetectableOptions = goModDetectableOptions;
     }
 
     @Override
@@ -52,6 +55,6 @@ public class GoModCliDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) {
-        return goModCliExtractor.extract(environment.getDirectory(), goExe);
+        return goModCliExtractor.extract(environment.getDirectory(), goExe, goModDetectableOptions.isDependencyVerificationEnabled());
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliDetectableOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliDetectableOptions.java
@@ -1,9 +1,9 @@
-package com.synopsys.integration.detectable.detectables.go;
+package com.synopsys.integration.detectable.detectables.go.gomod;
 
-public class GoModDetectableOptions {
+public class GoModCliDetectableOptions {
     private final boolean dependencyVerificationEnabled;
 
-    public GoModDetectableOptions(boolean dependencyVerificationEnabled) {
+    public GoModCliDetectableOptions(boolean dependencyVerificationEnabled) {
         this.dependencyVerificationEnabled = dependencyVerificationEnabled;
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliExtractor.java
@@ -8,6 +8,7 @@
 package com.synopsys.integration.detectable.detectables.go.gomod;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -33,8 +34,11 @@ public class GoModCliExtractor {
             List<String> listOutput = goModCommandExecutor.generateGoListOutput(directory, goExe);
             List<String> listUJsonOutput = goModCommandExecutor.generateGoListUJsonOutput(directory, goExe);
             List<String> modGraphOutput = goModCommandExecutor.generateGoModGraphOutput(directory, goExe);
-            List<String> modWhyOutput = goModCommandExecutor.generateGoModWhyOutput(directory, goExe);
-            Set<String> moduleExclusionList = goModWhyParser.createModuleExclusionList(modWhyOutput);
+            Set<String> moduleExclusionList = Collections.emptySet();
+            if (dependencyVerificationEnabled) {
+                List<String> modWhyOutput = goModCommandExecutor.generateGoModWhyOutput(directory, goExe);
+                moduleExclusionList = goModWhyParser.createModuleExclusionList(modWhyOutput);
+            }
             List<String> finalModGraphOutput = goModGraphTransformer.transformGoModGraphOutput(modGraphOutput, listUJsonOutput);
             List<CodeLocation> codeLocations = goModGraphParser.parseListAndGoModGraph(listOutput, finalModGraphOutput, moduleExclusionList);
             return new Extraction.Builder().success(codeLocations).build();//no project info - hoping git can help with that.

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliExtractor.java
@@ -28,7 +28,7 @@ public class GoModCliExtractor {
         this.goModGraphTransformer = goModGraphTransformer;
     }
 
-    public Extraction extract(File directory, ExecutableTarget goExe) {
+    public Extraction extract(File directory, ExecutableTarget goExe, boolean dependencyVerificationEnabled) {
         try {
             List<String> listOutput = goModCommandExecutor.generateGoListOutput(directory, goExe);
             List<String> listUJsonOutput = goModCommandExecutor.generateGoListUJsonOutput(directory, goExe);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -112,6 +112,7 @@ import com.synopsys.integration.detectable.detectables.git.parsing.GitParseExtra
 import com.synopsys.integration.detectable.detectables.git.parsing.parse.GitConfigNameVersionTransformer;
 import com.synopsys.integration.detectable.detectables.git.parsing.parse.GitConfigNodeTransformer;
 import com.synopsys.integration.detectable.detectables.git.parsing.parse.GitFileParser;
+import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepExtractor;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepLockDetectable;
 import com.synopsys.integration.detectable.detectables.go.godep.parse.GoLockParser;
@@ -299,8 +300,8 @@ public class DetectableFactory {
         return new GitParseDetectable(environment, fileFinder, gitParseExtractor());
     }
 
-    public GoModCliDetectable createGoModCliDetectable(DetectableEnvironment environment, GoResolver goResolver) {
-        return new GoModCliDetectable(environment, fileFinder, goResolver, goModCliExtractor());
+    public GoModCliDetectable createGoModCliDetectable(DetectableEnvironment environment, GoResolver goResolver, GoModDetectableOptions goModDetectableOptions) {
+        return new GoModCliDetectable(environment, fileFinder, goResolver, goModCliExtractor(), goModDetectableOptions);
     }
 
     public GoDepLockDetectable createGoLockDetectable(DetectableEnvironment environment) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -112,7 +112,6 @@ import com.synopsys.integration.detectable.detectables.git.parsing.GitParseExtra
 import com.synopsys.integration.detectable.detectables.git.parsing.parse.GitConfigNameVersionTransformer;
 import com.synopsys.integration.detectable.detectables.git.parsing.parse.GitConfigNodeTransformer;
 import com.synopsys.integration.detectable.detectables.git.parsing.parse.GitFileParser;
-import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepExtractor;
 import com.synopsys.integration.detectable.detectables.go.godep.GoDepLockDetectable;
 import com.synopsys.integration.detectable.detectables.go.godep.parse.GoLockParser;
@@ -120,6 +119,7 @@ import com.synopsys.integration.detectable.detectables.go.gogradle.GoGradleDetec
 import com.synopsys.integration.detectable.detectables.go.gogradle.GoGradleExtractor;
 import com.synopsys.integration.detectable.detectables.go.gogradle.GoGradleLockParser;
 import com.synopsys.integration.detectable.detectables.go.gomod.GoModCliDetectable;
+import com.synopsys.integration.detectable.detectables.go.gomod.GoModCliDetectableOptions;
 import com.synopsys.integration.detectable.detectables.go.gomod.GoModCliExtractor;
 import com.synopsys.integration.detectable.detectables.go.gomod.GoModCommandExecutor;
 import com.synopsys.integration.detectable.detectables.go.gomod.GoModGraphParser;
@@ -300,8 +300,8 @@ public class DetectableFactory {
         return new GitParseDetectable(environment, fileFinder, gitParseExtractor());
     }
 
-    public GoModCliDetectable createGoModCliDetectable(DetectableEnvironment environment, GoResolver goResolver, GoModDetectableOptions goModDetectableOptions) {
-        return new GoModCliDetectable(environment, fileFinder, goResolver, goModCliExtractor(), goModDetectableOptions);
+    public GoModCliDetectable createGoModCliDetectable(DetectableEnvironment environment, GoResolver goResolver, GoModCliDetectableOptions goModCliDetectableOptions) {
+        return new GoModCliDetectable(environment, fileFinder, goResolver, goModCliExtractor(), goModCliDetectableOptions);
     }
 
     public GoDepLockDetectable createGoLockDetectable(DetectableEnvironment environment) {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableTest.java
@@ -12,7 +12,7 @@ import com.synopsys.integration.detectable.DetectableEnvironment;
 import com.synopsys.integration.detectable.ExecutableTarget;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.detectable.detectable.executable.resolver.GoResolver;
-import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
+import com.synopsys.integration.detectable.detectables.go.gomod.GoModCliDetectableOptions;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.functional.DetectableFunctionalTest;
 import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
@@ -96,8 +96,8 @@ public class GoModDetectableTest extends DetectableFunctionalTest {
                 return ExecutableTarget.forCommand("go");
             }
         }
-        GoModDetectableOptions goModDetectableOptions = new GoModDetectableOptions(true);
-        return detectableFactory.createGoModCliDetectable(detectableEnvironment, new GoResolverTest(), goModDetectableOptions);
+        GoModCliDetectableOptions goModCliDetectableOptions = new GoModCliDetectableOptions(true);
+        return detectableFactory.createGoModCliDetectable(detectableEnvironment, new GoResolverTest(), goModCliDetectableOptions);
     }
 
     @Override

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableTest.java
@@ -12,6 +12,7 @@ import com.synopsys.integration.detectable.DetectableEnvironment;
 import com.synopsys.integration.detectable.ExecutableTarget;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.detectable.detectable.executable.resolver.GoResolver;
+import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.functional.DetectableFunctionalTest;
 import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
@@ -95,7 +96,8 @@ public class GoModDetectableTest extends DetectableFunctionalTest {
                 return ExecutableTarget.forCommand("go");
             }
         }
-        return detectableFactory.createGoModCliDetectable(detectableEnvironment, new GoResolverTest());
+        GoModDetectableOptions goModDetectableOptions = new GoModDetectableOptions(true);
+        return detectableFactory.createGoModCliDetectable(detectableEnvironment, new GoResolverTest(), goModDetectableOptions);
     }
 
     @Override

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModMinusWhyDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModMinusWhyDetectableTest.java
@@ -12,7 +12,7 @@ import com.synopsys.integration.detectable.DetectableEnvironment;
 import com.synopsys.integration.detectable.ExecutableTarget;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.detectable.detectable.executable.resolver.GoResolver;
-import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
+import com.synopsys.integration.detectable.detectables.go.gomod.GoModCliDetectableOptions;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.functional.DetectableFunctionalTest;
 import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
@@ -67,8 +67,8 @@ public class GoModMinusWhyDetectableTest extends DetectableFunctionalTest {
                 return ExecutableTarget.forCommand("go");
             }
         }
-        GoModDetectableOptions goModDetectableOptions = new GoModDetectableOptions(false);
-        return detectableFactory.createGoModCliDetectable(detectableEnvironment, new GoResolverTest(), goModDetectableOptions);
+        GoModCliDetectableOptions goModCliDetectableOptions = new GoModCliDetectableOptions(false);
+        return detectableFactory.createGoModCliDetectable(detectableEnvironment, new GoResolverTest(), goModCliDetectableOptions);
     }
 
     @Override

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModMinusWhyDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModMinusWhyDetectableTest.java
@@ -1,0 +1,85 @@
+package com.synopsys.integration.detectable.detectables.go.functional;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+
+import com.synopsys.integration.bdio.model.Forge;
+import com.synopsys.integration.detectable.Detectable;
+import com.synopsys.integration.detectable.DetectableEnvironment;
+import com.synopsys.integration.detectable.ExecutableTarget;
+import com.synopsys.integration.detectable.detectable.exception.DetectableException;
+import com.synopsys.integration.detectable.detectable.executable.resolver.GoResolver;
+import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
+import com.synopsys.integration.detectable.extraction.Extraction;
+import com.synopsys.integration.detectable.functional.DetectableFunctionalTest;
+import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
+import com.synopsys.integration.executable.ExecutableOutput;
+
+public class GoModMinusWhyDetectableTest extends DetectableFunctionalTest {
+    public GoModMinusWhyDetectableTest() throws IOException {
+        super("gomod");
+    }
+
+    @Override
+    protected void setup() throws IOException {
+        addFile(Paths.get("go.mod"));
+
+        ExecutableOutput goListOutput = createStandardOutput(
+            "github.com/dgrijalva/jwt-go"
+        );
+        addExecutableOutput(goListOutput, "go", "list", "-m");
+
+        ExecutableOutput goVersionOutput = createStandardOutput(
+            "go version go1.14.5 darwin/amd64"
+        );
+        addExecutableOutput(goVersionOutput, "go", "version");
+
+        ExecutableOutput goListUJsonOutput = createStandardOutput(
+            "{\n",
+            "\t\"Path\": \"github.com/dgrijalva/jwt-go\",\n",
+            "\t\"Version\": \"v3.2.0\"\n",
+            "}"
+        );
+        addExecutableOutput(goListUJsonOutput, "go", "list", "-mod=readonly", "-m", "-u", "-json", "all");
+
+        ExecutableOutput goModGraphOutput = createStandardOutput(
+            "github.com/dgrijalva/jwt-go github.com/dgrijalva/jwt-go@v3.2.0+incompatible"
+        );
+        addExecutableOutput(goModGraphOutput, "go", "mod", "graph");
+
+        ExecutableOutput goModWhyOutput = createStandardOutput(
+            "# github.com/dgrijalva/jwt-go",
+            "(main module does not need module github.com/dgrijalva/jwt-go)",
+            "github.com/davecgh/go-spew"
+        );
+
+        addExecutableOutput(goModWhyOutput, "go", "mod", "why", "-m", "all");
+    }
+
+    @NotNull
+    @Override
+    public Detectable create(@NotNull DetectableEnvironment detectableEnvironment) {
+        class GoResolverTest implements GoResolver {
+            @Override
+            public ExecutableTarget resolveGo() throws DetectableException {
+                return ExecutableTarget.forCommand("go");
+            }
+        }
+        GoModDetectableOptions goModDetectableOptions = new GoModDetectableOptions(false);
+        return detectableFactory.createGoModCliDetectable(detectableEnvironment, new GoResolverTest(), goModDetectableOptions);
+    }
+
+    @Override
+    public void assertExtraction(@NotNull Extraction extraction) {
+        Assertions.assertEquals(1, extraction.getCodeLocations().size());
+
+        NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.GOLANG, extraction.getCodeLocations().get(0).getDependencyGraph());
+        graphAssert.hasRootSize(1, "Dependency verification being disabled should allow for dependencies to be found.");
+        graphAssert.hasNoDependency("github.com/dgrijalva/jwt-go", "v3.2.0+incompatible");
+        graphAssert.hasDependency("github.com/dgrijalva/jwt-go", "v3.2.0");
+    }
+
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModMinusWhyDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModMinusWhyDetectableTest.java
@@ -52,8 +52,7 @@ public class GoModMinusWhyDetectableTest extends DetectableFunctionalTest {
 
         ExecutableOutput goModWhyOutput = createStandardOutput(
             "# github.com/dgrijalva/jwt-go",
-            "(main module does not need module github.com/dgrijalva/jwt-go)",
-            "github.com/davecgh/go-spew"
+            "(main module does not need module github.com/dgrijalva/jwt-go)"
         );
 
         addExecutableOutput(goModWhyOutput, "go", "mod", "why", "-m", "all");

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/unit/GoModCliExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/unit/GoModCliExtractorTest.java
@@ -34,9 +34,9 @@ public class GoModCliExtractorTest {
         File directory = new File("");
         ExecutableTarget goExe = ExecutableTarget.forFile(new File(""));
         Answer<ExecutableOutput> executableAnswer = new Answer<ExecutableOutput>() {
-            final String[] goListArgs = { "list", "-m" };
-            final String[] goListJsonArgs = { "list", "-m", "-u", "-json", "all" };
-            final String[] goModGraphArgs = { "mod", "graph" };
+            String[] goListArgs = { "list", "-m" };
+            String[] goListJsonArgs = { "list", "-m", "-u", "-json", "all" };
+            String[] goModGraphArgs = { "mod", "graph" };
 
             @Override
             public ExecutableOutput answer(InvocationOnMock invocation) {
@@ -77,10 +77,10 @@ public class GoModCliExtractorTest {
         File directory = new File("");
         ExecutableTarget goExe = ExecutableTarget.forFile(new File(""));
         Answer<ExecutableOutput> executableAnswer = new Answer<ExecutableOutput>() {
-            final String[] goListArgs = { "list", "-m" };
-            final String[] goListJsonArgs = { "list", "-m", "-u", "-json", "all" };
-            final String[] goModGraphArgs = { "mod", "graph" };
-            final String[] goModWhyArgs = { "mod", "why", "-m", "all" };
+            String[] goListArgs = { "list", "-m" };
+            String[] goListJsonArgs = { "list", "-m", "-u", "-json", "all" };
+            String[] goModGraphArgs = { "mod", "graph" };
+            String[] goModWhyArgs = { "mod", "why", "-m", "all" };
 
             @Override
             public ExecutableOutput answer(InvocationOnMock invocation) throws Throwable {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/unit/GoModCliExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/unit/GoModCliExtractorTest.java
@@ -34,9 +34,9 @@ public class GoModCliExtractorTest {
         File directory = new File("");
         ExecutableTarget goExe = ExecutableTarget.forFile(new File(""));
         Answer<ExecutableOutput> executableAnswer = new Answer<ExecutableOutput>() {
-            String[] goListArgs = { "list", "-m" };
-            String[] goListJsonArgs = { "list", "-m", "-u", "-json", "all" };
-            String[] goModGraphArgs = { "mod", "graph" };
+            final String[] goListArgs = { "list", "-m" };
+            final String[] goListJsonArgs = { "list", "-m", "-u", "-json", "all" };
+            final String[] goModGraphArgs = { "mod", "graph" };
 
             @Override
             public ExecutableOutput answer(InvocationOnMock invocation) {
@@ -63,7 +63,7 @@ public class GoModCliExtractorTest {
         GoModCliExtractor goModCliExtractor = new GoModCliExtractor(goModCommandExecutor, goModGraphParser, goModGraphTransformer, goModWhyParser);
 
         boolean wasSuccessful = true;
-        Extraction extraction = goModCliExtractor.extract(directory, goExe);
+        Extraction extraction = goModCliExtractor.extract(directory, goExe, true);
         if (extraction.getError() instanceof ArrayIndexOutOfBoundsException) {
             wasSuccessful = false;
         }
@@ -77,10 +77,10 @@ public class GoModCliExtractorTest {
         File directory = new File("");
         ExecutableTarget goExe = ExecutableTarget.forFile(new File(""));
         Answer<ExecutableOutput> executableAnswer = new Answer<ExecutableOutput>() {
-            String[] goListArgs = { "list", "-m" };
-            String[] goListJsonArgs = { "list", "-m", "-u", "-json", "all" };
-            String[] goModGraphArgs = { "mod", "graph" };
-            String[] goModWhyArgs = { "mod", "why", "-m", "all" };
+            final String[] goListArgs = { "list", "-m" };
+            final String[] goListJsonArgs = { "list", "-m", "-u", "-json", "all" };
+            final String[] goModGraphArgs = { "mod", "graph" };
+            final String[] goModWhyArgs = { "mod", "why", "-m", "all" };
 
             @Override
             public ExecutableOutput answer(InvocationOnMock invocation) throws Throwable {
@@ -110,7 +110,7 @@ public class GoModCliExtractorTest {
         GoModCliExtractor goModCliExtractor = new GoModCliExtractor(goModCommandExecutor, goModGraphParser, goModGraphTransformer, goModWhyParser);
 
         boolean wasSuccessful = true;
-        Extraction extraction = goModCliExtractor.extract(directory, goExe);
+        Extraction extraction = goModCliExtractor.extract(directory, goExe, true);
         if (extraction.getError() instanceof ArrayIndexOutOfBoundsException) {
             wasSuccessful = false;
         }

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -561,6 +561,12 @@ public class DetectProperties {
             .setHelp("Path to the Go executable.")
             .setGroups(DetectGroup.GO, DetectGroup.GLOBAL);
 
+    public static final DetectProperty<BooleanProperty> DETECT_GO_ENABLE_VERIFICATION =
+        new DetectProperty<>(new BooleanProperty("detect.go.mod.enable.verification", true))
+            .setInfo("Go Mod Dependency Verification", DetectPropertyFromVersion.VERSION_7_1_0)
+            .setHelp("When enabled, Detect will use the results of 'go mod why' to filter out unused dependencies. Set to false if you have an empty BOM.")
+            .setGroups(DetectGroup.GO, DetectGroup.GLOBAL);
+
     public static final DetectProperty<NullableStringProperty> DETECT_GRADLE_BUILD_COMMAND =
         new DetectProperty<>(new NullableStringProperty("detect.gradle.build.command"))
             .setInfo("Gradle Build Command", DetectPropertyFromVersion.VERSION_3_0_0)

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -37,7 +37,7 @@ import com.synopsys.integration.detectable.detectables.conan.cli.ConanCliExtract
 import com.synopsys.integration.detectable.detectables.conan.lockfile.ConanLockfileExtractorOptions;
 import com.synopsys.integration.detectable.detectables.conda.CondaCliDetectableOptions;
 import com.synopsys.integration.detectable.detectables.docker.DockerDetectableOptions;
-import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
+import com.synopsys.integration.detectable.detectables.go.gomod.GoModCliDetectableOptions;
 import com.synopsys.integration.detectable.detectables.gradle.inspection.GradleInspectorOptions;
 import com.synopsys.integration.detectable.detectables.gradle.inspection.inspector.GradleInspectorScriptOptions;
 import com.synopsys.integration.detectable.detectables.lerna.LernaOptions;
@@ -133,9 +133,9 @@ public class DetectableOptionFactory {
             dockerPlatformTopLayerId);
     }
 
-    public GoModDetectableOptions createGoDetectableOptions() {
+    public GoModCliDetectableOptions createGoModCliDetectableOptions() {
         Boolean dependencyVerificationEnabled = getValue(DetectProperties.DETECT_GO_ENABLE_VERIFICATION);
-        return new GoModDetectableOptions(dependencyVerificationEnabled);
+        return new GoModCliDetectableOptions(dependencyVerificationEnabled);
     }
 
     public GradleInspectorOptions createGradleInspectorOptions() {

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -37,6 +37,7 @@ import com.synopsys.integration.detectable.detectables.conan.cli.ConanCliExtract
 import com.synopsys.integration.detectable.detectables.conan.lockfile.ConanLockfileExtractorOptions;
 import com.synopsys.integration.detectable.detectables.conda.CondaCliDetectableOptions;
 import com.synopsys.integration.detectable.detectables.docker.DockerDetectableOptions;
+import com.synopsys.integration.detectable.detectables.go.GoModDetectableOptions;
 import com.synopsys.integration.detectable.detectables.gradle.inspection.GradleInspectorOptions;
 import com.synopsys.integration.detectable.detectables.gradle.inspection.inspector.GradleInspectorScriptOptions;
 import com.synopsys.integration.detectable.detectables.lerna.LernaOptions;
@@ -130,6 +131,11 @@ public class DetectableOptionFactory {
         String dockerPlatformTopLayerId = getNullableValue(DetectProperties.DETECT_DOCKER_PLATFORM_TOP_LAYER_ID);
         return new DockerDetectableOptions(dockerPathRequired, suppliedDockerImage, dockerImageId, suppliedDockerTar, dockerInspectorLoggingLevel, dockerInspectorVersion, additionalDockerProperties, dockerInspectorPath,
             dockerPlatformTopLayerId);
+    }
+
+    public GoModDetectableOptions createGoDetectableOptions() {
+        Boolean dependencyVerificationEnabled = getValue(DetectProperties.DETECT_GO_ENABLE_VERIFICATION);
+        return new GoModDetectableOptions(dependencyVerificationEnabled);
     }
 
     public GradleInspectorOptions createGradleInspectorOptions() {

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
@@ -124,7 +124,7 @@ public class DetectDetectableFactory {
     }
 
     public GoModCliDetectable createGoModCliDetectable(DetectableEnvironment environment) {
-        return detectableFactory.createGoModCliDetectable(environment, detectExecutableResolver, detectableOptionFactory.createGoDetectableOptions());
+        return detectableFactory.createGoModCliDetectable(environment, detectExecutableResolver, detectableOptionFactory.createGoModCliDetectableOptions());
     }
 
     public GoDepLockDetectable createGoLockDetectable(DetectableEnvironment environment) {

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
@@ -124,7 +124,7 @@ public class DetectDetectableFactory {
     }
 
     public GoModCliDetectable createGoModCliDetectable(DetectableEnvironment environment) {
-        return detectableFactory.createGoModCliDetectable(environment, detectExecutableResolver);
+        return detectableFactory.createGoModCliDetectable(environment, detectExecutableResolver, detectableOptionFactory.createGoDetectableOptions());
     }
 
     public GoDepLockDetectable createGoLockDetectable(DetectableEnvironment environment) {


### PR DESCRIPTION
# Description

User's desire the ability to disable dependency verification for Go Mod when running Detect separate from their build environment. 
This is a feature we introduced in 6.8.0 to filter out unused dependencies, which if no source is attached, can result in an empty BOM.
This PR adds a new Detect property for enabling dependency verification.
```
public static final DetectProperty<BooleanProperty> DETECT_GO_ENABLE_VERIFICATION =
        new DetectProperty<>(new BooleanProperty("detect.go.mod.enable.verification", true))
            .setInfo("Go Mod Dependency Verification", DetectPropertyFromVersion.VERSION_7_1_0)
            .setHelp("When enabled, Detect will use the results of 'go mod why' to filter out unused dependencies. Set to false if you have an empty BOM.")
            .setGroups(DetectGroup.GO, DetectGroup.GLOBAL);
```
# Jira Issues
IDETECT-2678 - Detect - disable go.mod dependency verification
IDETECT-2629 - Detect 6.9.1 returns zero components from known-good go.mod
