### PR TITLE
refactor: Eliminating return of wildcard generic with a data class.

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationFactory.java
@@ -26,7 +26,6 @@ import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
 import com.synopsys.integration.blackduck.api.manual.view.DeveloperScanComponentResultView;
 import com.synopsys.integration.blackduck.bdio2.util.Bdio2Factory;
-import com.synopsys.integration.blackduck.codelocation.CodeLocationBatchOutput;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationService;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationWaitResult;
@@ -105,6 +104,7 @@ import com.synopsys.integration.detect.workflow.blackduck.DetectProjectServiceOp
 import com.synopsys.integration.detect.workflow.blackduck.bdio.IntelligentPersistentUploadOperation;
 import com.synopsys.integration.detect.workflow.blackduck.bdio.LegacyBdio1UploadOperation;
 import com.synopsys.integration.detect.workflow.blackduck.bdio.LegacyBdio2UploadOperation;
+import com.synopsys.integration.detect.workflow.blackduck.codelocation.AccumulatedCodeLocationData;
 import com.synopsys.integration.detect.workflow.blackduck.codelocation.CodeLocationWaitCalculator;
 import com.synopsys.integration.detect.workflow.blackduck.codelocation.CodeLocationWaitData;
 import com.synopsys.integration.detect.workflow.blackduck.developer.RapidModeGenerateJsonOperation;
@@ -277,7 +277,7 @@ public class OperationFactory { //TODO: OperationRunner
         return auditLog.namedPublic("Upload Intelligent Persistent Bdio", () -> new IntelligentPersistentUploadOperation(blackDuckRunData.getBlackDuckServicesFactory().createIntelligentPersistenceService()).uploadBdioFiles(bdioResult));
     }
 
-    public final CodeLocationWaitData calulcateCodeLocationWaitData(List<CodeLocationCreationData<? extends CodeLocationBatchOutput<?>>> codeLocationCreationDatas) throws DetectUserFriendlyException {
+    public final CodeLocationWaitData calulcateCodeLocationWaitData(List<AccumulatedCodeLocationData> codeLocationCreationDatas) throws DetectUserFriendlyException {
         return auditLog.namedInternal("Calculate Code Location Wait Data", () -> new CodeLocationWaitCalculator().calculateWaitData(codeLocationCreationDatas));
     }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/codelocation/AccumulatedCodeLocationData.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/codelocation/AccumulatedCodeLocationData.java
@@ -1,0 +1,29 @@
+package com.synopsys.integration.detect.workflow.blackduck.codelocation;
+
+import java.util.Set;
+
+import com.synopsys.integration.blackduck.service.model.NotificationTaskRange;
+
+public class AccumulatedCodeLocationData {
+    private final int expectedNotificationCount;
+    private final Set<String> successfulCodeLocationNames;
+    private final NotificationTaskRange notificationTaskRange;
+
+    public AccumulatedCodeLocationData(final int expectedNotificationCount, final Set<String> successfulCodeLocationNames, final NotificationTaskRange notificationTaskRange) {
+        this.expectedNotificationCount = expectedNotificationCount;
+        this.successfulCodeLocationNames = successfulCodeLocationNames;
+        this.notificationTaskRange = notificationTaskRange;
+    }
+
+    public int getExpectedNotificationCount() {
+        return expectedNotificationCount;
+    }
+
+    public Set<String> getSuccessfulCodeLocationNames() {
+        return successfulCodeLocationNames;
+    }
+
+    public NotificationTaskRange getNotificationTaskRange() {
+        return notificationTaskRange;
+    }
+}

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/codelocation/CodeLocationAccumulator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/codelocation/CodeLocationAccumulator.java
@@ -16,20 +16,19 @@ import com.synopsys.integration.blackduck.codelocation.CodeLocationBatchOutput;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
 
 public class CodeLocationAccumulator {
-
-    private final List<CodeLocationCreationData<? extends CodeLocationBatchOutput<?>>> waitableCodeLocations = new ArrayList<>();
+    private final List<AccumulatedCodeLocationData> waitableCodeLocationData = new ArrayList<>();
     private final Set<String> nonWaitableCodeLocations = new HashSet<>();
 
     public void addWaitableCodeLocation(CodeLocationCreationData<? extends CodeLocationBatchOutput<?>> creationData) {
-        waitableCodeLocations.add(creationData);
+        waitableCodeLocationData.add(new AccumulatedCodeLocationData(creationData.getOutput().getExpectedNotificationCount(), creationData.getOutput().getSuccessfulCodeLocationNames(), creationData.getNotificationTaskRange()));
     }
 
     public void addNonWaitableCodeLocation(Set<String> names) {
         nonWaitableCodeLocations.addAll(names);
     }
 
-    public List<CodeLocationCreationData<? extends CodeLocationBatchOutput<?>>> getWaitableCodeLocations() {
-        return waitableCodeLocations;
+    public List<AccumulatedCodeLocationData> getWaitableCodeLocations() {
+        return waitableCodeLocationData;
     }
 
     public Set<String> getNonWaitableCodeLocations() {

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/codelocation/CodeLocationWaitCalculator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/codelocation/CodeLocationWaitCalculator.java
@@ -12,19 +12,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.synopsys.integration.blackduck.codelocation.CodeLocationBatchOutput;
-import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
 import com.synopsys.integration.blackduck.service.model.NotificationTaskRange;
 
 public class CodeLocationWaitCalculator {
-    public CodeLocationWaitData calculateWaitData(List<CodeLocationCreationData<? extends CodeLocationBatchOutput<?>>> codeLocationCreationDatas) {
+    public CodeLocationWaitData calculateWaitData(List<AccumulatedCodeLocationData> codeLocationCreationDatas) {
         int expectedNotificationCount = 0;
         NotificationTaskRange notificationRange = null;
         Set<String> codeLocationNames = new HashSet<>();
 
-        for (CodeLocationCreationData<? extends CodeLocationBatchOutput<?>> codeLocationCreationData : codeLocationCreationDatas) {
-            expectedNotificationCount += codeLocationCreationData.getOutput().getExpectedNotificationCount();
-            codeLocationNames.addAll(codeLocationCreationData.getOutput().getSuccessfulCodeLocationNames());
+        for (AccumulatedCodeLocationData codeLocationCreationData : codeLocationCreationDatas) {
+            expectedNotificationCount += codeLocationCreationData.getExpectedNotificationCount();
+            codeLocationNames.addAll(codeLocationCreationData.getSuccessfulCodeLocationNames());
 
             if (null == notificationRange) {
                 notificationRange = codeLocationCreationData.getNotificationTaskRange();


### PR DESCRIPTION
This addresses the sonar cloud problem. It doesn't like us returning a generic wildcard. Instead I am just grabbing the pieces we need from the generic and putting it in a strongly typed data class.