### PR TITLE
Peer Dependencies - NpmPackageJsonParseDetectable

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/NpmPackageJsonParseDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/NpmPackageJsonParseDetectable.java
@@ -28,6 +28,7 @@ public class NpmPackageJsonParseDetectable extends Detectable {
     private final FileFinder fileFinder;
     private final PackageJsonExtractor packageJsonExtractor;
     private final boolean includeDevDependencies;
+    private final boolean includePeerDependencies;
 
     private File packageJsonFile;
 
@@ -37,6 +38,7 @@ public class NpmPackageJsonParseDetectable extends Detectable {
         this.fileFinder = fileFinder;
         this.packageJsonExtractor = packageJsonExtractor;
         this.includeDevDependencies = npmPackageJsonParseDetectableOptions.shouldIncludeDevDependencies();
+        this.includePeerDependencies = npmPackageJsonParseDetectableOptions.shouldIncludePeerDependencies();
     }
 
     @Override
@@ -54,7 +56,7 @@ public class NpmPackageJsonParseDetectable extends Detectable {
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) {
         try (InputStream packageJsonInputStream = new FileInputStream(packageJsonFile)) {
-            return packageJsonExtractor.extract(packageJsonInputStream, includeDevDependencies);
+            return packageJsonExtractor.extract(packageJsonInputStream, includeDevDependencies, includePeerDependencies);
         } catch (Exception e) {
             return new Extraction.Builder().exception(e).failure(String.format("Failed to parse %s", PACKAGE_JSON)).build();
         }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/NpmPackageJsonParseDetectableOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/NpmPackageJsonParseDetectableOptions.java
@@ -9,12 +9,18 @@ package com.synopsys.integration.detectable.detectables.npm.packagejson;
 
 public class NpmPackageJsonParseDetectableOptions {
     private final boolean includeDevDependencies;
+    private final boolean includePeerDependencies;
 
-    public NpmPackageJsonParseDetectableOptions(final boolean includeDevDependencies) {
+    public NpmPackageJsonParseDetectableOptions(boolean includeDevDependencies, boolean includePeerDependencies) {
         this.includeDevDependencies = includeDevDependencies;
+        this.includePeerDependencies = includePeerDependencies;
     }
 
     public boolean shouldIncludeDevDependencies() {
         return includeDevDependencies;
+    }
+
+    public boolean shouldIncludePeerDependencies() {
+        return includePeerDependencies;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/model/PackageJson.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/model/PackageJson.java
@@ -24,4 +24,7 @@ public class PackageJson {
 
     @SerializedName("devDependencies")
     public Map<String, String> devDependencies = new HashMap<>();
+
+    @SerializedName("peerDependencies")
+    public Map<String, String> peerDependencies = new HashMap<>();
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/functional/PackageJsonExtractorFunctionalTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/functional/PackageJsonExtractorFunctionalTest.java
@@ -53,6 +53,8 @@ public class PackageJsonExtractorFunctionalTest {
     private ExternalId testDep2;
     private ExternalId testDevDep1;
     private ExternalId testDevDep2;
+    private ExternalId testPeerDep1;
+    private ExternalId testPeerDep2;
 
     @BeforeEach
     void setUp() {
@@ -63,13 +65,16 @@ public class PackageJsonExtractorFunctionalTest {
         testDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "name2", "version2");
         testDevDep1 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "nameDev1", "versionDev1");
         testDevDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "nameDev2", "versionDev2");
+        testPeerDep1 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "namePeer1", "versionPeer1");
+        testPeerDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "namePeer2", "versionPeer2");
+
         packageJsonExtractor = new PackageJsonExtractor(gson, externalIdFactory);
         packageJsonInputStream = FunctionalTestFiles.asInputStream("/npm/package.json");
     }
 
     @Test
     void extractWithNoDevDependencies() {
-        Extraction extraction = packageJsonExtractor.extract(packageJsonInputStream, false);
+        Extraction extraction = packageJsonExtractor.extract(packageJsonInputStream, false, false);
         assertEquals(1, extraction.getCodeLocations().size());
         CodeLocation codeLocation = extraction.getCodeLocations().get(0);
         DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
@@ -79,12 +84,14 @@ public class PackageJsonExtractorFunctionalTest {
         graphAssert.hasRootDependency(testDep2);
         graphAssert.hasNoDependency(testDevDep1);
         graphAssert.hasNoDependency(testDevDep2);
+        graphAssert.hasNoDependency(testPeerDep1);
+        graphAssert.hasNoDependency(testPeerDep2);
         graphAssert.hasRootSize(2);
     }
 
     @Test
     void extractWithDevDependencies() {
-        Extraction extraction = packageJsonExtractor.extract(packageJsonInputStream, true);
+        Extraction extraction = packageJsonExtractor.extract(packageJsonInputStream, true, false);
         assertEquals(1, extraction.getCodeLocations().size());
         CodeLocation codeLocation = extraction.getCodeLocations().get(0);
         DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
@@ -94,6 +101,25 @@ public class PackageJsonExtractorFunctionalTest {
         graphAssert.hasRootDependency(testDep2);
         graphAssert.hasRootDependency(testDevDep1);
         graphAssert.hasRootDependency(testDevDep2);
+        graphAssert.hasNoDependency(testPeerDep1);
+        graphAssert.hasNoDependency(testPeerDep2);
+        graphAssert.hasRootSize(4);
+    }
+
+    @Test
+    void extractWithPeerDependencies() {
+        Extraction extraction = packageJsonExtractor.extract(packageJsonInputStream, false, true);
+        assertEquals(1, extraction.getCodeLocations().size());
+        CodeLocation codeLocation = extraction.getCodeLocations().get(0);
+        DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
+
+        GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
+        graphAssert.hasRootDependency(testDep1);
+        graphAssert.hasRootDependency(testDep2);
+        graphAssert.hasRootDependency(testPeerDep1);
+        graphAssert.hasRootDependency(testPeerDep2);
+        graphAssert.hasNoDependency(testDevDep1);
+        graphAssert.hasNoDependency(testDevDep2);
         graphAssert.hasRootSize(4);
     }
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/NpmPackageJsonParseDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/NpmPackageJsonParseDetectableTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import com.synopsys.integration.detectable.DetectableEnvironment;
 import com.synopsys.integration.common.util.finder.FileFinder;
+import com.synopsys.integration.detectable.DetectableEnvironment;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.NpmPackageJsonParseDetectable;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.NpmPackageJsonParseDetectableOptions;
 import com.synopsys.integration.detectable.util.MockDetectableEnvironment;
@@ -41,7 +41,7 @@ public class NpmPackageJsonParseDetectableTest {
         DetectableEnvironment environment = MockDetectableEnvironment.empty();
         FileFinder fileFinder = MockFileFinder.withFileNamed(PACKAGE_JSON_FILENAME);
 
-        NpmPackageJsonParseDetectableOptions npmPackageJsonParseDetectableOptions = new NpmPackageJsonParseDetectableOptions(false);
+        NpmPackageJsonParseDetectableOptions npmPackageJsonParseDetectableOptions = new NpmPackageJsonParseDetectableOptions(false, false);
 
         NpmPackageJsonParseDetectable detectable = new NpmPackageJsonParseDetectable(environment, fileFinder, null, npmPackageJsonParseDetectableOptions);
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
@@ -35,11 +35,11 @@ import com.synopsys.integration.bdio.graph.DependencyGraph;
 import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.bdio.model.externalid.ExternalId;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
-import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.annotations.UnitTest;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.PackageJsonExtractor;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.model.PackageJson;
+import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.util.graph.GraphAssert;
 
 @UnitTest
@@ -53,8 +53,8 @@ class PackageJsonExtractorTest {
 
     @BeforeEach
     void setUp() {
-        final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        final ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        ExternalIdFactory externalIdFactory = new ExternalIdFactory();
 
         testDep1 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "name1", "version1");
         testDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "name2", "version2");
@@ -64,14 +64,14 @@ class PackageJsonExtractorTest {
     }
 
     @Test
-    void extractWithNoDevDependencies() {
-        final PackageJson packageJson = createPackageJson();
-        final Extraction extraction = packageJsonExtractor.extract(packageJson, false);
+    void extractWithNoDevOrPeerDependencies() {
+        PackageJson packageJson = createPackageJson();
+        Extraction extraction = packageJsonExtractor.extract(packageJson, false, false);
         assertEquals(1, extraction.getCodeLocations().size());
-        final CodeLocation codeLocation = extraction.getCodeLocations().get(0);
-        final DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
+        CodeLocation codeLocation = extraction.getCodeLocations().get(0);
+        DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
 
-        final GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
+        GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
         graphAssert.hasRootDependency(testDep1);
         graphAssert.hasRootDependency(testDep2);
         graphAssert.hasNoDependency(testDevDep1);
@@ -80,14 +80,14 @@ class PackageJsonExtractorTest {
     }
 
     @Test
-    void extractWithDevDependencies() {
-        final PackageJson packageJson = createPackageJson();
-        final Extraction extraction = packageJsonExtractor.extract(packageJson, true);
+    void extractWithDevNoPeerDependencies() {
+        PackageJson packageJson = createPackageJson();
+        Extraction extraction = packageJsonExtractor.extract(packageJson, true, false);
         assertEquals(1, extraction.getCodeLocations().size());
-        final CodeLocation codeLocation = extraction.getCodeLocations().get(0);
-        final DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
+        CodeLocation codeLocation = extraction.getCodeLocations().get(0);
+        DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
 
-        final GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
+        GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
         graphAssert.hasRootDependency(testDep1);
         graphAssert.hasRootDependency(testDep2);
         graphAssert.hasRootDependency(testDevDep1);
@@ -96,7 +96,7 @@ class PackageJsonExtractorTest {
     }
 
     private PackageJson createPackageJson() {
-        final PackageJson packageJson = new PackageJson();
+        PackageJson packageJson = new PackageJson();
 
         packageJson.name = "test";
         packageJson.version = "test-version";

--- a/detectable/src/test/resources/detectables/functional/npm/package.json
+++ b/detectable/src/test/resources/detectables/functional/npm/package.json
@@ -8,5 +8,9 @@
   "devDependencies": {
     "nameDev1": "versionDev1",
     "nameDev2": "versionDev2"
+  },
+  "peerDependencies": {
+    "namePeer1": "versionPeer1",
+    "namePeer2": "versionPeer2"
   }
 }

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -779,6 +779,12 @@ public class DetectProperties {
             .setHelp("Set this value to false if you would like to exclude your dev dependencies when ran.")
             .setGroups(DetectGroup.NPM, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN);
 
+    public static final DetectProperty<BooleanProperty> DETECT_NPM_INCLUDE_PEER_DEPENDENCIES =
+        new DetectProperty<>(new BooleanProperty("detect.npm.include.peer.dependencies", true))
+            .setInfo("Include NPM Peer Dependencies", DetectPropertyFromVersion.VERSION_7_1_0)
+            .setHelp("Set this value to false if you would like to exclude your peer dependencies when ran.")
+            .setGroups(DetectGroup.NPM, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN);
+
     public static final DetectProperty<NullablePathProperty> DETECT_NPM_PATH =
         new DetectProperty<>(new NullablePathProperty("detect.npm.path"))
             .setInfo("NPM Executable", DetectPropertyFromVersion.VERSION_3_0_0)

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -195,7 +195,8 @@ public class DetectableOptionFactory {
 
     public NpmPackageJsonParseDetectableOptions createNpmPackageJsonParseDetectableOptions() {
         Boolean includeDevDependencies = getValue(DetectProperties.DETECT_NPM_INCLUDE_DEV_DEPENDENCIES);
-        return new NpmPackageJsonParseDetectableOptions(includeDevDependencies);
+        Boolean includePeerDependencies = getValue(DetectProperties.DETECT_NPM_INCLUDE_PEER_DEPENDENCIES);
+        return new NpmPackageJsonParseDetectableOptions(includeDevDependencies, includePeerDependencies);
     }
 
     public PearCliDetectableOptions createPearCliDetectableOptions() {


### PR DESCRIPTION
# Description
Introduces a new property `detect.npm.include.peer.dependencies` for including peer dependencies from NPM detectors.

```
    public static final DetectProperty<BooleanProperty> DETECT_NPM_INCLUDE_PEER_DEPENDENCIES =
        new DetectProperty<>(new BooleanProperty("detect.npm.include.peer.dependencies", true))
            .setInfo("Include NPM Peer Dependencies", DetectPropertyFromVersion.VERSION_7_1_0)
            .setHelp("Set this value to false if you would like to exclude your peer dependencies when ran.")
            .setGroups(DetectGroup.NPM, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN);
```

Also adds support for parsing the `peerDependencies` block within a `package.json` file for the `NpmPackageJsonParseDetectable`.

More PRs will come for the other NPM based Detectables.

# Jira Issues
IDETECT-2691: Peer Dependency Support - NpmPackageJsonParseDetectable
