### PR TITLE
Peer Dependency Support for NpmPackageLockDetectable

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -49,6 +49,11 @@ public class NpmDependencyConverter {
                 List<NpmRequires> rootDevRequires = convertNameVersionMapToRequires(packageJson.devDependencies);
                 project.addAllDevDependencies(rootDevRequires);
             }
+
+            if (packageJson.peerDependencies != null) {
+                List<NpmRequires> rootPeerRequires = convertNameVersionMapToRequires(packageJson.peerDependencies);
+                project.addAllPeerDependencies(rootPeerRequires);
+            }
         }
 
         return project;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -65,7 +65,7 @@ public class NpmDependencyConverter {
             String packageName = packageEntry.getKey();
             PackageLockDependency packageLockDependency = packageEntry.getValue();
 
-            NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev);
+            NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer);
             dependency.setParent(parent);
             children.add(dependency);
 
@@ -78,11 +78,12 @@ public class NpmDependencyConverter {
         return children;
     }
 
-    private NpmDependency createNpmDependency(String name, String version, Boolean isDev) {
+    private NpmDependency createNpmDependency(String name, String version, Boolean isDev, Boolean isPeer) {
         ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, name, version);
         Dependency graphDependency = new Dependency(name, version, externalId);
         boolean dev = isDev != null && isDev;
-        return new NpmDependency(name, version, dev, graphDependency);
+        boolean peer = isPeer != null && isPeer;
+        return new NpmDependency(name, version, dev, peer, graphDependency);
 
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmLockfileExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmLockfileExtractor.java
@@ -27,7 +27,7 @@ public class NpmLockfileExtractor {
     /*
     packageJson is optional
      */
-    public Extraction extract(File lockfile, File packageJson, boolean includeDevDependencies) {
+    public Extraction extract(File lockfile, File packageJson, boolean includeDevDependencies, boolean includePeerDependencies) {
         try {
             String lockText = FileUtils.readFileToString(lockfile, StandardCharsets.UTF_8);
             String packageText = null;
@@ -35,7 +35,7 @@ public class NpmLockfileExtractor {
                 packageText = FileUtils.readFileToString(packageJson, StandardCharsets.UTF_8);
             }
 
-            NpmParseResult result = npmLockfileParser.parse(packageText, lockText, includeDevDependencies);
+            NpmParseResult result = npmLockfileParser.parse(packageText, lockText, includeDevDependencies, includePeerDependencies);
 
             return new Extraction.Builder()
                        .success(result.getCodeLocation())

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmLockfileOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmLockfileOptions.java
@@ -9,12 +9,18 @@ package com.synopsys.integration.detectable.detectables.npm.lockfile;
 
 public class NpmLockfileOptions {
     final boolean includeDeveloperDependencies;
+    final boolean includePeerDependencies;
 
-    public NpmLockfileOptions(final boolean includeDeveloperDependencies) {
+    public NpmLockfileOptions(boolean includeDeveloperDependencies, boolean includePeerDependencies) {
         this.includeDeveloperDependencies = includeDeveloperDependencies;
+        this.includePeerDependencies = includePeerDependencies;
     }
 
     public boolean shouldIncludeDeveloperDependencies() {
         return includeDeveloperDependencies;
+    }
+
+    public boolean shouldIncludePeerDependencies() {
+        return includePeerDependencies;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmPackageLockDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmPackageLockDetectable.java
@@ -31,6 +31,7 @@ public class NpmPackageLockDetectable extends Detectable {
     private final FileFinder fileFinder;
     private final NpmLockfileExtractor npmLockfileExtractor;
     private final boolean includeDevDependencies;
+    private final boolean includePeerDependencies;
 
     private File lockfile;
     private File packageJson;
@@ -40,6 +41,7 @@ public class NpmPackageLockDetectable extends Detectable {
         this.fileFinder = fileFinder;
         this.npmLockfileExtractor = npmLockfileExtractor;
         this.includeDevDependencies = npmLockfileOptions.shouldIncludeDeveloperDependencies();
+        this.includePeerDependencies = npmLockfileOptions.shouldIncludePeerDependencies();
     }
 
     @Override
@@ -57,7 +59,7 @@ public class NpmPackageLockDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) {
-        return npmLockfileExtractor.extract(lockfile, packageJson, includeDevDependencies);
+        return npmLockfileExtractor.extract(lockfile, packageJson, includeDevDependencies, includePeerDependencies);
     }
 
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/NpmDependency.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/NpmDependency.java
@@ -18,12 +18,14 @@ public class NpmDependency {
     private final String name;
     private final String version;
     private final boolean devDependency;
+    private final boolean peerDependency;
     private final Dependency dependency;
 
-    public NpmDependency(final String name, final String version, final boolean devDependency, final Dependency dependency) {
+    public NpmDependency(String name, String version, boolean devDependency, boolean peerDependency, Dependency dependency) {
         this.name = name;
         this.version = version;
         this.devDependency = devDependency;
+        this.peerDependency = peerDependency;
         this.dependency = dependency;
     }
 
@@ -35,15 +37,15 @@ public class NpmDependency {
         return Optional.ofNullable(parent);
     }
 
-    public void setParent(final NpmDependency parent) {
+    public void setParent(NpmDependency parent) {
         this.parent = parent;
     }
 
-    public void addAllRequires(final Collection<NpmRequires> required) {
+    public void addAllRequires(Collection<NpmRequires> required) {
         this.requires.addAll(required);
     }
 
-    public void addAllDependencies(final Collection<NpmDependency> dependencies) {
+    public void addAllDependencies(Collection<NpmDependency> dependencies) {
         this.dependencies.addAll(dependencies);
     }
 
@@ -65,6 +67,10 @@ public class NpmDependency {
 
     public boolean isDevDependency() {
         return devDependency;
+    }
+
+    public boolean isPeerDependency() {
+        return peerDependency;
     }
 
     public Dependency getGraphDependency() {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/NpmProject.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/NpmProject.java
@@ -16,6 +16,7 @@ public class NpmProject {
     private final String version;
 
     private final List<NpmRequires> declaredDevDependencies = new ArrayList<>();
+    private final List<NpmRequires> declaredPeerDependencies = new ArrayList<>();
     private final List<NpmRequires> declaredDependencies = new ArrayList<>();
 
     private final List<NpmDependency> resolvedDependencies = new ArrayList<>();
@@ -27,6 +28,10 @@ public class NpmProject {
 
     public void addAllDevDependencies(Collection<NpmRequires> requires) {
         this.declaredDevDependencies.addAll(requires);
+    }
+
+    public void addAllPeerDependencies(Collection<NpmRequires> requires) {
+        this.declaredPeerDependencies.addAll(requires);
     }
 
     public void addAllDependencies(Collection<NpmRequires> requires) {
@@ -51,6 +56,10 @@ public class NpmProject {
 
     public List<NpmRequires> getDeclaredDevDependencies() {
         return declaredDevDependencies;
+    }
+
+    public List<NpmRequires> getDeclaredPeerDependencies() {
+        return declaredPeerDependencies;
     }
 
     public List<NpmDependency> getResolvedDependencies() {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/PackageLock.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/PackageLock.java
@@ -11,9 +11,7 @@ import java.util.Map;
 
 import com.google.gson.annotations.SerializedName;
 
-public class
-
-PackageLock {
+public class PackageLock {
     @SerializedName("name")
     public String name;
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/PackageLockDependency.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/PackageLockDependency.java
@@ -18,6 +18,9 @@ public class PackageLockDependency {
     @SerializedName("dev")
     public Boolean dev;
 
+    @SerializedName("peer")
+    public Boolean peer;
+
     @SerializedName("requires")
     public Map<String, String> requires;
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
@@ -67,11 +67,16 @@ public class NpmLockfilePackager {
             }
 
             //Then we will add relationships between the project (root) and the graph
-            boolean atLeastOneRequired = !project.getDeclaredDependencies().isEmpty() || !project.getDeclaredDevDependencies().isEmpty();
+            boolean atLeastOneRequired = !project.getDeclaredDependencies().isEmpty()
+                                             || !project.getDeclaredDevDependencies().isEmpty()
+                                             || !project.getDeclaredPeerDependencies().isEmpty();
             if (atLeastOneRequired) {
                 addRootDependencies(project.getResolvedDependencies(), project.getDeclaredDependencies(), dependencyGraph, externalDependencies);
                 if (includeDevDependencies) {
                     addRootDependencies(project.getResolvedDependencies(), project.getDeclaredDevDependencies(), dependencyGraph, externalDependencies);
+                }
+                if (includePeerDependencies) {
+                    addRootDependencies(project.getResolvedDependencies(), project.getDeclaredPeerDependencies(), dependencyGraph, externalDependencies);
                 }
             } else {
                 project.getResolvedDependencies()
@@ -161,6 +166,8 @@ public class NpmLockfilePackager {
     private boolean shouldIncludeDependency(NpmDependency packageLockDependency, boolean includeDevDependencies, boolean includePeerDependencies) {
         if (packageLockDependency.isDevDependency()) {
             return includeDevDependencies;
+        } else if (packageLockDependency.isPeerDependency()) {
+            return includePeerDependencies;
         }
         return true;
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
@@ -42,11 +42,11 @@ public class NpmLockfilePackager {
         this.externalIdFactory = externalIdFactory;
     }
 
-    public NpmParseResult parse(@Nullable String packageJsonText, String lockFileText, boolean includeDevDependencies) {
-        return parse(packageJsonText, lockFileText, includeDevDependencies, new ArrayList<>());
+    public NpmParseResult parse(@Nullable String packageJsonText, String lockFileText, boolean includeDevDependencies, boolean includePeerDependencies) {
+        return parse(packageJsonText, lockFileText, includeDevDependencies, includePeerDependencies, new ArrayList<>());
     }
 
-    public NpmParseResult parse(@Nullable String packageJsonText, String lockFileText, boolean includeDevDependencies, List<NameVersion> externalDependencies) {
+    public NpmParseResult parse(@Nullable String packageJsonText, String lockFileText, boolean includeDevDependencies, boolean includePeerDependencies, List<NameVersion> externalDependencies) {
         MutableDependencyGraph dependencyGraph = new MutableMapDependencyGraph();
 
         Optional<PackageJson> packageJson = Optional.ofNullable(packageJsonText)
@@ -63,7 +63,7 @@ public class NpmLockfilePackager {
 
             //First we will recreate the graph from the resolved npm dependencies
             for (NpmDependency resolved : project.getResolvedDependencies()) {
-                transformTreeToGraph(resolved, project, dependencyGraph, includeDevDependencies, externalDependencies);
+                transformTreeToGraph(resolved, project, dependencyGraph, includeDevDependencies, includePeerDependencies, externalDependencies);
             }
 
             //Then we will add relationships between the project (root) and the graph
@@ -106,8 +106,8 @@ public class NpmLockfilePackager {
         }
     }
 
-    private void transformTreeToGraph(NpmDependency npmDependency, NpmProject npmProject, MutableDependencyGraph dependencyGraph, boolean includeDevDependencies, List<NameVersion> externalDependencies) {
-        if (!shouldIncludeDependency(npmDependency, includeDevDependencies)) {
+    private void transformTreeToGraph(NpmDependency npmDependency, NpmProject npmProject, MutableDependencyGraph dependencyGraph, boolean includeDevDependencies, boolean includePeerDependencies, List<NameVersion> externalDependencies) {
+        if (!shouldIncludeDependency(npmDependency, includeDevDependencies, includePeerDependencies)) {
             return;
         }
 
@@ -122,7 +122,7 @@ public class NpmLockfilePackager {
             }
         });
 
-        npmDependency.getDependencies().forEach(child -> transformTreeToGraph(child, npmProject, dependencyGraph, includeDevDependencies, externalDependencies));
+        npmDependency.getDependencies().forEach(child -> transformTreeToGraph(child, npmProject, dependencyGraph, includeDevDependencies, includePeerDependencies, externalDependencies));
     }
 
     private Dependency lookupProjectOrExternal(String name, List<NpmDependency> projectResolvedDependencies, List<NameVersion> externalDependencies) {
@@ -158,7 +158,7 @@ public class NpmLockfilePackager {
         return null;
     }
 
-    private boolean shouldIncludeDependency(NpmDependency packageLockDependency, boolean includeDevDependencies) {
+    private boolean shouldIncludeDependency(NpmDependency packageLockDependency, boolean includeDevDependencies, boolean includePeerDependencies) {
         if (packageLockDependency.isDevDependency()) {
             return includeDevDependencies;
         }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmLockDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmLockDetectableTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Assertions;
 import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.detectable.Detectable;
 import com.synopsys.integration.detectable.DetectableEnvironment;
-import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.NpmLockfileOptions;
+import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.functional.DetectableFunctionalTest;
 import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
 
@@ -50,6 +50,12 @@ public class NpmLockDetectableTest extends DetectableFunctionalTest {
             "           \"resolved\": \"https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\",",
             "           \"integrity\": \"sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=\",",
             "           \"dev\": true",
+            "       },",
+            "       \"peer-example\": {",
+            "           \"version\": \"1.0.0\",",
+            "           \"resolved\": \"https://synopsys.com/404/peer-example.tgz\",",
+            "           \"integrity\": \"sha1-1Klr13/Wjfd5OnMDajug1UBdR3s=\",",
+            "           \"peer\": true",
             "       }",
             "   }",
             "}"
@@ -58,17 +64,18 @@ public class NpmLockDetectableTest extends DetectableFunctionalTest {
 
     @NotNull
     @Override
-    public Detectable create(@NotNull final DetectableEnvironment environment) {
-        return detectableFactory.createNpmPackageLockDetectable(environment, new NpmLockfileOptions(true));
+    public Detectable create(@NotNull DetectableEnvironment environment) {
+        return detectableFactory.createNpmPackageLockDetectable(environment, new NpmLockfileOptions(true, true));
     }
 
     @Override
-    public void assertExtraction(@NotNull final Extraction extraction) {
+    public void assertExtraction(@NotNull Extraction extraction) {
         Assertions.assertEquals(1, extraction.getCodeLocations().size(), "A code location should have been generated.");
 
-        final NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, extraction.getCodeLocations().get(0).getDependencyGraph());
+        NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, extraction.getCodeLocations().get(0).getDependencyGraph());
 
-        graphAssert.hasRootSize(3);
+        graphAssert.hasRootSize(4);
+        graphAssert.hasRootDependency("peer-example", "1.0.0");
         graphAssert.hasRootDependency("brace-expansion", "1.1.8");
         graphAssert.hasRootDependency("balanced-match", "1.0.0");
         graphAssert.hasRootDependency("concat-map", "0.0.1");

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmPeerExclusionTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmPeerExclusionTest.java
@@ -36,9 +36,9 @@ import com.synopsys.integration.detectable.util.FunctionalTestFiles;
 import com.synopsys.integration.detectable.util.graph.GraphAssert;
 
 @FunctionalTest
-public class NpmDevExclusionTest {
-    ExternalId childDev;
-    ExternalId parentDev;
+public class NpmPeerExclusionTest {
+    ExternalId childPeer;
+    ExternalId parentPeer;
     NpmLockfilePackager npmLockfileParser;
     String packageJsonText;
     String packageLockText;
@@ -49,28 +49,28 @@ public class NpmDevExclusionTest {
 
         npmLockfileParser = new NpmLockfilePackager(new GsonBuilder().setPrettyPrinting().create(), externalIdFactory);
 
-        packageJsonText = FunctionalTestFiles.asString("/npm/dev-exclusion-test/package.json");
-        packageLockText = FunctionalTestFiles.asString("/npm/dev-exclusion-test/package-lock.json");
+        packageJsonText = FunctionalTestFiles.asString("/npm/peer-exclusion-test/package.json");
+        packageLockText = FunctionalTestFiles.asString("/npm/peer-exclusion-test/package-lock.json");
 
-        childDev = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "child-dev", "3.0.0");
-        parentDev = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "parent-dev", "2.0.0");
+        childPeer = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "child-peer", "3.0.0");
+        parentPeer = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "parent-peer", "2.0.0");
     }
 
     @Test
-    public void testDevDependencyNotExists() {
+    public void testPeerDependencyNotExists() {
         NpmParseResult result = npmLockfileParser.parse(packageJsonText, packageLockText, false, false);
         GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, result.getCodeLocation().getDependencyGraph());
-        graphAssert.hasNoDependency(childDev);
-        graphAssert.hasNoDependency(parentDev);
+        graphAssert.hasNoDependency(childPeer);
+        graphAssert.hasNoDependency(parentPeer);
         graphAssert.hasRootSize(0);
     }
 
     @Test
-    public void testDevDependencyExists() {
-        NpmParseResult result = npmLockfileParser.parse(packageJsonText, packageLockText, true, false);
+    public void testPeerDependencyExists() {
+        NpmParseResult result = npmLockfileParser.parse(packageJsonText, packageLockText, false, true);
         GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, result.getCodeLocation().getDependencyGraph());
-        graphAssert.hasDependency(childDev);
-        graphAssert.hasDependency(parentDev);
+        graphAssert.hasDependency(childPeer);
+        graphAssert.hasDependency(parentPeer);
         graphAssert.hasRootSize(1);
     }
 }

--- a/detectable/src/test/resources/detectables/functional/npm/peer-exclusion-test/package-lock.json
+++ b/detectable/src/test/resources/detectables/functional/npm/peer-exclusion-test/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "npm-dev",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "child-peer": {
+      "version": "3.0.0",
+      "peer": true
+    },
+    "parent-peer": {
+      "version": "2.0.0",
+      "peer": true,
+      "requires": {
+        "child-peer": "3.0.0"
+      }
+    }
+  }
+}

--- a/detectable/src/test/resources/detectables/functional/npm/peer-exclusion-test/package.json
+++ b/detectable/src/test/resources/detectables/functional/npm/peer-exclusion-test/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "npm-dev",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "peerDependencies": {
+    "parent-peer": "^2.0.0"
+  }
+}

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -190,7 +190,8 @@ public class DetectableOptionFactory {
 
     public NpmLockfileOptions createNpmLockfileOptions() {
         Boolean includeDevDependencies = getValue(DetectProperties.DETECT_NPM_INCLUDE_DEV_DEPENDENCIES);
-        return new NpmLockfileOptions(includeDevDependencies);
+        Boolean includePeerDependencies = getValue(DetectProperties.DETECT_NPM_INCLUDE_PEER_DEPENDENCIES);
+        return new NpmLockfileOptions(includeDevDependencies, includePeerDependencies);
     }
 
     public NpmPackageJsonParseDetectableOptions createNpmPackageJsonParseDetectableOptions() {


### PR DESCRIPTION
# Description
Adds support for [peerDependencies](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies) with the `NpmPackageLockDetectable`.
The PR is broken into three commits for readability. 
Commit 7557dda is where the logic changes are happening.

# Jira Issues
IDETECT-2692: Peer Dependency Support - NpmPackageLockDetectable
