### PR TITLE
Peer Dependency Support for NpmShrinkwrapDetectable

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmShrinkwrapDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmShrinkwrapDetectable.java
@@ -32,6 +32,7 @@ public class NpmShrinkwrapDetectable extends Detectable {
     private final FileFinder fileFinder;
     private final NpmLockfileExtractor npmLockfileExtractor;
     private final boolean includeDevDependencies;
+    private final boolean includePeerDependencies;
 
     private File lockfile;
     private File packageJson;
@@ -41,6 +42,7 @@ public class NpmShrinkwrapDetectable extends Detectable {
         this.fileFinder = fileFinder;
         this.npmLockfileExtractor = npmLockfileExtractor;
         this.includeDevDependencies = npmLockfileOptions.shouldIncludeDeveloperDependencies();
+        this.includePeerDependencies = npmLockfileOptions.shouldIncludePeerDependencies();
     }
 
     @Override
@@ -58,7 +60,7 @@ public class NpmShrinkwrapDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment environment) {
-        return npmLockfileExtractor.extract(lockfile, packageJson, includeDevDependencies);
+        return npmLockfileExtractor.extract(lockfile, packageJson, includeDevDependencies, includePeerDependencies);
     }
 
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmShrinkwrapDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmShrinkwrapDetectableTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Assertions;
 import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.detectable.Detectable;
 import com.synopsys.integration.detectable.DetectableEnvironment;
-import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.NpmLockfileOptions;
+import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.functional.DetectableFunctionalTest;
 import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
 
@@ -53,6 +53,10 @@ public class NpmShrinkwrapDetectableTest extends DetectableFunctionalTest {
             "       \"negotiator\": {",
             "           \"version\": \"https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz\",",
             "           \"integrity\": \"sha1-wY29fHOl2/b0SgJNwNFloeexw5I=\"",
+            "       },",
+            "       \"peer-example\": {",
+            "           \"version\": \"1.0.0\",",
+            "           \"integrity\": \"sha1-wY36fHOl2/b0SgJNwNFloeexw57=\"",
             "       }",
             "   }",
             "}"
@@ -61,22 +65,23 @@ public class NpmShrinkwrapDetectableTest extends DetectableFunctionalTest {
 
     @NotNull
     @Override
-    public Detectable create(@NotNull final DetectableEnvironment detectableEnvironment) {
-        return detectableFactory.createNpmShrinkwrapDetectable(detectableEnvironment, new NpmLockfileOptions(true));
+    public Detectable create(@NotNull DetectableEnvironment detectableEnvironment) {
+        return detectableFactory.createNpmShrinkwrapDetectable(detectableEnvironment, new NpmLockfileOptions(true, true));
     }
 
     @Override
-    public void assertExtraction(@NotNull final Extraction extraction) {
+    public void assertExtraction(@NotNull Extraction extraction) {
         Assertions.assertEquals(1, extraction.getCodeLocations().size(), "A code location should have been generated.");
 
-        final NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, extraction.getCodeLocations().get(0).getDependencyGraph());
+        NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, extraction.getCodeLocations().get(0).getDependencyGraph());
 
-        graphAssert.hasRootSize(5);
+        graphAssert.hasRootSize(6);
         graphAssert.hasRootDependency("abbrev", "1.0.9");
         graphAssert.hasRootDependency("accepts", "1.3.3");
         graphAssert.hasRootDependency("mime-types", "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz");
         graphAssert.hasRootDependency("mime-db", "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz");
         graphAssert.hasRootDependency("negotiator", "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz");
+        graphAssert.hasRootDependency("peer-example", "1.0.0");
         graphAssert.hasParentChildRelationship("accepts", "1.3.3", "mime-types", "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz");
         graphAssert.hasParentChildRelationship("mime-types", "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz", "mime-db", "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz");
         graphAssert.hasParentChildRelationship("accepts", "1.3.3", "negotiator", "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz");


### PR DESCRIPTION
# Description
Adds support for [peerDependencies](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies) with the `NpmShrinkwrapDetectable`.
Most of the logic is shared with PR#417

# Jira Issues
IDETECT-2693: Peer Dependency Support - NpmShrinkwrapDetectable
