### PR TITLE
Peer Dependency Support for Lerna

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/lerna/LernaPackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/lerna/LernaPackager.java
@@ -147,10 +147,18 @@ public class LernaPackager {
         }
 
         if (lockFile.getNpmLockContents().isPresent()) {
-            //TODO: What if the NPM result is FAILED?
-            NpmParseResult npmParseResult = npmLockfileParser
-                                                .parse(packageJsonContents, lockFile.getNpmLockContents().get(), npmLockfileOptions.shouldIncludeDeveloperDependencies(), externalPackages);
-            return LernaResult.success(npmParseResult.getProjectName(), npmParseResult.getProjectVersion(), Collections.singletonList(npmParseResult.getCodeLocation()));
+            try {
+                NpmParseResult npmParseResult = npmLockfileParser.parse(
+                    packageJsonContents,
+                    lockFile.getNpmLockContents().get(),
+                    npmLockfileOptions.shouldIncludeDeveloperDependencies(),
+                    npmLockfileOptions.shouldIncludePeerDependencies(),
+                    externalPackages
+                );
+                return LernaResult.success(npmParseResult.getProjectName(), npmParseResult.getProjectVersion(), Collections.singletonList(npmParseResult.getCodeLocation()));
+            } catch (Exception exception) {
+                return LernaResult.failure(exception);
+            }
         } else if (lockFile.getYarnLockContents().isPresent()) {
             YarnLock yarnLock = yarnLockParser.parseYarnLock(lockFile.getYarnLockContents().get());
             NullSafePackageJson rootPackageJson = packageJsonReader.read(packageJsonContents);

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/lerna/unit/LernaExternalDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/lerna/unit/LernaExternalDetectableTest.java
@@ -96,7 +96,7 @@ public class LernaExternalDetectableTest extends DetectableFunctionalTest {
     @NotNull
     @Override
     public Detectable create(@NotNull DetectableEnvironment environment) {
-        NpmLockfileOptions npmLockFileOptions = new NpmLockfileOptions(true);
+        NpmLockfileOptions npmLockFileOptions = new NpmLockfileOptions(true, true);
         YarnLockOptions yarnLockOptions = new YarnLockOptions(false, new ArrayList<>(0), new ArrayList<>(0));
         LernaOptions lernaOptions = new LernaOptions(false, new LinkedList<>(), new LinkedList<>());
         return detectableFactory.createLernaDetectable(environment, () -> ExecutableTarget.forCommand("lerna"), npmLockFileOptions, yarnLockOptions, lernaOptions);


### PR DESCRIPTION
# Description
Adds support for [peerDependencies](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies) with the `LernaDetectable`.
Lerna uses a lot of code from Npm as well as Yarn Detectables. This allows most of the support comming from PR #417.

# Jira Issues
IDETECT-2702: Peer Dependency Support - LernaDetectable
