### PR TITLE
NPM Cli - Peer Dependency Support

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliDetectable.java
@@ -70,7 +70,14 @@ public class NpmCliDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) {
-        return npmCliExtractor.extract(environment.getDirectory(), npmExe, npmCliExtractorOptions, npmPackageJsonNameVersionExtractor.extract(packageJson));
+        return npmCliExtractor.extract(
+            environment.getDirectory(),
+            npmExe,
+            npmCliExtractorOptions.getNpmArguments().orElse(null),
+            npmCliExtractorOptions.shouldIncludeDevDependencies(),
+            npmCliExtractorOptions.shouldIncludePeerDependencies(),
+            packageJson
+        );
     }
 
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
@@ -26,6 +26,7 @@ import com.synopsys.integration.detectable.ExecutableTarget;
 import com.synopsys.integration.detectable.ExecutableUtils;
 import com.synopsys.integration.detectable.detectable.executable.DetectableExecutableRunner;
 import com.synopsys.integration.detectable.detectables.npm.cli.parse.NpmCliParser;
+import com.synopsys.integration.detectable.detectables.npm.cli.parse.NpmDependencyTypeFilter;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmParseResult;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.model.PackageJson;
 import com.synopsys.integration.detectable.extraction.Extraction;
@@ -77,7 +78,8 @@ public class NpmCliExtractor {
         } else if (StringUtils.isNotBlank(standardOutput)) {
             logger.debug("Parsing npm ls file.");
             logger.debug(standardOutput);
-            NpmParseResult result = npmCliParser.generateCodeLocation(standardOutput);
+            NpmDependencyTypeFilter npmDependencyTypeFilter = new NpmDependencyTypeFilter(packageJson.devDependencies.keySet(), packageJson.peerDependencies.keySet(), includeDevDependencies, includePeerDependencies);
+            NpmParseResult result = npmCliParser.generateCodeLocation(standardOutput, npmDependencyTypeFilter);
             String projectName = result.getProjectName() != null ? result.getProjectName() : packageJson.name;
             String projectVersion = result.getProjectVersion() != null ? result.getProjectVersion() : packageJson.version;
             return new Extraction.Builder().success(result.getCodeLocation()).projectName(projectName).projectVersion(projectVersion).build();

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
@@ -8,22 +8,28 @@
 package com.synopsys.integration.detectable.detectables.npm.cli;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
 import com.synopsys.integration.detectable.ExecutableTarget;
 import com.synopsys.integration.detectable.ExecutableUtils;
 import com.synopsys.integration.detectable.detectable.executable.DetectableExecutableRunner;
 import com.synopsys.integration.detectable.detectables.npm.cli.parse.NpmCliParser;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmParseResult;
+import com.synopsys.integration.detectable.detectables.npm.packagejson.model.PackageJson;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.executable.ExecutableOutput;
-import com.synopsys.integration.util.NameVersion;
 
 public class NpmCliExtractor {
     public static final String OUTPUT_FILE = "detect_npm_proj_dependencies.json";
@@ -32,20 +38,25 @@ public class NpmCliExtractor {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final DetectableExecutableRunner executableRunner;
     private final NpmCliParser npmCliParser;
+    private final Gson gson;
 
-    public NpmCliExtractor(DetectableExecutableRunner executableRunner, NpmCliParser npmCliParser) {
+    public NpmCliExtractor(DetectableExecutableRunner executableRunner, NpmCliParser npmCliParser, Gson gson) {
         this.executableRunner = executableRunner;
         this.npmCliParser = npmCliParser;
+        this.gson = gson;
     }
 
-    public Extraction extract(File directory, ExecutableTarget npmExe, NpmCliExtractorOptions npmCliExtractorOptions, NameVersion packageJsonNameVersion) {//TODO: Extractor should not use DetectableOptions
+    public Extraction extract(File directory, ExecutableTarget npmExe, @Nullable String npmArguments, boolean includeDevDependencies, boolean includePeerDependencies, File packageJsonFile) {
+        PackageJson packageJson;
+        try {
+            packageJson = parsePackageJson(packageJsonFile);
+        } catch (IOException e) {
+            return new Extraction.Builder().exception(e).build();
+        }
 
         List<String> exeArgs = new ArrayList<>();
         exeArgs.add("ls");
         exeArgs.add("-json");
-        if (!includeDevDeps) {
-            exeArgs.add("-prod");
-        }
 
         Optional.ofNullable(npmArguments)
             .map(arg -> arg.split(" "))
@@ -67,12 +78,17 @@ public class NpmCliExtractor {
             logger.debug("Parsing npm ls file.");
             logger.debug(standardOutput);
             NpmParseResult result = npmCliParser.generateCodeLocation(standardOutput);
-            String projectName = result.getProjectName() != null ? result.getProjectName() : packageJsonNameVersion.getName();
-            String projectVersion = result.getProjectVersion() != null ? result.getProjectVersion() : packageJsonNameVersion.getVersion();
+            String projectName = result.getProjectName() != null ? result.getProjectName() : packageJson.name;
+            String projectVersion = result.getProjectVersion() != null ? result.getProjectVersion() : packageJson.version;
             return new Extraction.Builder().success(result.getCodeLocation()).projectName(projectName).projectVersion(projectVersion).build();
         } else {
             logger.error("Nothing returned from npm ls -json command");
             return new Extraction.Builder().failure("Npm returned error after running npm ls.").build();
         }
+    }
+
+    private PackageJson parsePackageJson(File packageJson) throws IOException {
+        String packageJsonText = FileUtils.readFileToString(packageJson, StandardCharsets.UTF_8);
+        return gson.fromJson(packageJsonText, PackageJson.class);
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
@@ -40,7 +40,6 @@ public class NpmCliExtractor {
 
     public Extraction extract(File directory, ExecutableTarget npmExe, NpmCliExtractorOptions npmCliExtractorOptions, NameVersion packageJsonNameVersion) {//TODO: Extractor should not use DetectableOptions
 
-        boolean includeDevDeps = npmCliExtractorOptions.shouldIncludeDevDependencies();
         List<String> exeArgs = new ArrayList<>();
         exeArgs.add("ls");
         exeArgs.add("-json");
@@ -48,7 +47,7 @@ public class NpmCliExtractor {
             exeArgs.add("-prod");
         }
 
-        npmCliExtractorOptions.getNpmArguments()
+        Optional.ofNullable(npmArguments)
             .map(arg -> arg.split(" "))
             .ifPresent(additionalArguments -> exeArgs.addAll(Arrays.asList(additionalArguments)));
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractorOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractorOptions.java
@@ -11,15 +11,21 @@ import java.util.Optional;
 
 public class NpmCliExtractorOptions {
     private final boolean includeDevDependencies;
+    private final boolean includePeerDependencies;
     private final String npmArguments;
 
-    public NpmCliExtractorOptions(final boolean includeDevDependencies, final String npmArguments) {
+    public NpmCliExtractorOptions(boolean includeDevDependencies, boolean includePeerDependencies, String npmArguments) {
         this.includeDevDependencies = includeDevDependencies;
+        this.includePeerDependencies = includePeerDependencies;
         this.npmArguments = npmArguments;
     }
 
     public boolean shouldIncludeDevDependencies() {
         return includeDevDependencies;
+    }
+
+    public boolean shouldIncludePeerDependencies() {
+        return includePeerDependencies;
     }
 
     public Optional<String> getNpmArguments() {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/parse/NpmDependencyTypeFilter.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/parse/NpmDependencyTypeFilter.java
@@ -1,0 +1,29 @@
+package com.synopsys.integration.detectable.detectables.npm.cli.parse;
+
+import java.util.Set;
+
+public class NpmDependencyTypeFilter {
+    private final Set<String> devDependencies;
+    private final Set<String> peerDependencies;
+    private final boolean includeDevDependencies;
+    private final boolean includePeerDependencies;
+
+    public NpmDependencyTypeFilter(Set<String> devDependencies, Set<String> peerDependencies, boolean includeDevDependencies, boolean includePeerDependencies) {
+        this.devDependencies = devDependencies;
+        this.peerDependencies = peerDependencies;
+        this.includeDevDependencies = includeDevDependencies;
+        this.includePeerDependencies = includePeerDependencies;
+    }
+
+    public boolean shouldInclude(String dependencyName, boolean isRootDependency) {
+        if (!isRootDependency) {
+            return true;
+        }
+
+        boolean excludeDev = !includeDevDependencies && devDependencies.contains(dependencyName);
+        boolean excludePeer = !includePeerDependencies && peerDependencies.contains(dependencyName);
+
+        return !(excludeDev || excludePeer);
+
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/parse/NpmDependencyTypeFilter.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/parse/NpmDependencyTypeFilter.java
@@ -1,3 +1,10 @@
+/*
+ * detectable
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.detectable.detectables.npm.cli.parse;
 
 import java.util.Set;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -625,7 +625,7 @@ public class DetectableFactory {
     }
 
     private NpmCliExtractor npmCliExtractor() {
-        return new NpmCliExtractor(executableRunner, npmCliDependencyFinder());
+        return new NpmCliExtractor(executableRunner, npmCliDependencyFinder(), gson);
     }
 
     private NpmPackageJsonNameVersionExtractor npmPackageJsonDiscoverer() {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmCliDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmCliDetectableTest.java
@@ -47,7 +47,7 @@ public class NpmCliDetectableTest {
         DetectableEnvironment environment = MockDetectableEnvironment.empty();
         FileFinder fileFinder = MockFileFinder.withFileNamed("package.json");
 
-        NpmCliDetectable detectable = new NpmCliDetectable(environment, fileFinder, npmResolver, npmCliExtractor, new NpmPackageJsonNameVersionExtractor(new Gson()), new NpmCliExtractorOptions(false, ""));
+        NpmCliDetectable detectable = new NpmCliDetectable(environment, fileFinder, npmResolver, npmCliExtractor, new NpmPackageJsonNameVersionExtractor(new Gson()), new NpmCliExtractorOptions(false, false, ""));
 
         assertTrue(detectable.applicable().getPassed());
     }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
@@ -1,3 +1,10 @@
+/*
+ * detectable
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.detectable.detectables.npm.cli.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,7 +20,7 @@ import com.synopsys.integration.detectable.detectables.npm.cli.parse.NpmDependen
 import com.synopsys.integration.util.Stringable;
 
 class NpmDependencyTypeFilterTest {
-    
+
     @ParameterizedTest()
     @MethodSource("generateTest")
     void includeDependencies(TestParameter testParameter) {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
@@ -88,12 +88,10 @@ class NpmDependencyTypeFilterTest {
     static Stream<TestParameter> shouldNotIncludeSource() {
         return Stream.<TestParameter>builder()
                    // Dev Dependencies
-                   // isDevDependency = true
                    .add(TestParameter.dev(false, false, true))
                    .add(TestParameter.dev(false, true, true))
 
                    // Peer Dependencies
-                   // isPeerDependency = true
                    .add(TestParameter.peer(false, false, true))
                    .add(TestParameter.peer(true, false, true))
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
@@ -1,0 +1,92 @@
+package com.synopsys.integration.detectable.detectables.npm.cli.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.synopsys.integration.detectable.detectables.npm.cli.parse.NpmDependencyTypeFilter;
+import com.synopsys.integration.util.Stringable;
+
+class NpmDependencyTypeFilterTest {
+    
+    @ParameterizedTest()
+    @MethodSource("generateTest")
+    void includeDependencies(TestParameter testParameter) {
+        Set<String> devDependencies = Collections.singleton("test-dev");
+        Set<String> peerDependencies = Collections.singleton("test-peer");
+
+        NpmDependencyTypeFilter npmDependencyTypeFilter = new NpmDependencyTypeFilter(devDependencies, peerDependencies, testParameter.includeDevDependencies, testParameter.includePeerDependencies);
+        String dependencyName = "test";
+        if (testParameter.isDevDependency) {
+            dependencyName = "test-dev";
+        } else if (testParameter.isPeerDependency) {
+            dependencyName = "test-peer";
+        }
+        boolean actual = npmDependencyTypeFilter.shouldInclude(dependencyName, testParameter.isRootDependency);
+        assertEquals(testParameter.shouldInclude, actual, "TestParameters: " + testParameter);
+    }
+
+    static Stream<TestParameter> generateTest() {
+        return Stream.<TestParameter>builder()
+                   // Dev Dependencies
+                   // isDevDependency = true
+                   .add(new TestParameter(true, false, true, false, true, true))
+                   .add(new TestParameter(true, false, true, false, false, true))
+                   .add(new TestParameter(false, false, true, false, false, true))
+                   .add(new TestParameter(false, false, true, false, true, false))
+                   // isDevDependency = false
+                   .add(new TestParameter(true, false, false, false, true, true))
+                   .add(new TestParameter(true, false, false, false, false, true))
+                   .add(new TestParameter(false, false, false, false, false, true))
+                   .add(new TestParameter(false, false, false, false, true, true))
+
+                   // Peer Dependencies
+                   // isPeerDependency = true
+                   .add(new TestParameter(false, true, false, true, true, true))
+                   .add(new TestParameter(false, true, false, true, false, true))
+                   .add(new TestParameter(false, false, false, true, true, false))
+                   .add(new TestParameter(false, false, false, true, false, true))
+                   // isPeerDependency = false
+                   .add(new TestParameter(false, true, false, false, true, true))
+                   .add(new TestParameter(false, true, false, false, false, true))
+                   .add(new TestParameter(false, false, false, false, true, true))
+                   .add(new TestParameter(false, false, false, false, false, true))
+
+                   // Together
+                   // Include Both Types
+                   .add(new TestParameter(true, true, true, false, true, true))
+                   .add(new TestParameter(true, true, true, false, false, true))
+                   .add(new TestParameter(true, true, false, true, true, true))
+                   .add(new TestParameter(true, true, false, true, false, true))
+                   // Exclude Both types
+                   .add(new TestParameter(false, false, true, false, true, false))
+                   .add(new TestParameter(false, false, true, false, false, true))
+                   .add(new TestParameter(false, false, false, true, true, false))
+                   .add(new TestParameter(false, false, false, true, false, true))
+
+                   .build();
+    }
+
+    private static class TestParameter extends Stringable {
+        public final boolean includeDevDependencies;
+        public final boolean includePeerDependencies;
+        public final boolean isDevDependency;
+        public final boolean isPeerDependency;
+        public final boolean isRootDependency;
+        public final boolean shouldInclude;
+
+        public TestParameter(boolean includeDevDependencies, boolean includePeerDependencies, boolean isDevDependency, boolean isPeerDependency, boolean isRootDependency, boolean shouldInclude) {
+            this.includeDevDependencies = includeDevDependencies;
+            this.includePeerDependencies = includePeerDependencies;
+            this.isDevDependency = isDevDependency;
+            this.isPeerDependency = isPeerDependency;
+            this.isRootDependency = isRootDependency;
+            this.shouldInclude = shouldInclude;
+        }
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
@@ -55,31 +55,33 @@ class NpmDependencyTypeFilterTest {
         return Stream.<TestParameter>builder()
                    // Dev Dependencies
                    // isDevDependency = true
-                   .add(new TestParameter(true, false, true, false, true))
-                   .add(new TestParameter(true, false, true, false, false))
-                   .add(new TestParameter(false, false, true, false, false))
+                   .add(TestParameter.dev(true, false, true))
+                   .add(TestParameter.dev(true, false, false))
+                   .add(TestParameter.dev(false, false, false))
                    // isDevDependency = false
-                   .add(new TestParameter(true, false, false, false, true))
-                   .add(new TestParameter(true, false, false, false, false))
-                   .add(new TestParameter(false, false, false, false, false))
-                   .add(new TestParameter(false, false, false, false, true))
+                   .add(TestParameter.reg(true, false, true))
+                   .add(TestParameter.reg(true, false, false))
+                   .add(TestParameter.reg(false, false, false))
+                   .add(TestParameter.reg(false, false, true))
 
                    // Peer Dependencies
                    // isPeerDependency = true
-                   .add(new TestParameter(false, true, false, true, true))
-                   .add(new TestParameter(false, true, false, true, false))
-                   .add(new TestParameter(false, false, false, true, false))
+                   .add(TestParameter.peer(false, true, true))
+                   .add(TestParameter.peer(false, true, false))
+                   .add(TestParameter.peer(false, false, false))
                    // isPeerDependency = false
-                   .add(new TestParameter(false, true, false, false, true))
-                   .add(new TestParameter(false, true, false, false, false))
-                   .add(new TestParameter(false, false, false, false, true))
-                   .add(new TestParameter(false, false, false, false, false))
+                   .add(TestParameter.reg(false, true, true))
+                   .add(TestParameter.reg(false, true, false))
+                   .add(TestParameter.reg(false, false, true))
+                   .add(TestParameter.reg(false, false, false))
 
                    // Together - Include both dependency types
-                   .add(new TestParameter(true, true, true, false, true))
-                   .add(new TestParameter(true, true, true, false, false))
-                   .add(new TestParameter(true, true, false, true, true))
-                   .add(new TestParameter(true, true, false, true, false))
+                   .add(TestParameter.dev(true, true, true))
+                   .add(TestParameter.dev(true, true, false))
+                   .add(TestParameter.peer(true, true, true))
+                   .add(TestParameter.peer(true, true, false))
+                   .add(TestParameter.reg(true, true, true))
+                   .add(TestParameter.reg(true, true, false))
 
                    .build();
     }
@@ -88,11 +90,11 @@ class NpmDependencyTypeFilterTest {
         return Stream.<TestParameter>builder()
                    // Dev Dependencies
                    // isDevDependency = true
-                   .add(new TestParameter(false, false, true, false, true))
+                   .add(TestParameter.dev(false, false, true))
 
                    // Peer Dependencies
                    // isPeerDependency = true
-                   .add(new TestParameter(false, false, false, true, true))
+                   .add(TestParameter.peer(false, false, true))
 
                    .build();
     }
@@ -104,7 +106,19 @@ class NpmDependencyTypeFilterTest {
         public final boolean isPeerDependency;
         public final boolean isRootDependency;
 
-        public TestParameter(boolean includeDevDependencies, boolean includePeerDependencies, boolean isDevDependency, boolean isPeerDependency, boolean isRootDependency) {
+        public static TestParameter reg(boolean includeDevDependencies, boolean includePeerDependencies, boolean isRootDependency) {
+            return new TestParameter(includeDevDependencies, includePeerDependencies, false, false, isRootDependency);
+        }
+
+        public static TestParameter dev(boolean includeDevDependencies, boolean includePeerDependencies, boolean isRootDependency) {
+            return new TestParameter(includeDevDependencies, includePeerDependencies, true, false, isRootDependency);
+        }
+
+        public static TestParameter peer(boolean includeDevDependencies, boolean includePeerDependencies, boolean isRootDependency) {
+            return new TestParameter(includeDevDependencies, includePeerDependencies, false, true, isRootDependency);
+        }
+
+        private TestParameter(boolean includeDevDependencies, boolean includePeerDependencies, boolean isDevDependency, boolean isPeerDependency, boolean isRootDependency) {
             this.includeDevDependencies = includeDevDependencies;
             this.includePeerDependencies = includePeerDependencies;
             this.isDevDependency = isDevDependency;

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
@@ -7,7 +7,8 @@
  */
 package com.synopsys.integration.detectable.detectables.npm.cli.unit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.Set;
@@ -22,8 +23,20 @@ import com.synopsys.integration.util.Stringable;
 class NpmDependencyTypeFilterTest {
 
     @ParameterizedTest()
-    @MethodSource("generateTest")
-    void includeDependencies(TestParameter testParameter) {
+    @MethodSource("shouldIncludeSource")
+    void shouldIncludeTest(TestParameter testParameter) {
+        boolean shouldInclude = testWithParameter(testParameter);
+        assertTrue(shouldInclude);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("shouldNotIncludeSource")
+    void shouldNotIncludeTest(TestParameter testParameter) {
+        boolean shouldInclude = testWithParameter(testParameter);
+        assertFalse(shouldInclude);
+    }
+
+    boolean testWithParameter(TestParameter testParameter) {
         Set<String> devDependencies = Collections.singleton("test-dev");
         Set<String> peerDependencies = Collections.singleton("test-peer");
 
@@ -34,47 +47,52 @@ class NpmDependencyTypeFilterTest {
         } else if (testParameter.isPeerDependency) {
             dependencyName = "test-peer";
         }
-        boolean actual = npmDependencyTypeFilter.shouldInclude(dependencyName, testParameter.isRootDependency);
-        assertEquals(testParameter.shouldInclude, actual, "TestParameters: " + testParameter);
+
+        return npmDependencyTypeFilter.shouldInclude(dependencyName, testParameter.isRootDependency);
     }
 
-    static Stream<TestParameter> generateTest() {
+    static Stream<TestParameter> shouldIncludeSource() {
         return Stream.<TestParameter>builder()
                    // Dev Dependencies
                    // isDevDependency = true
-                   .add(new TestParameter(true, false, true, false, true, true))
-                   .add(new TestParameter(true, false, true, false, false, true))
-                   .add(new TestParameter(false, false, true, false, false, true))
-                   .add(new TestParameter(false, false, true, false, true, false))
+                   .add(new TestParameter(true, false, true, false, true))
+                   .add(new TestParameter(true, false, true, false, false))
+                   .add(new TestParameter(false, false, true, false, false))
                    // isDevDependency = false
-                   .add(new TestParameter(true, false, false, false, true, true))
-                   .add(new TestParameter(true, false, false, false, false, true))
-                   .add(new TestParameter(false, false, false, false, false, true))
-                   .add(new TestParameter(false, false, false, false, true, true))
+                   .add(new TestParameter(true, false, false, false, true))
+                   .add(new TestParameter(true, false, false, false, false))
+                   .add(new TestParameter(false, false, false, false, false))
+                   .add(new TestParameter(false, false, false, false, true))
 
                    // Peer Dependencies
                    // isPeerDependency = true
-                   .add(new TestParameter(false, true, false, true, true, true))
-                   .add(new TestParameter(false, true, false, true, false, true))
-                   .add(new TestParameter(false, false, false, true, true, false))
-                   .add(new TestParameter(false, false, false, true, false, true))
+                   .add(new TestParameter(false, true, false, true, true))
+                   .add(new TestParameter(false, true, false, true, false))
+                   .add(new TestParameter(false, false, false, true, false))
                    // isPeerDependency = false
-                   .add(new TestParameter(false, true, false, false, true, true))
-                   .add(new TestParameter(false, true, false, false, false, true))
-                   .add(new TestParameter(false, false, false, false, true, true))
-                   .add(new TestParameter(false, false, false, false, false, true))
+                   .add(new TestParameter(false, true, false, false, true))
+                   .add(new TestParameter(false, true, false, false, false))
+                   .add(new TestParameter(false, false, false, false, true))
+                   .add(new TestParameter(false, false, false, false, false))
 
-                   // Together
-                   // Include Both Types
-                   .add(new TestParameter(true, true, true, false, true, true))
-                   .add(new TestParameter(true, true, true, false, false, true))
-                   .add(new TestParameter(true, true, false, true, true, true))
-                   .add(new TestParameter(true, true, false, true, false, true))
-                   // Exclude Both types
-                   .add(new TestParameter(false, false, true, false, true, false))
-                   .add(new TestParameter(false, false, true, false, false, true))
-                   .add(new TestParameter(false, false, false, true, true, false))
-                   .add(new TestParameter(false, false, false, true, false, true))
+                   // Together - Include both dependency types
+                   .add(new TestParameter(true, true, true, false, true))
+                   .add(new TestParameter(true, true, true, false, false))
+                   .add(new TestParameter(true, true, false, true, true))
+                   .add(new TestParameter(true, true, false, true, false))
+
+                   .build();
+    }
+
+    static Stream<TestParameter> shouldNotIncludeSource() {
+        return Stream.<TestParameter>builder()
+                   // Dev Dependencies
+                   // isDevDependency = true
+                   .add(new TestParameter(false, false, true, false, true))
+
+                   // Peer Dependencies
+                   // isPeerDependency = true
+                   .add(new TestParameter(false, false, false, true, true))
 
                    .build();
     }
@@ -85,15 +103,13 @@ class NpmDependencyTypeFilterTest {
         public final boolean isDevDependency;
         public final boolean isPeerDependency;
         public final boolean isRootDependency;
-        public final boolean shouldInclude;
 
-        public TestParameter(boolean includeDevDependencies, boolean includePeerDependencies, boolean isDevDependency, boolean isPeerDependency, boolean isRootDependency, boolean shouldInclude) {
+        public TestParameter(boolean includeDevDependencies, boolean includePeerDependencies, boolean isDevDependency, boolean isPeerDependency, boolean isRootDependency) {
             this.includeDevDependencies = includeDevDependencies;
             this.includePeerDependencies = includePeerDependencies;
             this.isDevDependency = isDevDependency;
             this.isPeerDependency = isPeerDependency;
             this.isRootDependency = isRootDependency;
-            this.shouldInclude = shouldInclude;
         }
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
@@ -26,14 +26,14 @@ class NpmDependencyTypeFilterTest {
     @MethodSource("shouldIncludeSource")
     void shouldIncludeTest(TestParameter testParameter) {
         boolean shouldInclude = testWithParameter(testParameter);
-        assertTrue(shouldInclude);
+        assertTrue(shouldInclude, "Test Parameters: " + testParameter);
     }
 
     @ParameterizedTest()
     @MethodSource("shouldNotIncludeSource")
     void shouldNotIncludeTest(TestParameter testParameter) {
         boolean shouldInclude = testWithParameter(testParameter);
-        assertFalse(shouldInclude);
+        assertFalse(shouldInclude, "Test Parameters: " + testParameter);
     }
 
     boolean testWithParameter(TestParameter testParameter) {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/cli/unit/NpmDependencyTypeFilterTest.java
@@ -53,29 +53,28 @@ class NpmDependencyTypeFilterTest {
 
     static Stream<TestParameter> shouldIncludeSource() {
         return Stream.<TestParameter>builder()
-                   // Dev Dependencies
-                   // isDevDependency = true
-                   .add(TestParameter.dev(true, false, true))
-                   .add(TestParameter.dev(true, false, false))
-                   .add(TestParameter.dev(false, false, false))
-                   // isDevDependency = false
+                   // Include Dev Dependencies
                    .add(TestParameter.reg(true, false, true))
                    .add(TestParameter.reg(true, false, false))
-                   .add(TestParameter.reg(false, false, false))
-                   .add(TestParameter.reg(false, false, true))
+                   .add(TestParameter.dev(true, false, true))
+                   .add(TestParameter.dev(true, false, false))
+                   .add(TestParameter.peer(true, false, false))
 
-                   // Peer Dependencies
-                   // isPeerDependency = true
-                   .add(TestParameter.peer(false, true, true))
-                   .add(TestParameter.peer(false, true, false))
-                   .add(TestParameter.peer(false, false, false))
-                   // isPeerDependency = false
+                   // Include Peer Dependencies
                    .add(TestParameter.reg(false, true, true))
                    .add(TestParameter.reg(false, true, false))
-                   .add(TestParameter.reg(false, false, true))
-                   .add(TestParameter.reg(false, false, false))
+                   .add(TestParameter.dev(false, true, true))
+                   .add(TestParameter.dev(false, true, false))
+                   .add(TestParameter.peer(false, true, true))
+                   .add(TestParameter.peer(false, true, false))
 
-                   // Together - Include both dependency types
+                   // Exclude both dependency types
+                   .add(TestParameter.reg(false, false, false))
+                   .add(TestParameter.reg(false, false, true))
+                   .add(TestParameter.dev(false, false, false))
+                   .add(TestParameter.peer(false, false, false))
+
+                   // Include both dependency types
                    .add(TestParameter.dev(true, true, true))
                    .add(TestParameter.dev(true, true, false))
                    .add(TestParameter.peer(true, true, true))
@@ -91,10 +90,12 @@ class NpmDependencyTypeFilterTest {
                    // Dev Dependencies
                    // isDevDependency = true
                    .add(TestParameter.dev(false, false, true))
+                   .add(TestParameter.dev(false, true, true))
 
                    // Peer Dependencies
                    // isPeerDependency = true
                    .add(TestParameter.peer(false, false, true))
+                   .add(TestParameter.peer(true, false, true))
 
                    .build();
     }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmOutputParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/functional/NpmOutputParserTest.java
@@ -23,6 +23,7 @@
 package com.synopsys.integration.detectable.detectables.npm.lockfile.functional;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,14 +31,15 @@ import org.junit.jupiter.api.Test;
 import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.detectable.detectables.npm.cli.parse.NpmCliParser;
+import com.synopsys.integration.detectable.detectables.npm.cli.parse.NpmDependencyTypeFilter;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmParseResult;
 import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
 
 public class NpmOutputParserTest {
     @Test
     public void npmCliDependencyFinder() {
-        final NpmCliParser parser = new NpmCliParser(new ExternalIdFactory());
-        final String testIn = String.join(System.lineSeparator(), Arrays.asList(
+        NpmCliParser parser = new NpmCliParser(new ExternalIdFactory());
+        String testIn = String.join(System.lineSeparator(), Arrays.asList(
             "{",
             "   \"name\": \"node-js\",",
             "   \"version\": \"0.2.0\",",
@@ -73,12 +75,13 @@ public class NpmOutputParserTest {
             "       }",
             "   }",
             "}"));
-        final NpmParseResult result = parser.convertNpmJsonFileToCodeLocation(testIn);
+        NpmDependencyTypeFilter npmDependencyTypeFilter = new NpmDependencyTypeFilter(Collections.emptySet(), Collections.emptySet(), true, true);
+        NpmParseResult result = parser.convertNpmJsonFileToCodeLocation(testIn, npmDependencyTypeFilter);
 
         Assertions.assertEquals("node-js", result.getProjectName());
         Assertions.assertEquals("0.2.0", result.getProjectVersion());
 
-        final NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, result.getCodeLocation().getDependencyGraph());
+        NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, result.getCodeLocation().getDependencyGraph());
 
         graphAssert.hasRootSize(2);
         graphAssert.hasRootDependency("xml2js", "0.4.17");

--- a/docs/templates/content/90-releasenotes.ftl
+++ b/docs/templates/content/90-releasenotes.ftl
@@ -7,6 +7,7 @@
 * There now exist Docker images that can be used to run ${solution_name} from within a container.  See [Running ${solution_name} from within a Docker container](/30-running/#running-synopsys-detect-from-within-a-docker-container) for more details.
 * Added detect.go.mod.enable.verification for disabling the `go mod why` check that ${solution_name} uses to filter out unused dependencies.
 * Added support for dotnet 5 when running the NuGet inspector.
+* Added a new property [detect.npm.include.peer.dependencies](../properties/detectors/npm/#include-npm-peer-dependencies) which allows the users to filter out NPM peer dependencies from their BOM.
 
 ### Changed features
 * (IDETECT-2524) Default clone categories increased to include license terms and custom fields to match default settings in Black Duck.

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -184,8 +184,9 @@ public class DetectableOptionFactory {
 
     public NpmCliExtractorOptions createNpmCliExtractorOptions() {
         Boolean includeDevDependencies = getValue(DetectProperties.DETECT_NPM_INCLUDE_DEV_DEPENDENCIES);
+        Boolean includePeerDependencies = getValue(DetectProperties.DETECT_NPM_INCLUDE_PEER_DEPENDENCIES);
         String npmArguments = getNullableValue(DetectProperties.DETECT_NPM_ARGUMENTS);
-        return new NpmCliExtractorOptions(includeDevDependencies, npmArguments);
+        return new NpmCliExtractorOptions(includeDevDependencies, includePeerDependencies, npmArguments);
     }
 
     public NpmLockfileOptions createNpmLockfileOptions() {


### PR DESCRIPTION
# Description
Adds peer dependencies support to the NpmCliDetectqable
Detect now parses the PackageJson as a requirement and uses the dependency blocks (reg, dev, peer) to filter out dev or peer dependencies based on the configuration.
Detect no longer runs `npm ls -prod`. The `-prod` flag was excluding both dev and peer dependencies.

# Jira Issues
IDETECT-2694: Peer Dependency Support - NpmCliDetectable
