### PR TITLE
refactor(detectable-tool): Split detectable tool into two operations. 

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
@@ -55,15 +55,15 @@ public class DetectRun {
 
             ProductRunData productRunData = bootSingletons.getProductRunData(); //TODO: Remove run data from boot singletons
             OperationFactory operationFactory = createOperationFactory(bootSingletons, utilitySingletons, eventSingletons);
+            StepHelper stepHelper = new StepHelper(utilitySingletons.getOperationSystem(), utilitySingletons.getOperationWrapper(), productRunData.getDetectToolFilter());
 
-            UniversalStepRunner stepRunner = new UniversalStepRunner(operationFactory, productRunData.getDetectToolFilter()); //Product independent tools
+            UniversalStepRunner stepRunner = new UniversalStepRunner(operationFactory, stepHelper); //Product independent tools
             UniversalToolsResult universalToolsResult = stepRunner.runUniversalTools();
 
             // combine: processProjectInformation() -> ProjectResult (nameversion, bdio)
             NameVersion nameVersion = stepRunner.determineProjectInformation(universalToolsResult);
             operationFactory.publishProjectNameVersionChosen(nameVersion);
             BdioResult bdio = stepRunner.generateBdio(universalToolsResult, nameVersion);
-            StepHelper stepHelper = new StepHelper(utilitySingletons.getOperationSystem(), utilitySingletons.getOperationWrapper(), productRunData.getDetectToolFilter());
 
             if (productRunData.shouldUseBlackDuckProduct()) {
                 BlackDuckRunData blackDuckRunData = productRunData.getBlackDuckRunData();

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/UniversalStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/UniversalStepRunner.java
@@ -23,11 +23,12 @@ import com.synopsys.integration.detect.configuration.DetectUserFriendlyException
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 import com.synopsys.integration.detect.lifecycle.run.operation.OperationFactory;
+import com.synopsys.integration.detect.lifecycle.run.step.utility.StepHelper;
+import com.synopsys.integration.detect.tool.DetectableTool;
 import com.synopsys.integration.detect.tool.DetectableToolResult;
 import com.synopsys.integration.detect.tool.UniversalToolsResult;
 import com.synopsys.integration.detect.tool.UniversalToolsResultBuilder;
 import com.synopsys.integration.detect.tool.detector.DetectorToolResult;
-import com.synopsys.integration.detect.util.filter.DetectToolFilter;
 import com.synopsys.integration.detect.workflow.bdio.AggregateCodeLocation;
 import com.synopsys.integration.detect.workflow.bdio.AggregateDecision;
 import com.synopsys.integration.detect.workflow.bdio.AggregateMode;
@@ -42,61 +43,53 @@ import com.synopsys.integration.util.NameVersion;
 public class UniversalStepRunner {
     private OperationFactory operationFactory;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    private final DetectToolFilter detectToolFilter; //TODO: This should be a decision
+    private final StepHelper stepHelper;
 
-    public UniversalStepRunner(final OperationFactory operationFactory, DetectToolFilter detectToolFilter) { //TODO: Move to Step Helper
+    public UniversalStepRunner(final OperationFactory operationFactory, StepHelper stepHelper) {
         this.operationFactory = operationFactory;
-        this.detectToolFilter = detectToolFilter;
+        this.stepHelper = stepHelper;
     }
 
     public UniversalToolsResult runUniversalTools() throws DetectUserFriendlyException, IntegrationException {
         UniversalToolsResultBuilder resultBuilder = new UniversalToolsResultBuilder();
-        runDocker().ifPresent(resultBuilder::addDetectableToolResult);
-        runBazel().ifPresent(resultBuilder::addDetectableToolResult);
-        runDetectors().ifPresent(resultBuilder::addDetectorToolResult);
+
+        stepHelper.runToolIfIncluded(DetectTool.DOCKER, "Docker", this::runDocker)
+            .ifPresent(resultBuilder::addDetectableToolResult);
+
+        stepHelper.runToolIfIncluded(DetectTool.BAZEL, "Bazel", this::runBazel)
+            .ifPresent(resultBuilder::addDetectableToolResult);
+
+        stepHelper.runToolIfIncluded(DetectTool.DETECTOR, "Detectors", this::runDetectors)
+            .ifPresent(resultBuilder::addDetectorToolResult);
+
         return resultBuilder.build();
     }
 
-    private Optional<DetectableToolResult> runDocker() throws DetectUserFriendlyException, IntegrationException {
-        logger.info(ReportConstants.RUN_SEPARATOR);
-        if (detectToolFilter.shouldInclude(DetectTool.DOCKER)) {
-            logger.info("Will include the Docker tool.");
-            DetectableToolResult result = operationFactory.executeDocker();
-            logger.info("Docker actions finished.");
-            return Optional.ofNullable(result);
+    private DetectableToolResult runDocker() throws DetectUserFriendlyException, IntegrationException {
+        Optional<DetectableTool> potentialTool = operationFactory.checkForDocker();
+        if (potentialTool.isPresent()) {
+            return operationFactory.executeDocker(potentialTool.get());
         } else {
-            logger.info("Docker tool will not be run.");
-            return Optional.empty();
+            return DetectableToolResult.skip();
         }
     }
 
-    private Optional<DetectableToolResult> runBazel() throws DetectUserFriendlyException, IntegrationException {
-        logger.info(ReportConstants.RUN_SEPARATOR);
-        if (detectToolFilter.shouldInclude(DetectTool.BAZEL)) {
-            logger.info("Will include the Bazel tool.");
-            DetectableToolResult result = operationFactory.executeBazel();
-            logger.info("Bazel actions finished.");
-            return Optional.ofNullable(result);
+    private DetectableToolResult runBazel() throws DetectUserFriendlyException, IntegrationException {
+        Optional<DetectableTool> potentialTool = operationFactory.checkForBazel();
+        if (potentialTool.isPresent()) {
+            return operationFactory.executeBazel(potentialTool.get());
         } else {
-            logger.info("Bazel tool will not be run.");
-            return Optional.empty();
+            return DetectableToolResult.skip();
         }
     }
 
-    private Optional<DetectorToolResult> runDetectors() throws DetectUserFriendlyException, IntegrationException {
-        logger.info(ReportConstants.RUN_SEPARATOR);
-        if (detectToolFilter.shouldInclude(DetectTool.DETECTOR)) {
-            logger.info("Will include the detector tool.");
-            DetectorToolResult result = operationFactory.executeDetectors();
-            if (result.anyDetectorsFailed()) {
-                operationFactory.publishDetectorFailure();
-            }
-            logger.info("Detector actions finished.");
-            return Optional.ofNullable(result);
-        } else {
-            logger.info("Detector tool will not be run.");
-            return Optional.empty();
+    private DetectorToolResult runDetectors() throws DetectUserFriendlyException, IntegrationException {
+        DetectorToolResult result = operationFactory.executeDetectors();
+        if (result.anyDetectorsFailed()) {
+            operationFactory.publishDetectorFailure();
         }
+        logger.info("Detector actions finished.");
+        return result;
     }
 
     public BdioResult generateBdio(UniversalToolsResult universalToolsResult, NameVersion projectNameVersion) throws DetectUserFriendlyException, IntegrationException {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/UniversalStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/UniversalStepRunner.java
@@ -88,7 +88,6 @@ public class UniversalStepRunner {
         if (result.anyDetectorsFailed()) {
             operationFactory.publishDetectorFailure();
         }
-        logger.info("Detector actions finished.");
         return result;
     }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/StepHelper.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/StepHelper.java
@@ -40,6 +40,10 @@ public class StepHelper {
         }, () -> {}, (e) -> {});
     }
 
+    public <T> Optional<T> runToolIfIncluded(DetectTool detectTool, String name, OperationWrapper.OperationSupplier<T> supplier) throws DetectUserFriendlyException {
+        return runToolIfIncluded(detectTool, name, supplier, () -> {}, (e) -> {});
+    }
+
     public void runToolIfIncludedWithCallbacks(DetectTool detectTool, String name, OperationWrapper.OperationFunction supplier, Runnable successConsumer, Consumer<Exception> errorConsumer)
         throws DetectUserFriendlyException {
         runToolIfIncluded(detectTool, name, () -> {

--- a/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
@@ -25,7 +25,6 @@ import com.synopsys.integration.detect.tool.detector.CodeLocationConverter;
 import com.synopsys.integration.detect.tool.detector.extraction.ExtractionEnvironmentProvider;
 import com.synopsys.integration.detect.workflow.codelocation.DetectCodeLocation;
 import com.synopsys.integration.detect.workflow.project.DetectToolProjectInfo;
-import com.synopsys.integration.detect.workflow.status.OperationSystem;
 import com.synopsys.integration.detect.workflow.status.Status;
 import com.synopsys.integration.detect.workflow.status.StatusEventPublisher;
 import com.synopsys.integration.detect.workflow.status.StatusType;
@@ -51,8 +50,12 @@ public class DetectableTool {
     private final StatusEventPublisher statusEventPublisher;
     private final ExitCodePublisher exitCodePublisher;
 
+    //TODO: Move docker/bazel out of detectable and drop this notion of a detctable tool. Will simplify this logic and make this unneccessary.
+    private Detectable detectable;
+    private File sourcePath;
+
     public DetectableTool(DetectableCreatable detectableCreatable, ExtractionEnvironmentProvider extractionEnvironmentProvider, CodeLocationConverter codeLocationConverter,
-        String name, DetectTool detectTool, StatusEventPublisher statusEventPublisher, ExitCodePublisher exitCodePublisher, OperationSystem operationSystem) {
+        String name, DetectTool detectTool, StatusEventPublisher statusEventPublisher, ExitCodePublisher exitCodePublisher) {
         this.codeLocationConverter = codeLocationConverter;
         this.name = name;
         this.detectableCreatable = detectableCreatable;
@@ -62,23 +65,23 @@ public class DetectableTool {
         this.exitCodePublisher = exitCodePublisher;
     }
 
-    public DetectableToolResult execute(File sourcePath) { //TODO: Caller publishes result.
+    public boolean initializeAndCheckForApplicable(File sourcePath) { //TODO: Move docker/bazel out of detectable and drop this notion of a detctable tool. Will simplify this logic and make this unneccessary.
         logger.trace("Starting a detectable tool.");
 
         DetectableEnvironment detectableEnvironment = new DetectableEnvironment(sourcePath);
-        Detectable detectable = detectableCreatable.createDetectable(detectableEnvironment);
-
-        //TODO: Replicate? logger.info(String.format("Initializing %s.", detectable.getDescriptiveName()));
-
+        detectable = detectableCreatable.createDetectable(detectableEnvironment);
         DetectableResult applicable = detectable.applicable();
 
         if (!applicable.getPassed()) {
             logger.debug("Was not applicable.");
-            return DetectableToolResult.skip();
+            return false;
         }
 
         logger.debug("Applicable passed.");
+        return true;
+    }
 
+    public DetectableToolResult extract() { //TODO: Move docker/bazel out of detectable and drop this notion of a detctable tool. Will simplify this logic and make this unneccessary.
         DetectableResult extractable;
         try {
             extractable = detectable.extractable();


### PR DESCRIPTION
This is a temporary change to allow Detectable Tool to nicely fit in the operation system. In the future both Docker and Bazel will be removed from the Detectable project and become fully formed tools with better operations. Additionally their 'applicables' should be moved to decisions in boot, as is the plan with a lot of the shouldInclude(tool) methods barring additional complication there (such as binary needing to search to decide if it should run?). 

Hopefully in the future, moving them out of detectable allows us to split them into proper operations and putting all decision making in one place makes this all easier to understand.