### PR TITLE
Carthage support

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectable/result/CartfileResolvedNotFoundDetectableResult.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectable/result/CartfileResolvedNotFoundDetectableResult.java
@@ -1,0 +1,14 @@
+package com.synopsys.integration.detectable.detectable.result;
+
+public class CartfileResolvedNotFoundDetectableResult extends FailedDetectableResult {
+    private final String directoryPath;
+
+    public CartfileResolvedNotFoundDetectableResult(String directoryPath) {
+        this.directoryPath = directoryPath;
+    }
+
+    @Override
+    public String toDescription() {
+        return String.format("A Cartfile was located in %s, but the Cartfile.resolved file was NOT located. Please run 'carthage update' in that location and try again.", directoryPath);
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/carthage/CarthageDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/carthage/CarthageDetectable.java
@@ -1,0 +1,65 @@
+package com.synopsys.integration.detectable.detectables.carthage;
+
+import java.io.File;
+
+import com.synopsys.integration.common.util.finder.FileFinder;
+import com.synopsys.integration.detectable.Detectable;
+import com.synopsys.integration.detectable.DetectableEnvironment;
+import com.synopsys.integration.detectable.detectable.Requirements;
+import com.synopsys.integration.detectable.detectable.exception.DetectableException;
+import com.synopsys.integration.detectable.detectable.executable.ExecutableFailedException;
+import com.synopsys.integration.detectable.detectable.result.CartfileResolvedNotFoundDetectableResult;
+import com.synopsys.integration.detectable.detectable.result.DetectableResult;
+import com.synopsys.integration.detectable.detectable.result.FilesNotFoundDetectableResult;
+import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
+import com.synopsys.integration.detectable.extraction.Extraction;
+import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
+
+public class CarthageDetectable extends Detectable {
+    private static final String CARTFILE_FILENAME = "Cartfile";
+    private static final String CARTFILE_RESOLVED_FILENAME = "Cartfile.resolved";
+
+    private FileFinder fileFinder;
+    private CarthageExtractor carthageExtractor;
+
+    private File cartfile;
+    private File cartfileResolved;
+
+    public CarthageDetectable(DetectableEnvironment environment, FileFinder fileFinder, CarthageExtractor carthageExtractor) {
+        super(environment);
+        this.fileFinder = fileFinder;
+        this.carthageExtractor = carthageExtractor;
+    }
+
+    @Override
+    public DetectableResult applicable() {
+        Requirements requirements = new Requirements(fileFinder, environment);
+
+        cartfile = fileFinder.findFile(environment.getDirectory(), CARTFILE_FILENAME);
+        cartfileResolved = fileFinder.findFile(environment.getDirectory(), CARTFILE_RESOLVED_FILENAME);
+
+        if (cartfile == null && cartfileResolved == null) {
+            return new FilesNotFoundDetectableResult(CARTFILE_FILENAME, CARTFILE_RESOLVED_FILENAME);
+        }
+        if (cartfile != null) {
+            requirements.explainFile(cartfile);
+        }
+        if (cartfileResolved != null) {
+            requirements.explainFile(cartfileResolved);
+        }
+        return requirements.result();
+    }
+
+    @Override
+    public DetectableResult extractable() throws DetectableException {
+        if (cartfileResolved == null && cartfile != null) {
+            return new CartfileResolvedNotFoundDetectableResult(environment.getDirectory().getAbsolutePath());
+        }
+        return new PassedDetectableResult();
+    }
+
+    @Override
+    public Extraction extract(ExtractionEnvironment extractionEnvironment) throws ExecutableFailedException {
+        return carthageExtractor.extract(cartfileResolved);
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/carthage/CarthageExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/carthage/CarthageExtractor.java
@@ -35,6 +35,7 @@ public class CarthageExtractor {
                     String name = dependencyDeclarationPieces[1].replace("\"", "");
                     String version = dependencyDeclarationPieces[2].replace("\"", "");
 
+                    // Because the dependency is hosted on GitHub, we must use the github forge in order for KB to match it
                     ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.GITHUB, name, version);
                     // As of Carthage 0.38.0 the dependencies in Cartfile.resolved are produced as a flat list
                     dependencyGraph.addChildToRoot(new Dependency(name, version, externalId));

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/carthage/CarthageExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/carthage/CarthageExtractor.java
@@ -14,7 +14,7 @@ import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.extraction.Extraction;
 
 public class CarthageExtractor {
-    private static String GITHUB_SOURCE_ID = "github";
+    private static String GITHUB_ORIGIN_ID = "github";
 
     private ExternalIdFactory externalIdFactory = new ExternalIdFactory();
 
@@ -26,14 +26,14 @@ public class CarthageExtractor {
             while ((dependencyDeclaration = reader.readLine()) != null) {
                 // Each line in a Cartfile.resolved file is a dependency declaration: <origin> <name/resource> <version>
                 // eg. github "realm/realm-cocoa" "v10.7.2"
-                String[] pieces = dependencyDeclaration.split("\\s+");
-                String origin = pieces[0];
+                String[] dependencyDeclarationPieces = dependencyDeclaration.split("\\s+");
+                String origin = dependencyDeclarationPieces[0];
                 // Carthage supports declarations of dependencies via github org/repo, a URL, or a local path
                 // As of now, Detect only supports dependencies with github origins
                 // The KB does not have mappings for binaries, or resources that are not open source.  It has some mappings, though, for GitHub repos
-                if (origin.equals(GITHUB_SOURCE_ID)) {
-                    String name = pieces[1].replace("\"", "");
-                    String version = pieces[2].replace("\"", "");
+                if (origin.equals(GITHUB_ORIGIN_ID)) {
+                    String name = dependencyDeclarationPieces[1].replace("\"", "");
+                    String version = dependencyDeclarationPieces[2].replace("\"", "");
 
                     ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.GITHUB, name, version);
                     // As of Carthage 0.38.0 the dependencies in Cartfile.resolved are produced as a flat list

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/carthage/CarthageExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/carthage/CarthageExtractor.java
@@ -1,0 +1,51 @@
+package com.synopsys.integration.detectable.detectables.carthage;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+
+import com.synopsys.integration.bdio.graph.MutableDependencyGraph;
+import com.synopsys.integration.bdio.graph.MutableMapDependencyGraph;
+import com.synopsys.integration.bdio.model.Forge;
+import com.synopsys.integration.bdio.model.dependency.Dependency;
+import com.synopsys.integration.bdio.model.externalid.ExternalId;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
+import com.synopsys.integration.detectable.extraction.Extraction;
+
+public class CarthageExtractor {
+    private static String GITHUB_SOURCE_ID = "github";
+
+    private ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+
+    public Extraction extract(File carthfileResolved) {
+        MutableDependencyGraph dependencyGraph = new MutableMapDependencyGraph();
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(carthfileResolved));
+            String dependencyDeclaration = null;
+            while ((dependencyDeclaration = reader.readLine()) != null) {
+                // Each line in a Cartfile.resolved file is a dependency declaration: <origin> <name/resource> <version>
+                // eg. github "realm/realm-cocoa" "v10.7.2"
+                String[] pieces = dependencyDeclaration.split("\\s+");
+                String origin = pieces[0];
+                // Carthage supports declarations of dependencies via github org/repo, a URL, or a local path
+                // As of now, Detect only supports dependencies with github origins
+                // The KB does not have mappings for binaries, or resources that are not open source.  It has some mappings, though, for GitHub repos
+                if (origin.equals(GITHUB_SOURCE_ID)) {
+                    String name = pieces[1].replace("\"", "");
+                    String version = pieces[2].replace("\"", "");
+
+                    ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.GITHUB, name, version);
+                    // As of Carthage 0.38.0 the dependencies in Cartfile.resolved are produced as a flat list
+                    dependencyGraph.addChildToRoot(new Dependency(name, version, externalId));
+
+                }
+            }
+        } catch (Exception e) {
+            return new Extraction.Builder().failure(String.format("There was a problem extracting dependencies from %s", carthfileResolved.getAbsolutePath())).build();
+        }
+        CodeLocation codeLocation = new CodeLocation(dependencyGraph);
+        // No project info - hoping git can help with that.
+        return new Extraction.Builder().success(codeLocation).build();
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -58,6 +58,8 @@ import com.synopsys.integration.detectable.detectables.bitbake.parse.GraphParser
 import com.synopsys.integration.detectable.detectables.cargo.CargoDetectable;
 import com.synopsys.integration.detectable.detectables.cargo.CargoExtractor;
 import com.synopsys.integration.detectable.detectables.cargo.parse.CargoLockParser;
+import com.synopsys.integration.detectable.detectables.carthage.CarthageDetectable;
+import com.synopsys.integration.detectable.detectables.carthage.CarthageExtractor;
 import com.synopsys.integration.detectable.detectables.clang.ClangDetectable;
 import com.synopsys.integration.detectable.detectables.clang.ClangDetectableOptions;
 import com.synopsys.integration.detectable.detectables.clang.ClangExtractor;
@@ -271,6 +273,10 @@ public class DetectableFactory {
         return new CargoDetectable(environment, fileFinder, cargoExtractor());
     }
 
+    public CarthageDetectable createCarthageDetectable(DetectableEnvironment environment) {
+        return new CarthageDetectable(environment, fileFinder, carthageExtractor());
+    }
+
     public ClangDetectable createClangDetectable(DetectableEnvironment environment, ClangDetectableOptions clangDetectableOptions) {
         return new ClangDetectable(environment, executableRunner, fileFinder, clangPackageManagerFactory().createPackageManagers(), clangExtractor(), clangDetectableOptions, clangPackageManagerRunner());
     }
@@ -444,6 +450,10 @@ public class DetectableFactory {
 
     private CargoExtractor cargoExtractor() {
         return new CargoExtractor(new CargoLockParser());
+    }
+
+    private CarthageExtractor carthageExtractor() {
+        return new CarthageExtractor();
     }
 
     private ClangPackageDetailsTransformer clangPackageDetailsTransformer() {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/carthage/CarthageDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/carthage/CarthageDetectableTest.java
@@ -1,0 +1,48 @@
+package com.synopsys.integration.detectable.detectables.carthage;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+
+import com.synopsys.integration.bdio.model.Forge;
+import com.synopsys.integration.detectable.Detectable;
+import com.synopsys.integration.detectable.DetectableEnvironment;
+import com.synopsys.integration.detectable.extraction.Extraction;
+import com.synopsys.integration.detectable.functional.DetectableFunctionalTest;
+import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
+
+public class CarthageDetectableTest extends DetectableFunctionalTest {
+    public CarthageDetectableTest() throws IOException {
+        super("Carthage");
+    }
+
+    @Override
+    protected void setup() throws IOException {
+        addFile(Paths.get("Cartfile.resolved"),
+            "binary \"https://downloads.localytics.com/SDKs/iOS/Localytics.json\" \"6.2.1\"",
+            "github \"GEOSwift/GEOSwift\" \"8.0.2\"",
+            "github \"MobileNativeFoundation/Kronos\" \"4.2.1\"",
+            "github \"ReactiveCocoa/ReactiveCocoa\" \"11.1.0\"",
+            "github \"realm/realm-cocoa\" \"v10.7.2\""
+        );
+    }
+
+    @Override
+    public @NotNull Detectable create(@NotNull DetectableEnvironment detectableEnvironment) {
+        return detectableFactory.createCarthageDetectable(detectableEnvironment);
+    }
+
+    @Override
+    public void assertExtraction(@NotNull Extraction extraction) {
+        Assertions.assertEquals(1, extraction.getCodeLocations().size());
+
+        NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.GITHUB, extraction.getCodeLocations().get(0).getDependencyGraph());
+        graphAssert.hasRootSize(4);
+        graphAssert.hasRootDependency("GEOSwift/GEOSwift", "8.0.2");
+        graphAssert.hasRootDependency("MobileNativeFoundation/Kronos", "4.2.1");
+        graphAssert.hasRootDependency("ReactiveCocoa/ReactiveCocoa", "11.1.0");
+        graphAssert.hasRootDependency("realm/realm-cocoa", "v10.7.2");
+    }
+}

--- a/detector/src/main/java/com/synopsys/integration/detector/base/DetectorResultStatusCodeLookup.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/base/DetectorResultStatusCodeLookup.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.detectable.detectable.result.CargoLockfileNotFoundDetectableResult;
+import com.synopsys.integration.detectable.detectable.result.CartfileResolvedNotFoundDetectableResult;
 import com.synopsys.integration.detectable.detectable.result.ExceptionDetectableResult;
 import com.synopsys.integration.detectable.detectable.result.ExcludedDetectableResult;
 import com.synopsys.integration.detectable.detectable.result.ExecutableNotFoundDetectableResult;
@@ -55,6 +56,7 @@ public class DetectorResultStatusCodeLookup {
         Map<Class, DetectorStatusCode> map = new HashMap<>();
 
         map.put(CargoLockfileNotFoundDetectableResult.class, DetectorStatusCode.CARGO_LOCKFILE_NOT_FOUND);
+        map.put(CartfileResolvedNotFoundDetectableResult.class, DetectorStatusCode.CARTFILE_RESOLVED_FILE_NOT_FOUND);
         map.put(ExceptionDetectableResult.class, DetectorStatusCode.EXCEPTION);
         map.put(ExcludedDetectableResult.class, DetectorStatusCode.EXCLUDED);
         map.put(ExcludedDetectorResult.class, DetectorStatusCode.EXCLUDED);

--- a/detector/src/main/java/com/synopsys/integration/detector/base/DetectorStatusCode.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/base/DetectorStatusCode.java
@@ -9,6 +9,7 @@ package com.synopsys.integration.detector.base;
 
 public enum DetectorStatusCode {
     CARGO_LOCKFILE_NOT_FOUND("A Cargo.toml was located in the target project, but the Cargo.lock file was NOT located."),
+    CARTFILE_RESOLVED_FILE_NOT_FOUND("A Cartfile was located in the target project, but the Cartfile.resolved file was NOT located."),
     EXCEPTION("An exception occurred."),
     EXCLUDED("Detector type was excluded."),
     EXECUTABLE_FAILED("During extraction, one or more executables did not execute successfully."),

--- a/detector/src/main/java/com/synopsys/integration/detector/base/DetectorType.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/base/DetectorType.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 public enum DetectorType {
     BITBAKE,
     CARGO,
+    CARTHAGE,
     COCOAPODS,
     CONAN,
     CONDA,

--- a/docs/templates/content/90-releasenotes.ftl
+++ b/docs/templates/content/90-releasenotes.ftl
@@ -3,6 +3,7 @@
 ## Version 7.3.0
 
 ### New Features
+* Added support for the Carthage package manager.
 
 ### Changed features
 * The Poetry detector is no longer categorized as a PIP detector, and is now categorized under detector type POETRY.

--- a/docs/templates/content/advanced/package-managers/carthage.ftl
+++ b/docs/templates/content/advanced/package-managers/carthage.ftl
@@ -9,6 +9,6 @@ The Carthage detector parses the Cartfile.resolved file for information on your 
 
 ## Supported Dependency Origins
 
-${solution_name} only reports dependencies declared in a Cartfile.resolved file that have a 'github' [origin](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#origin).  This limited support is a result of the de-centralized nature of the Carthage ecosystem.  Many commonly-used frameworks used in Carthage projects are not open-source, and thus not reported on by Black Duck.
+${solution_name} only reports dependencies declared in a Cartfile.resolved file that have a 'github' [origin](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#origin).  This limited support is a result of the de-centralized nature of the Carthage ecosystem.  Many commonly-used frameworks used in Carthage projects are not open-source, and thus not tracked by Black Duck.
 
 * Note: Even for dependencies from Github that are declared with the 'github' origin, it is possible that some may not be matched by Black Duck, as Black Duck does not track all repositories hosted on GitHub.

--- a/docs/templates/content/advanced/package-managers/carthage.ftl
+++ b/docs/templates/content/advanced/package-managers/carthage.ftl
@@ -1,0 +1,14 @@
+# Carthage support
+
+${solution_name} runs the Carthage detector if it finds either of the following files in your project:
+
+* Cartfile
+* Cartfile.resolved
+
+The Carthage detector parses the Cartfile.resolved file for information on your project's dependencies. If the detector discovers a Cartfile file but not a Cartfile.resolved file, it will prompt the user to generate a Cartfile.resolved file by running `carthage update` and then run Detect again.
+
+## Supported Dependency Origins
+
+${solution_name} only reports dependencies declared in a Cartfile.resolved file that have a 'github' [origin](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#origin).  This limited support is a result of the de-centralized nature of the Carthage ecosystem.  Many commonly-used frameworks used in Carthage projects are not open-source, and thus not reported on by Black Duck.
+
+* Note: Even for dependencies from Github that are declared with the 'github' origin, it is possible that some may not be matched by Black Duck, as Black Duck does not track all repositories hosted on GitHub.

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
@@ -10,6 +10,7 @@ package com.synopsys.integration.detect.tool.detector;
 import com.synopsys.integration.detect.tool.detector.factory.DetectDetectableFactory;
 import com.synopsys.integration.detectable.detectables.bitbake.BitbakeDetectable;
 import com.synopsys.integration.detectable.detectables.cargo.CargoDetectable;
+import com.synopsys.integration.detectable.detectables.carthage.CarthageDetectable;
 import com.synopsys.integration.detectable.detectables.clang.ClangDetectable;
 import com.synopsys.integration.detectable.detectables.cocoapods.PodlockDetectable;
 import com.synopsys.integration.detectable.detectables.conan.cli.ConanCliDetectable;
@@ -67,6 +68,8 @@ public class DetectorRuleFactory {
 
         //TODO: Verify we still need to pass detector name here. We may now be able to get it from the detectable class - before we could not as it was not instantiated.
         ruleSet.addDetector(DetectorType.CARGO, "Cargo", CargoDetectable.class, detectableFactory::createCargoDetectable).defaults().build();
+
+        ruleSet.addDetector(DetectorType.CARTHAGE, "Carthage", CarthageDetectable.class, detectableFactory::createCarthageDetectable).defaults().build();
 
         ruleSet.addDetector(DetectorType.BITBAKE, "Bitbake", BitbakeDetectable.class, detectableFactory::createBitbakeDetectable).defaults().build();
 
@@ -141,6 +144,8 @@ public class DetectorRuleFactory {
         DetectorRuleSetBuilder ruleSet = new DetectorRuleSetBuilder();
 
         ruleSet.addDetector(DetectorType.CARGO, "Cargo", CargoDetectable.class, detectableFactory::createCargoDetectable).defaults().build();
+
+        ruleSet.addDetector(DetectorType.CARTHAGE, "Carthage", CarthageDetectable.class, detectableFactory::createCarthageDetectable).defaults().build();
 
         ruleSet.addDetector(DetectorType.COCOAPODS, "Pod Lock", PodlockDetectable.class, detectableFactory::createPodLockDetectable).defaults().build();
         ruleSet.addDetector(DetectorType.PACKAGIST, "Packrat Lock", PackratLockDetectable.class, detectableFactory::createPackratLockDetectable).defaults().build();

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
@@ -16,6 +16,7 @@ import com.synopsys.integration.detectable.detectable.inspector.nuget.NugetInspe
 import com.synopsys.integration.detectable.detectables.bazel.BazelDetectable;
 import com.synopsys.integration.detectable.detectables.bitbake.BitbakeDetectable;
 import com.synopsys.integration.detectable.detectables.cargo.CargoDetectable;
+import com.synopsys.integration.detectable.detectables.carthage.CarthageDetectable;
 import com.synopsys.integration.detectable.detectables.clang.ClangDetectable;
 import com.synopsys.integration.detectable.detectables.cocoapods.PodlockDetectable;
 import com.synopsys.integration.detectable.detectables.conan.cli.ConanCliDetectable;
@@ -93,6 +94,10 @@ public class DetectDetectableFactory {
 
     public CargoDetectable createCargoDetectable(DetectableEnvironment environment) {
         return detectableFactory.createCargoDetectable(environment);
+    }
+
+    public CarthageDetectable createCarthageDetectable(DetectableEnvironment environment) {
+        return detectableFactory.createCarthageDetectable(environment);
     }
 
     public ClangDetectable createClangDetectable(DetectableEnvironment environment) {


### PR DESCRIPTION
Adding support for Carthage.  See carthage.ftl, which also includes a link to documentation, for info on Carthage/Detect's support for Carthage.
