### PR TITLE
Wrong scanner offline

### DIFF
--- a/docs/templates/content/90-releasenotes.ftl
+++ b/docs/templates/content/90-releasenotes.ftl
@@ -93,7 +93,7 @@ use --detect.tools.exluded=BINARY_SCAN to disable the binary scan step.
 
 ### Changed features
 * The following directories will be excluded from signature scan by default, in addition to node_modules: bin, build, .git, .gradle, out, packages, target. Use
- [detect.excluded.directories.defaults](../properties/configuration/paths/#detect-excluded-directories-defaults-disabled-advanced) to disable these defaults.
+[detect.excluded.directories.defaults](../properties/configuration/paths/#detect-excluded-directories-defaults-disabled-advanced) to disable these defaults.
 * Detect no longer supports the exclusion of individual files during detector search, only directories.
 * Gradle detector no longer uses the gradle inspector. Only the init script is required.
 * The default BDIO format for communicating dependency graphs to Black Duck has been changed from BDIO1 to BDIO2.
@@ -150,7 +150,7 @@ detect.blackduck.signature.scanner.upload.source.mode.
 * Deprecated all Detect signature scanner properties. Future releases will feature an alternative mechanism for providing signature scanner arguments to Detect.
 * Deprecated property detect.resolve.tilde.in.paths. Resolving tildes is a shell feature which Detect will no longer support in a future version.
 * Deprecated property detect.python.python3. Due to the January 2020 sunset of Python 2, this property (which toggles between searching for a 'python' and 'python3' executable) is no longer necessary. See:
- [PEP-394](https://www.python.org/dev/peps/pep-0394/#recommendation)
+[PEP-394](https://www.python.org/dev/peps/pep-0394/#recommendation)
 * Deprecated properties detect.docker.inspector.air.gap.path, detect.gradle.inspector.air.gap.path, and detect.docker.inspector.air.gap.path as part of an effort to simplify Detect.
 * Deprecated properties detect.default.project.version.scheme, detect.default.project.version.text, detect.default.project.version.timeformat as part of the effort to simplify Detect.
 * Deprecated properties blackduck.username and blackduck.password. Authentication should be performed using an API token.

--- a/docs/templates/content/90-releasenotes.ftl
+++ b/docs/templates/content/90-releasenotes.ftl
@@ -1,5 +1,10 @@
 # Release notes
 
+# Version 7.6.0
+
+### Resolved issues
+* (IDETECT-2829) Resolved an issue that caused ${solution_name} to use the wrong scan cli when in offline mode and ignore a specified local scan cli.
+
 # Version 7.5.0
 
 ### New Features

--- a/docs/templates/content/90-releasenotes.ftl
+++ b/docs/templates/content/90-releasenotes.ftl
@@ -79,7 +79,8 @@
 * Added scripts detect7.sh and detect7.ps1 for invoking ${solution_name} 7.x.x. detect.sh and detect.ps1 will (by default) continue to invoke the latest ${solution_name} 6 version.
 * Added support for Yarn workspaces.
 * Added support for the dependency graph SBT plugin. Resolution cache generation is no longer a requirement of the SBT detector.
-* Added the properties [detect.excluded.directories](../properties/configuration/paths/#detect-excluded-directories-advanced), [detect.excluded.directories.defaults.disabled](../properties/configuration/paths/#detect-excluded-directories-defaults-disabled-advanced), and [detect.excluded.directories.search.depth](../properties/configuration/signature
+* Added the properties [detect.excluded.directories](../properties/configuration/paths/#detect-excluded-directories-advanced),
+[detect.excluded.directories.defaults.disabled](../properties/configuration/paths/#detect-excluded-directories-defaults-disabled-advanced), and [detect.excluded.directories.search.depth](../properties/configuration/signature
 scanner/#detect-excluded-directories-search-depth) to handle exclusions for detector search and signature scanning.
 * Added ability to specify excluded directory paths using [glob patterns](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)).
 * Added properties [detect.lerna.excluded.packages](../properties/detectors/lerna/#lerna-packages-excluded-advanced) and [detect.lerna.included.packages](../properties/detectors/lerna/#lerna-packages-included-advanced) to exclude and
@@ -91,7 +92,8 @@ If you are scanning Docker images and your Black Duck server does not have the b
 use --detect.tools.exluded=BINARY_SCAN to disable the binary scan step.
 
 ### Changed features
-* The following directories will be excluded from signature scan by default, in addition to node_modules: bin, build, .git, .gradle, out, packages, target. Use [detect.excluded.directories.defaults](../properties/configuration/paths/#detect-excluded-directories-defaults-disabled-advanced) to disable these defaults.
+* The following directories will be excluded from signature scan by default, in addition to node_modules: bin, build, .git, .gradle, out, packages, target. Use
+ [detect.excluded.directories.defaults](../properties/configuration/paths/#detect-excluded-directories-defaults-disabled-advanced) to disable these defaults.
 * Detect no longer supports the exclusion of individual files during detector search, only directories.
 * Gradle detector no longer uses the gradle inspector. Only the init script is required.
 * The default BDIO format for communicating dependency graphs to Black Duck has been changed from BDIO1 to BDIO2.
@@ -147,7 +149,8 @@ detect.blackduck.signature.scanner.upload.source.mode.
 * Deprecated all Detect exclusion properties. Future releases will feature a new property to extend and consolidate these properties.
 * Deprecated all Detect signature scanner properties. Future releases will feature an alternative mechanism for providing signature scanner arguments to Detect.
 * Deprecated property detect.resolve.tilde.in.paths. Resolving tildes is a shell feature which Detect will no longer support in a future version.
-* Deprecated property detect.python.python3. Due to the January 2020 sunset of Python 2, this property (which toggles between searching for a 'python' and 'python3' executable) is no longer necessary. See: [PEP-394](https://www.python.org/dev/peps/pep-0394/#recommendation)
+* Deprecated property detect.python.python3. Due to the January 2020 sunset of Python 2, this property (which toggles between searching for a 'python' and 'python3' executable) is no longer necessary. See:
+ [PEP-394](https://www.python.org/dev/peps/pep-0394/#recommendation)
 * Deprecated properties detect.docker.inspector.air.gap.path, detect.gradle.inspector.air.gap.path, and detect.docker.inspector.air.gap.path as part of an effort to simplify Detect.
 * Deprecated properties detect.default.project.version.scheme, detect.default.project.version.text, detect.default.project.version.timeformat as part of the effort to simplify Detect.
 * Deprecated properties blackduck.username and blackduck.password. Authentication should be performed using an API token.
@@ -230,7 +233,8 @@ and writes them to the status.json file.
 
 ### Resolved issues
 * (IDETECT-2019) Resolved an issue where the pip inspector would not be able to parse the requirements.txt file if pip's version was >= 20.1.
-* (IDETECT-2034) Resolved an issue that would cause a NullPointerException when ${solution_name}'s initial attempt at generating a code location name produced a code location name greater than 250 characters and either code location prefix or code location suffix is not set.
+* (IDETECT-2034) Resolved an issue that would cause a NullPointerException when ${solution_name}'s initial attempt at generating a code location name produced a code location name greater than 250 characters and either code location
+prefix or code location suffix is not set.
 * (IDETECT-1979) Resolved an issue that could cause the CLANG detector to miss some dependencies because it failed to correctly parse complex nested quoted strings within compile_commands.json values.
 * (IDETECT-1966) Resolved an issue that would cause Detect to ignore replacement directives for Go Mod projects.
 
@@ -244,7 +248,8 @@ and writes them to the status.json file.
 * ${solution_name} logs policy violations when it is configured to [fail on policy violations](../properties/configuration/project/#fail-on-policy-violation-severities).
 
 ### Changed features
-* Users can [upload source](../properties/configuration/signature scanner/#upload-source-mode) files when [license search](../properties/configuration/signature scanner/#signature-scanner-license-search) is enabled regardless of whether [snippet matching](../properties/configuration/signature scanner/#snippet-matching) has been enabled.
+* Users can [upload source](../properties/configuration/signature scanner/#upload-source-mode) files when [license search](../properties/configuration/signature scanner/#signature-scanner-license-search) is enabled regardless of whether
+[snippet matching](../properties/configuration/signature scanner/#snippet-matching) has been enabled.
 * ${solution_name} is now compatible with Yocto 3.0.
 * ${solution_name} stops if the Docker Inspector tool applies and ${solution_name} is running on Windows.
 * ${solution_name} configures Docker Inspector's working directories inside ${solution_name}'s run directory.
@@ -283,7 +288,8 @@ and writes them to the status.json file.
 ### Resolved issues
 * Resolved an issue where the download URL for ${solution_name} was being set to an internal URL upon release (IDETECT-1847).
 * Resolved an issue where all transitive dependencies found by the [Pip inspector](../advanced/package-managers/python/#the-pip-detector) were being reported as direct dependencies (IDETECT-1893).
-* Resolved an issue where using pip version 20+ with the [Pip inspector](../advanced/package-managers/python/#the-pip-detector) caused a failure to import a dependency. [GitHub PR](https://github.com/blackducksoftware/synopsys-detect/pull/107) (IDETECT-1868)
+* Resolved an issue where using pip version 20+ with the [Pip inspector](../advanced/package-managers/python/#the-pip-detector) caused a failure to import a dependency. [GitHub
+PR](https://github.com/blackducksoftware/synopsys-detect/pull/107) (IDETECT-1868)
 * Resolved the following vulnerabilities (IDETECT-1872):
 * org.springframework.boot:spring-boot-starter 5.1.7.RELEASE BDSA-2020-0069 (CVE-2020-5398)
 * Resolved an issue where ${solution_name} had the potential to fail on projects that utilized Yarn workspaces (IDETECT-1916).
@@ -332,7 +338,8 @@ command is no longer executed, the detect.yarn.path property has been removed.
 * Detect now logs username, roles, and groups for the current user.
 * Detect now includes the project name/version in every code location name.
 * Detect now takes in a go path, but does not take in go.dep.path; nor does Detect trigger on *.go.
-* The property detect.parallel.processors is added. This property controls the number of parallel threads, and replaces the properties detect.blackduck.signature.scanner.parallel.processors and detect.hub.signature.scanner.parallel.processors.
+* The property detect.parallel.processors is added. This property controls the number of parallel threads, and replaces the properties detect.blackduck.signature.scanner.parallel.processors and
+detect.hub.signature.scanner.parallel.processors.
 * Added the property detect.maven.included.scopes. This is a comma-separated list of Maven scopes. Output is limited to dependencies within these scopes, and is overridden by exclude.
 * Added the property detect.maven.excluded.scopes. This is a comma-separated list of Maven scopes. Output is limited to dependencies outside these scopes, and is overridden by include.
 * Bazel detector: added support for dependencies specified using the maven_install workspace rule. The detect.bazel.advanced.rules.path property is removed.
@@ -341,7 +348,8 @@ command is no longer executed, the detect.yarn.path property has been removed.
 ### Changed features
 
 * Architecture is no longer included in BitBake dependencies discovered by Detect. The property detect.bitbake.reference.impl is no longer used and is deprecated.
-* The BitBake detector no longer uses the property detect.bitbake.reference.impl because architecture is no longer required to match with artifacts in the KnowledgeBase. The Bitbake detector now attempts to determine the layer in which a component originated instead of the architecture.
+* The BitBake detector no longer uses the property detect.bitbake.reference.impl because architecture is no longer required to match with artifacts in the KnowledgeBase. The Bitbake detector now attempts to determine the layer in which
+a component originated instead of the architecture.
 * Improved the Detect on-screen logging to be more concise.
 * The PiP inspector is no longer deprecated, and is currently supported.
 * When creating an air gap zip of Detect using the switch -z or --zip, the created zip file is now published to your output directory.
@@ -362,7 +370,8 @@ command is no longer executed, the detect.yarn.path property has been removed.
 * Resolved an issue wherein Detect was not finding the file recipe-depends.dot written to the current directory. Detect now looks in the source directory to a depth of 1 if it cannot find the expected files in the expected location.
 * Resolved an issue wherein Detect was failing if it could not resolve placeholders.
 * Resolved an issue wherein Detect was not handling SSH URLs, which caused Detect to fail in extracting project information from the Git executable. GitCliDetectable now properly handles SSH URLs.
-* Resolved an issue wherein the Detect JAR was downloading for each scan when the script could not communicate with Artifactory. Now, if the script cannot communicate with Artifactory, and there is an existing downloaded Detect, then the previously-downloaded version of Detect runs. However, if you provided a DETECT_LATEST_RELEASE_VERSION and Detect cannot communicate with Artifactory, Detect will not run.
+* Resolved an issue wherein the Detect JAR was downloading for each scan when the script could not communicate with Artifactory. Now, if the script cannot communicate with Artifactory, and there is an existing downloaded Detect, then
+the previously-downloaded version of Detect runs. However, if you provided a DETECT_LATEST_RELEASE_VERSION and Detect cannot communicate with Artifactory, Detect will not run.
 * Resolved an issue wherein Detect was not properly parsing GIT URLs such as git://git.yoctoproject.org/poky.git.
 
 ## Version 5.6.2
@@ -418,7 +427,8 @@ stale data to the BOM. Due to the new method of scanning, the code location name
 ### New features
 
 * Added support for snippet modes.
-* The property detect.wait.for.results is been added to wait for Black Duck. The default value is false. If this property is set to true, Detect won't complete until the normal timeout is reached or the underlying systems with which Detect is communicating are once again idle and ready to receive more data. The timeout value is controlled by blackduck.timeout.
+* The property detect.wait.for.results is been added to wait for Black Duck. The default value is false. If this property is set to true, Detect won't complete until the normal timeout is reached or the underlying systems with which
+Detect is communicating are once again idle and ready to receive more data. The timeout value is controlled by blackduck.timeout.
 * The shell script and PowerShell script now accept DETECT_JAVA_PATH and DETECT_JAVA_HOME as environment variables for pointing to your Java installation.
 * Added a new property --detect.detector.search.exclusion.paths. A comma-separated list of directory paths to exclude from a detector search. For example, foo/bar/biz only excludes the biz directory if the parent directory structure is
 'foo/bar/'.
@@ -434,7 +444,8 @@ stale data to the BOM. Due to the new method of scanning, the code location name
 * Resolved an issue wherein with two users running Detect on a single system may result in a Permission denied error.
 * Resolved an issue wherein the property -detect.policy.check.fail.on.severities may not be waiting for the snippet scans to complete.
 * Resolved an issue wherein the property --detect.blackduck.signature.scanner.exclusion.name.patterns may not be following the paths.
-* Resolved an issue wherein Detect may fail when the directory specified by --detect.risk.report.pdf.path did not exist. Detect now attempts to create the directory structure to the specified path. A warning is logged if Detect fails to create the directory.
+* Resolved an issue wherein Detect may fail when the directory specified by --detect.risk.report.pdf.path did not exist. Detect now attempts to create the directory structure to the specified path. A warning is logged if Detect fails to
+create the directory.
 * Resolved an issue wherein properties that had a primary group and additional property group may have been excluded from the group search.
 * Resolved an issue wherein the deprecation warning displayed when the deprecated property was provided by the user.
 * Resolved an issue with aggregate BOM filename generation that could cause the message Unable to relativize path, full source path will be used to display in the log.

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -373,14 +373,14 @@ public class DetectConfigurationFactory {
         String additionalArguments = PropertyConfigUtils
                                          .getFirstProvidedValueOrEmpty(detectConfiguration, DetectProperties.DETECT_BLACKDUCK_SIGNATURE_SCANNER_ARGUMENTS.getProperty())
                                          .orElse(null);
-        Path onlineLocalScannerInstallPath = PropertyConfigUtils.getFirstProvidedValueOrEmpty(detectConfiguration, DetectProperties.DETECT_BLACKDUCK_SIGNATURE_SCANNER_LOCAL_PATH.getProperty()).map(path -> path.resolvePath(pathResolver))
-                                                 .orElse(null);
+        Path localScannerInstallPath = PropertyConfigUtils.getFirstProvidedValueOrEmpty(detectConfiguration, DetectProperties.DETECT_BLACKDUCK_SIGNATURE_SCANNER_LOCAL_PATH.getProperty()).map(path -> path.resolvePath(pathResolver))
+                                           .orElse(null);
         Integer maxDepth = getValue(DetectProperties.DETECT_EXCLUDED_DIRECTORIES_SEARCH_DEPTH);
 
         return new BlackDuckSignatureScannerOptions(
             signatureScannerPaths,
             exclusionPatterns,
-            onlineLocalScannerInstallPath,
+            localScannerInstallPath,
             scanMemory,
             findParallelProcessors(),
             dryRun,

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationFactory.java
@@ -15,9 +15,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.synopsys.integration.bdio.model.dependency.Dependency;
-import com.synopsys.integration.blackduck.bdio.model.dependency.ProjectDependency;
-import com.synopsys.integration.detect.workflow.bdio.aggregation.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,10 +22,12 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.synopsys.integration.bdio.SimpleBdioFactory;
 import com.synopsys.integration.bdio.graph.DependencyGraph;
+import com.synopsys.integration.bdio.model.dependency.Dependency;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
 import com.synopsys.integration.blackduck.api.manual.view.DeveloperScanComponentResultView;
+import com.synopsys.integration.blackduck.bdio.model.dependency.ProjectDependency;
 import com.synopsys.integration.blackduck.bdio2.util.Bdio2Factory;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationService;
@@ -108,6 +107,8 @@ import com.synopsys.integration.detect.workflow.bdio.CreateAggregateCodeLocation
 import com.synopsys.integration.detect.workflow.bdio.CreateBdio1FilesOperation;
 import com.synopsys.integration.detect.workflow.bdio.CreateBdio2FilesOperation;
 import com.synopsys.integration.detect.workflow.bdio.DetectBdioWriter;
+import com.synopsys.integration.detect.workflow.bdio.aggregation.AggregateModeDirectOperation;
+import com.synopsys.integration.detect.workflow.bdio.aggregation.FullAggregateGraphCreator;
 import com.synopsys.integration.detect.workflow.blackduck.BlackDuckPostOptions;
 import com.synopsys.integration.detect.workflow.blackduck.DetectFontLoader;
 import com.synopsys.integration.detect.workflow.blackduck.bdio.IntelligentPersistentUploadOperation;
@@ -459,7 +460,7 @@ public class OperationFactory { //TODO: OperationRunner
     }
 
     public Optional<File> calculateOnlineLocalScannerInstallPath() throws DetectUserFriendlyException {
-        return auditLog.namedInternal("Calculate Online Local Scanner Path", () -> detectConfigurationFactory.createBlackDuckSignatureScannerOptions().getOnlineLocalScannerInstallPath().map(Path::toFile));
+        return auditLog.namedInternal("Calculate Online Local Scanner Path", () -> detectConfigurationFactory.createBlackDuckSignatureScannerOptions().getLocalScannerInstallPath().map(Path::toFile));
     }
 
     public ScanBatchRunner createScanBatchRunnerWithBlackDuck(BlackDuckRunData blackDuckRunData, File installDirectory) throws DetectUserFriendlyException {
@@ -586,11 +587,13 @@ public class OperationFactory { //TODO: OperationRunner
     }
 
     public DependencyGraph aggregateTransitive(List<DetectCodeLocation> detectCodeLocations) throws DetectUserFriendlyException {
-        return auditLog.namedPublic("Transitive Aggregate", "TransitiveAggregate", () -> (new FullAggregateGraphCreator(new SimpleBdioFactory())).aggregateCodeLocations(Dependency::new, directoryManager.getSourceDirectory(), detectCodeLocations));
+        return auditLog.namedPublic("Transitive Aggregate", "TransitiveAggregate",
+            () -> (new FullAggregateGraphCreator(new SimpleBdioFactory())).aggregateCodeLocations(Dependency::new, directoryManager.getSourceDirectory(), detectCodeLocations));
     }
 
     public DependencyGraph aggregateSubProject(List<DetectCodeLocation> detectCodeLocations) throws DetectUserFriendlyException {
-        return auditLog.namedPublic("SubProject Aggregate", "SubProjectAggregate", () -> (new FullAggregateGraphCreator(new SimpleBdioFactory())).aggregateCodeLocations(ProjectDependency::new, directoryManager.getSourceDirectory(), detectCodeLocations));
+        return auditLog.namedPublic("SubProject Aggregate", "SubProjectAggregate",
+            () -> (new FullAggregateGraphCreator(new SimpleBdioFactory())).aggregateCodeLocations(ProjectDependency::new, directoryManager.getSourceDirectory(), detectCodeLocations));
     }
 
     public void createAggregateBdio1File(AggregateCodeLocation aggregateCodeLocation) throws DetectUserFriendlyException {

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
@@ -20,7 +20,7 @@ public class BlackDuckSignatureScannerOptions {
     private final List<Path> signatureScannerPaths;
     private final List<String> exclusionPatterns;
     @Nullable
-    private final Path onlineLocalScannerInstallPath;
+    private final Path localScannerInstallPath;
 
     private final Integer scanMemory;
     private final Integer parallelProcessors;
@@ -45,7 +45,7 @@ public class BlackDuckSignatureScannerOptions {
     public BlackDuckSignatureScannerOptions(
         List<Path> signatureScannerPaths,
         List<String> exclusionPatterns,
-        @Nullable Path onlineLocalScannerInstallPath,
+        @Nullable Path localScannerInstallPath,
         Integer scanMemory,
         Integer parallelProcessors,
         Boolean dryRun,
@@ -61,7 +61,7 @@ public class BlackDuckSignatureScannerOptions {
 
         this.signatureScannerPaths = signatureScannerPaths;
         this.exclusionPatterns = exclusionPatterns;
-        this.onlineLocalScannerInstallPath = onlineLocalScannerInstallPath;
+        this.localScannerInstallPath = localScannerInstallPath;
         this.scanMemory = scanMemory;
         this.parallelProcessors = parallelProcessors;
         this.dryRun = dryRun;
@@ -120,8 +120,8 @@ public class BlackDuckSignatureScannerOptions {
         return maxDepth;
     }
 
-    public Optional<Path> getOnlineLocalScannerInstallPath() {
-        return Optional.ofNullable(onlineLocalScannerInstallPath);
+    public Optional<Path> getLocalScannerInstallPath() {
+        return Optional.ofNullable(localScannerInstallPath);
     }
 
     public Optional<IndividualFileMatching> getIndividualFileMatching() {


### PR DESCRIPTION
(IDETECT-2829)

Make sure SignatureScanStepRunner honors value of BlackDuckSignatureScannerOptions.localScannerInstallPath when in offline mode.
