### PR TITLE
FilterableEnumList as a first class concept

### DIFF
--- a/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumList.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumList.java
@@ -1,0 +1,44 @@
+/*
+ * configuration
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.configuration.property.types.enumfilterable;
+
+import java.util.List;
+
+public class FilterableEnumList<T extends Enum<T>> {
+    private final List<FilterableEnumValue<T>> providedValues;
+    private final Class<T> enumClass;
+
+    public FilterableEnumList(List<FilterableEnumValue<T>> providedValues, Class<T> enumClass) {
+        this.providedValues = providedValues;
+        this.enumClass = enumClass;
+    }
+
+    public boolean containsNone() {
+        return FilterableEnumUtils.containsNone(providedValues);
+    }
+
+    public boolean containsAll() {
+        return FilterableEnumUtils.containsAll(providedValues);
+    }
+
+    public boolean containsValue(T value) {
+        return FilterableEnumUtils.containsValue(providedValues, value);
+    }
+
+    public List<T> toPresentValues() {
+        return FilterableEnumUtils.toPresentValues(providedValues);
+    }
+
+    public List<T> representedValues() {
+        return FilterableEnumUtils.representedValues(providedValues, enumClass);
+    }
+
+    public List<FilterableEnumValue<T>> toFilterableValues() {
+        return providedValues;
+    }
+}

--- a/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumListParser.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumListParser.java
@@ -1,0 +1,34 @@
+/*
+ * configuration
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.configuration.property.types.enumfilterable;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.synopsys.integration.configuration.parse.ListValueParser;
+import com.synopsys.integration.configuration.parse.ValueParseException;
+import com.synopsys.integration.configuration.parse.ValueParser;
+
+public class FilterableEnumListParser<T extends Enum<T>> extends ValueParser<FilterableEnumList<T>> {
+    private ListValueParser<FilterableEnumValue<T>> listValueParser;
+    private final Class<T> enumClass;
+
+    public FilterableEnumListParser(@NotNull ListValueParser<FilterableEnumValue<T>> listValueParser, @NotNull Class<T> enumClass) {
+        this.listValueParser = listValueParser;
+        this.enumClass = enumClass;
+    }
+
+    public FilterableEnumListParser(@NotNull Class<T> enumClass) {
+        this(new ListValueParser<>(new FilterableEnumValueParser<>(enumClass)), enumClass);
+    }
+
+    @NotNull
+    @Override
+    public FilterableEnumList<T> parse(@NotNull final String value) throws ValueParseException {
+        return new FilterableEnumList<T>(listValueParser.parse(value), enumClass);
+    }
+}

--- a/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumListProperty.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumListProperty.java
@@ -12,17 +12,16 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import com.synopsys.integration.configuration.parse.ListValueParser;
-import com.synopsys.integration.configuration.property.base.ValuedListProperty;
+import com.synopsys.integration.configuration.property.base.ValuedProperty;
 import com.synopsys.integration.configuration.util.EnumPropertyUtils;
 import com.synopsys.integration.configuration.util.PropertyUtils;
 
-public class FilterableEnumListProperty<E extends Enum<E>> extends ValuedListProperty<FilterableEnumValue<E>> {
+public class FilterableEnumListProperty<E extends Enum<E>> extends ValuedProperty<FilterableEnumList<E>> {
     @NotNull
     private final Class<E> enumClass;
 
     public FilterableEnumListProperty(@NotNull String key, @NotNull List<FilterableEnumValue<E>> defaultValue, @NotNull Class<E> enumClass) {
-        super(key, new ListValueParser<>(new FilterableEnumValueParser<>(enumClass)), defaultValue);
+        super(key, new FilterableEnumListParser<>(enumClass), new FilterableEnumList<>(defaultValue, enumClass));
         this.enumClass = enumClass;
     }
 
@@ -40,7 +39,7 @@ public class FilterableEnumListProperty<E extends Enum<E>> extends ValuedListPro
     @Nullable
     @Override
     public String describeDefault() {
-        return PropertyUtils.describeObjectList(getDefaultValue());
+        return PropertyUtils.describeObjectList(getDefaultValue().toFilterableValues());
     }
 
     @Nullable

--- a/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumUtils.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumUtils.java
@@ -41,6 +41,7 @@ public class FilterableEnumUtils {
                    .anyMatch(value::equals);
     }
 
+    //The set of values actually PRESENT in the underlying collection, regardless of NONE, ALL. Example LIST(ALL, VALUE1, VALUE2) -> [VALUE1, VALUE2]
     public static <T extends Enum<T>> List<T> toPresentValues(@NotNull List<FilterableEnumValue<T>> filterableList) {
         return filterableList.stream()
                    .map(FilterableEnumValue::getValue)
@@ -49,7 +50,8 @@ public class FilterableEnumUtils {
                    .collect(Collectors.toList());
     }
 
-    public static <T extends Enum<T>> List<T> populatedValues(@NotNull List<FilterableEnumValue<T>> filterableList, Class<T> enumClass) {
+    //The set of values REPRESENTED by the underlying collection, basically ALL and NONE are resolved to their actual values. So LIST(ALL) -> [VALUE1, VALUE2 ...]
+    public static <T extends Enum<T>> List<T> representedValues(@NotNull List<FilterableEnumValue<T>> filterableList, Class<T> enumClass) {
         if (FilterableEnumUtils.containsNone(filterableList)) {
             return new ArrayList<>();
         } else if (FilterableEnumUtils.containsAll(filterableList)) {

--- a/configuration/src/test/java/com/synopsys/integration/configuration/property/PropertyTestHelpUtil.java
+++ b/configuration/src/test/java/com/synopsys/integration/configuration/property/PropertyTestHelpUtil.java
@@ -90,8 +90,6 @@ public class PropertyTestHelpUtil {
         assertHasTypeDescription(property);
         Assertions.assertFalse(property.describeType().startsWith(NULLABLE_TYPE_DESCRIPTION_PREFIX),
             String.format("%s is a %s so its type description should not start with '%s'.", property.getClass().getSimpleName(), ValuedProperty.class.getSimpleName(), NULLABLE_TYPE_DESCRIPTION_PREFIX));
-        Assertions.assertFalse(property.describeType().endsWith(VALUED_TYPE_DESCRIPTION_POSTFIX),
-            String.format("%s is a %s so its type description should not end with '%s'.", property.getClass().getSimpleName(), ValuedProperty.class.getSimpleName(), VALUED_TYPE_DESCRIPTION_POSTFIX));
     }
 
     public static <T> void assertValidTypeDescription(final ValuedListProperty<T> property) {

--- a/configuration/src/test/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumPropertiesTests.java
+++ b/configuration/src/test/java/com/synopsys/integration/configuration/property/types/enumfilterable/FilterableEnumPropertiesTests.java
@@ -83,7 +83,7 @@ class FilterableEnumPropertiesTests {
         final FilterableEnumListProperty<Example> property = new FilterableEnumListProperty<>("enum.list", Arrays.asList(FilterableEnumValue.value(Example.ANOTHER), FilterableEnumValue.value(Example.THING)), Example.class);
         final PropertyConfiguration config = configOf(Pair.of("enum.valued", "ANOTHER,THING"));
 
-        final List<FilterableEnumValue<Example>> value = config.getValue(property);
+        final List<FilterableEnumValue<Example>> value = config.getValue(property).toFilterableValues();
 
         if (FilterableEnumUtils.containsNone(value)) {
             fail("Expected type to be Value instead of None.");
@@ -93,6 +93,6 @@ class FilterableEnumPropertiesTests {
             Assertions.assertEquals(Arrays.asList(FilterableEnumValue.value(Example.ANOTHER), FilterableEnumValue.value(Example.THING)), value);
         }
 
-        PropertyTestHelpUtil.assertAllListHelpValid(property, Arrays.asList("THING", "ANOTHER", "THIRD", "NONE", "ALL"));
+        PropertyTestHelpUtil.assertAllHelpValid(property, Arrays.asList("THING", "ANOTHER", "THIRD", "NONE", "ALL"));
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -35,8 +35,7 @@ import com.synopsys.integration.configuration.config.PropertyConfiguration;
 import com.synopsys.integration.configuration.property.base.NullableProperty;
 import com.synopsys.integration.configuration.property.base.ValuedProperty;
 import com.synopsys.integration.configuration.property.types.enumextended.ExtendedEnumValue;
-import com.synopsys.integration.configuration.property.types.enumfilterable.FilterableEnumUtils;
-import com.synopsys.integration.configuration.property.types.enumfilterable.FilterableEnumValue;
+import com.synopsys.integration.configuration.property.types.enumfilterable.FilterableEnumList;
 import com.synopsys.integration.configuration.property.types.path.NullablePathProperty;
 import com.synopsys.integration.configuration.property.types.path.PathResolver;
 import com.synopsys.integration.configuration.property.types.path.PathValue;
@@ -203,8 +202,8 @@ public class DetectConfigurationFactory {
     public DetectToolFilter createToolFilter(RunDecision runDecision, BlackDuckDecision blackDuckDecision) {
         Optional<Boolean> impactEnabled = Optional.of(detectConfiguration.getValue(DetectProperties.DETECT_IMPACT_ANALYSIS_ENABLED.getProperty()));
 
-        List<FilterableEnumValue<DetectTool>> includedTools = getValue(DetectProperties.DETECT_TOOLS);
-        List<FilterableEnumValue<DetectTool>> excludedTools = getValue(DetectProperties.DETECT_TOOLS_EXCLUDED);
+        FilterableEnumList<DetectTool> includedTools = getValue(DetectProperties.DETECT_TOOLS);
+        FilterableEnumList<DetectTool> excludedTools = getValue(DetectProperties.DETECT_TOOLS_EXCLUDED);
         ExcludeIncludeEnumFilter<DetectTool> filter = new ExcludeIncludeEnumFilter<>(excludedTools, includedTools);
         return new DetectToolFilter(filter, impactEnabled.orElse(false), runDecision, blackDuckDecision);
     }
@@ -276,9 +275,9 @@ public class DetectConfigurationFactory {
         Boolean forceNestedSearch = getValue(DetectProperties.DETECT_DETECTOR_SEARCH_CONTINUE);
 
         //Detector Filter
-        List<FilterableEnumValue<DetectorType>> excluded = getValue(DetectProperties.DETECT_EXCLUDED_DETECTOR_TYPES);
-        List<FilterableEnumValue<DetectorType>> included = getValue(DetectProperties.DETECT_INCLUDED_DETECTOR_TYPES);
-        ExcludeIncludeEnumFilter detectorFilter = new ExcludeIncludeEnumFilter(excluded, included);
+        FilterableEnumList<DetectorType> excluded = getValue(DetectProperties.DETECT_EXCLUDED_DETECTOR_TYPES);
+        FilterableEnumList<DetectorType> included = getValue(DetectProperties.DETECT_INCLUDED_DETECTOR_TYPES);
+        ExcludeIncludeEnumFilter<DetectorType> detectorFilter = new ExcludeIncludeEnumFilter<>(excluded, included);
 
         return new DetectorEvaluationOptions(forceNestedSearch, getFollowSymLinks(), (rule -> detectorFilter.shouldInclude(rule.getDetectorType())));
     }
@@ -312,8 +311,7 @@ public class DetectConfigurationFactory {
         Integer projectTier = getNullableValue(DetectProperties.DETECT_PROJECT_TIER);
         String projectDescription = getNullableValue(DetectProperties.DETECT_PROJECT_DESCRIPTION);
         String projectVersionNotes = getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NOTES);
-        List<FilterableEnumValue<ProjectCloneCategoriesType>> filterableCloneCategories = getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES);
-        List<ProjectCloneCategoriesType> cloneCategories = FilterableEnumUtils.populatedValues(filterableCloneCategories, ProjectCloneCategoriesType.class);
+        List<ProjectCloneCategoriesType> cloneCategories = getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).representedValues();
         Boolean projectLevelAdjustments = getValue(DetectProperties.DETECT_PROJECT_LEVEL_ADJUSTMENTS);
         Boolean forceProjectVersionUpdate = getValue(DetectProperties.DETECT_PROJECT_VERSION_UPDATE);
         String projectVersionNickname = getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NICKNAME);
@@ -414,8 +412,7 @@ public class DetectConfigurationFactory {
         Boolean runNoticesReport = getValue(DetectProperties.DETECT_NOTICES_REPORT);
         Path riskReportPdfPath = getPathOrNull(DetectProperties.DETECT_RISK_REPORT_PDF_PATH);
         Path noticesReportPath = getPathOrNull(DetectProperties.DETECT_NOTICES_REPORT_PATH);
-        List<FilterableEnumValue<PolicyRuleSeverityType>> policySeverities = getValue(DetectProperties.DETECT_POLICY_CHECK_FAIL_ON_SEVERITIES);
-        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = FilterableEnumUtils.populatedValues(policySeverities, PolicyRuleSeverityType.class);
+        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = getValue(DetectProperties.DETECT_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
 
         return new BlackDuckPostOptions(waitForResults, runRiskReport, runNoticesReport, riskReportPdfPath, noticesReportPath, severitiesToFailPolicyCheck);
     }

--- a/src/main/java/com/synopsys/integration/detect/configuration/ExcludeIncludeEnumFilter.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/ExcludeIncludeEnumFilter.java
@@ -9,6 +9,7 @@ package com.synopsys.integration.detect.configuration;
 
 import java.util.List;
 
+import com.synopsys.integration.configuration.property.types.enumfilterable.FilterableEnumList;
 import com.synopsys.integration.configuration.property.types.enumfilterable.FilterableEnumUtils;
 import com.synopsys.integration.configuration.property.types.enumfilterable.FilterableEnumValue;
 
@@ -19,6 +20,11 @@ public class ExcludeIncludeEnumFilter<T extends Enum<T>> {
     public ExcludeIncludeEnumFilter(List<FilterableEnumValue<T>> excluded, List<FilterableEnumValue<T>> included) {
         this.excluded = excluded;
         this.included = included;
+    }
+
+    public ExcludeIncludeEnumFilter(FilterableEnumList<T> excluded, FilterableEnumList<T> included) {
+        this.excluded = excluded.toFilterableValues();
+        this.included = included.toFilterableValues();
     }
 
     private boolean willExclude(T value) {


### PR DESCRIPTION
FilterableEnumList is now a class - so you can ask it things like 'containsValue', 'containsAll' or 'representedValues' directly from getValue and without having to know about the enum utils. This uses all the existing code under the hood and is simply a convenience wrapper that makes using the list a bit more intuitive. 