### PR TITLE
Pnpm packages

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLinkedPackageResolver.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLinkedPackageResolver.java
@@ -1,0 +1,49 @@
+package com.synopsys.integration.detectable.detectables.pnpm.lockfile;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.NullSafePackageJson;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonFiles;
+
+public class PnpmLinkedPackageResolver {
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final File projectRoot;
+    private PackageJsonFiles packageJsonFiles;
+
+    public PnpmLinkedPackageResolver(File projectRoot, PackageJsonFiles packageJsonFiles) {
+        this.projectRoot = projectRoot;
+        this.packageJsonFiles = packageJsonFiles;
+    }
+
+    @Nullable
+    public String resolveVersionOfLinkedPackage(@Nullable String reportingProjectPackagePath, String relativePathToLinkedPackage) {
+        File reportingPackage;
+        if (reportingProjectPackagePath != null) {
+            reportingPackage = new File(projectRoot, reportingProjectPackagePath);
+        } else {
+            reportingPackage = projectRoot;
+        }
+        File linkedPackage = new File(reportingPackage, relativePathToLinkedPackage);
+        File packageJsonFile = new File(linkedPackage, "package.json");
+
+        if (!packageJsonFile.exists()) {
+            logger.debug(String.format("Unable to resolve version for linked package: %s", linkedPackage));
+            return null;
+        }
+
+        try {
+            NullSafePackageJson packageJson = packageJsonFiles.read(packageJsonFile);
+            return packageJson.getVersionString();
+        } catch (IOException e) {
+            logger.debug(String.format("Unable to parse package.json: %s", packageJsonFile.getAbsolutePath()));
+            return null;
+        }
+    }
+
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLinkedPackageResolver.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLinkedPackageResolver.java
@@ -1,3 +1,10 @@
+/*
+ * detectable
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.detectable.detectables.pnpm.lockfile;
 
 import java.io.File;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLockDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLockDetectable.java
@@ -21,6 +21,7 @@ import com.synopsys.integration.detectable.detectable.annotation.DetectableInfo;
 import com.synopsys.integration.detectable.detectable.enums.DependencyType;
 import com.synopsys.integration.detectable.detectable.result.DetectableResult;
 import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonFiles;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 
@@ -34,15 +35,17 @@ public class PnpmLockDetectable extends Detectable {
     private final FileFinder fileFinder;
     private final PnpmLockExtractor pnpmExtractor;
     private final List<DependencyType> dependencyTypes;
+    private final PackageJsonFiles packageJsonFiles;
 
     private File pnpmLockYaml;
     private File packageJson;
 
-    public PnpmLockDetectable(DetectableEnvironment environment, FileFinder fileFinder, PnpmLockExtractor pnpmExtractor, List<DependencyType> dependencyTypes) {
+    public PnpmLockDetectable(DetectableEnvironment environment, FileFinder fileFinder, PnpmLockExtractor pnpmExtractor, List<DependencyType> dependencyTypes, PackageJsonFiles packageJsonFiles) {
         super(environment);
         this.fileFinder = fileFinder;
         this.pnpmExtractor = pnpmExtractor;
         this.dependencyTypes = dependencyTypes;
+        this.packageJsonFiles = packageJsonFiles;
     }
 
     @Override
@@ -60,6 +63,7 @@ public class PnpmLockDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) {
-        return pnpmExtractor.extract(pnpmLockYaml, packageJson, dependencyTypes);
+        PnpmLinkedPackageResolver linkedPackageResolver = new PnpmLinkedPackageResolver(pnpmLockYaml.getParentFile(), packageJsonFiles); // we are assuming parent of the lock file we are parsing is the project root
+        return pnpmExtractor.extract(pnpmLockYaml, packageJson, dependencyTypes, linkedPackageResolver);
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLockYamlParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLockYamlParser.java
@@ -35,6 +35,7 @@ public class PnpmLockYamlParser {
         this.pnpmTransformer = pnpmTransformer;
     }
 
+    //TODO- can we improve this by utilizing streams?
     public List<CodeLocation> parse(File pnpmLockYamlFile, List<DependencyType> dependencyTypes, @Nullable NameVersion projectNameVersion, PnpmLinkedPackageResolver linkedPackageResolver) throws IOException, IntegrationException {
         Representer representer = new Representer();
         representer.getPropertyUtils().setSkipMissingProperties(true);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLockYamlParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLockYamlParser.java
@@ -10,8 +10,11 @@ package com.synopsys.integration.detectable.detectables.pnpm.lockfile;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.collections4.MapUtils;
 import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -19,7 +22,9 @@ import org.yaml.snakeyaml.representer.Representer;
 
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectable.enums.DependencyType;
+import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.model.PnpmLockYaml;
+import com.synopsys.integration.detectable.detectables.pnpm.lockfile.model.PnpmProjectPackage;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.NameVersion;
 
@@ -30,12 +35,40 @@ public class PnpmLockYamlParser {
         this.pnpmTransformer = pnpmTransformer;
     }
 
-    public CodeLocation parse(File pnpmLockYamlFile, List<DependencyType> dependencyTypes, @Nullable NameVersion projectNameVersion) throws IOException, IntegrationException {
+    public List<CodeLocation> parse(File pnpmLockYamlFile, List<DependencyType> dependencyTypes, @Nullable NameVersion projectNameVersion, PnpmLinkedPackageResolver linkedPackageResolver) throws IOException, IntegrationException {
         Representer representer = new Representer();
         representer.getPropertyUtils().setSkipMissingProperties(true);
         Yaml yaml = new Yaml(new Constructor(PnpmLockYaml.class), representer);
         PnpmLockYaml pnpmLockYaml = yaml.load(new FileReader(pnpmLockYamlFile));
-
-        return pnpmTransformer.generateCodeLocation(pnpmLockYaml, dependencyTypes, projectNameVersion);
+        List<CodeLocation> codeLocations = new LinkedList<>();
+        if (MapUtils.isNotEmpty(pnpmLockYaml.importers)) {
+            for (Map.Entry<String, PnpmProjectPackage> projectPackageInfo : pnpmLockYaml.importers.entrySet()) {
+                String projectPackageName;
+                String projectPackageVersion;
+                String reportingProjectPackagePath;
+                if (projectPackageInfo.getKey().equals(".") && projectNameVersion != null && projectNameVersion.getName() != null) {
+                    // resolve "." package to project root
+                    projectPackageName = projectNameVersion.getName();
+                    projectPackageVersion = projectNameVersion.getVersion();
+                    reportingProjectPackagePath = null;
+                } else {
+                    projectPackageName = projectPackageInfo.getKey();
+                    projectPackageVersion = linkedPackageResolver.resolveVersionOfLinkedPackage(null, projectPackageName);
+                    reportingProjectPackagePath = projectPackageName;
+                }
+                PnpmProjectPackage projectPackage = projectPackageInfo.getValue();
+                codeLocations.add(pnpmTransformer.generateCodeLocation(projectPackage, reportingProjectPackagePath, dependencyTypes, new NameVersion(projectPackageName, projectPackageVersion), pnpmLockYaml.packages, linkedPackageResolver));
+            }
+        }
+        try {
+            codeLocations.add(pnpmTransformer.generateCodeLocation(pnpmLockYaml, dependencyTypes, projectNameVersion, linkedPackageResolver));
+        } catch (DetectableException e) {
+            if (!codeLocations.isEmpty()) {
+                // If lock file is structured such that all root dependencies are declared in importers section, ignore exception
+            } else {
+                throw e;
+            }
+        }
+        return codeLocations;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/model/PnpmLockYaml.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/model/PnpmLockYaml.java
@@ -13,6 +13,9 @@ import org.jetbrains.annotations.Nullable;
 
 public class PnpmLockYaml {
     @Nullable
+    public Map<String, PnpmProjectPackage> importers;
+
+    @Nullable
     public Map<String, String> dependencies;
 
     @Nullable

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/model/PnpmProjectPackage.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/model/PnpmProjectPackage.java
@@ -1,0 +1,16 @@
+package com.synopsys.integration.detectable.detectables.pnpm.lockfile.model;
+
+import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
+
+public class PnpmProjectPackage {
+    @Nullable
+    public Map<String, String> dependencies;
+
+    @Nullable
+    public Map<String, String> devDependencies;
+
+    @Nullable
+    public Map<String, String> optionalDependencies;
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/model/PnpmProjectPackage.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/model/PnpmProjectPackage.java
@@ -1,3 +1,10 @@
+/*
+ * detectable
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.detectable.detectables.pnpm.lockfile.model;
 
 import java.util.Map;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -441,7 +441,7 @@ public class DetectableFactory {
     }
 
     public PnpmLockDetectable createPnpmLockDetectable(DetectableEnvironment environment, List<DependencyType> dependencyTypes) {
-        return new PnpmLockDetectable(environment, fileFinder, pnpmLockExtractor(), dependencyTypes);
+        return new PnpmLockDetectable(environment, fileFinder, pnpmLockExtractor(), dependencyTypes, packageJsonFiles());
     }
 
     public PodlockDetectable createPodLockDetectable(DetectableEnvironment environment) {
@@ -759,7 +759,7 @@ public class DetectableFactory {
     }
 
     private PnpmLockExtractor pnpmLockExtractor() {
-        return new PnpmLockExtractor(gson, pnpmLockYamlParser());
+        return new PnpmLockExtractor(pnpmLockYamlParser(), packageJsonFiles());
     }
 
     private PnpmLockYamlParser pnpmLockYamlParser() {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/functional/PnpmLinkedPackageResolverTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/functional/PnpmLinkedPackageResolverTest.java
@@ -1,0 +1,19 @@
+package com.synopsys.integration.detectable.detectables.pnpm.functional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLinkedPackageResolver;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonFiles;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonReader;
+import com.synopsys.integration.detectable.util.FunctionalTestFiles;
+
+public class PnpmLinkedPackageResolverTest {
+    PnpmLinkedPackageResolver pnpmLinkedPackageResolver = new PnpmLinkedPackageResolver(FunctionalTestFiles.asFile("/pnpm"), new PackageJsonFiles(new PackageJsonReader(new Gson())));
+
+    @Test
+    public void testResolveVersionOfLinkedPackage() {
+        Assertions.assertEquals("1.0.0", pnpmLinkedPackageResolver.resolveVersionOfLinkedPackage(null, "linkedProjectPackage"));
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/functional/PnpmLockDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/functional/PnpmLockDetectableTest.java
@@ -68,6 +68,9 @@ public class PnpmLockDetectableTest extends DetectableFunctionalTest {
     public void assertExtraction(@NotNull Extraction extraction) {
         Assertions.assertEquals(1, extraction.getCodeLocations().size());
 
+        Assertions.assertEquals("project", extraction.getProjectName());
+        Assertions.assertEquals("version", extraction.getProjectVersion());
+
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, extraction.getCodeLocations().get(0).getDependencyGraph());
         graphAssert.hasRootSize(2);
         graphAssert.hasRootDependency("material-design-icons", "3.0.1");

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/functional/PnpmLockDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/functional/PnpmLockDetectableTest.java
@@ -22,7 +22,12 @@ public class PnpmLockDetectableTest extends DetectableFunctionalTest {
 
     @Override
     protected void setup() throws IOException {
-        addFile("package.json");
+        addFile(Paths.get("package.json"),
+            "{",
+            "name: \"project\",",
+            "version: \"version\"",
+            "}"
+        );
 
         addFile(Paths.get("pnpm-lock.yaml"),
             "lockfileVersion: 1.0.0",

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/functional/PnpmLockYamlParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/functional/PnpmLockYamlParserTest.java
@@ -1,0 +1,43 @@
+package com.synopsys.integration.detectable.detectables.pnpm.functional;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
+import com.synopsys.integration.detectable.detectable.enums.DependencyType;
+import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLinkedPackageResolver;
+import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLockYamlParser;
+import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmYamlTransformer;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonFiles;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonReader;
+import com.synopsys.integration.detectable.util.FunctionalTestFiles;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.util.NameVersion;
+
+public class PnpmLockYamlParserTest {
+    File pnpmLockYaml = FunctionalTestFiles.asFile("/pnpm/pnpm-lock.yaml");
+    PnpmLockYamlParser pnpmLockYamlParser = new PnpmLockYamlParser(new PnpmYamlTransformer(new ExternalIdFactory()));
+    PnpmLinkedPackageResolver pnpmLinkedPackageResolver = new PnpmLinkedPackageResolver(FunctionalTestFiles.asFile("/pnpm"), new PackageJsonFiles(new PackageJsonReader(new Gson())));
+
+    @Test
+    public void testParse() throws IOException, IntegrationException {
+        List<CodeLocation> codeLocations = pnpmLockYamlParser.parse(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), new NameVersion("project", "version"), pnpmLinkedPackageResolver);
+
+        Assertions.assertEquals(2, codeLocations.size());
+
+        // Did we correctly identify root project package in "importers"?
+        Assertions.assertTrue(codeLocations.stream()
+                                  .anyMatch(
+                                      codeLocation -> codeLocation.getExternalId().get().getName().equals("project") && codeLocation.getExternalId().get().getName().equals("project")
+                                  )
+        );
+    }
+
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmLockExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmLockExtractorTest.java
@@ -8,15 +8,19 @@ import org.junit.jupiter.api.Test;
 import com.google.gson.Gson;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.detectable.detectable.enums.DependencyType;
+import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLinkedPackageResolver;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLockExtractor;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLockYamlParser;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmYamlTransformer;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonFiles;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonReader;
 
 public class PnpmLockExtractorTest {
-    PnpmLockExtractor extractor = new PnpmLockExtractor(new Gson(), new PnpmLockYamlParser(new PnpmYamlTransformer(new ExternalIdFactory())));
+    PackageJsonFiles packageJsonFiles = new PackageJsonFiles(new PackageJsonReader(new Gson()));
+    PnpmLockExtractor extractor = new PnpmLockExtractor(new PnpmLockYamlParser(new PnpmYamlTransformer(new ExternalIdFactory())), packageJsonFiles);
 
     @Test
     public void testNoFailureOnNullPackageJson() {
-        extractor.extract(new File("pnpm-lock.yaml"), null, Arrays.asList(DependencyType.OPTIONAL, DependencyType.DEV));
+        extractor.extract(new File("pnpm-lock.yaml"), null, Arrays.asList(DependencyType.OPTIONAL, DependencyType.DEV), new PnpmLinkedPackageResolver(new File(""), packageJsonFiles));
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmYamlTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmYamlTransformerTest.java
@@ -85,10 +85,10 @@ public class PnpmYamlTransformerTest {
         pnpmLockYaml.dependencies = null;
         pnpmLockYaml.devDependencies = null;
         pnpmLockYaml.optionalDependencies = null;
-        try {
-            pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver);
-        } catch (IntegrationException e) {
-        }
+
+        Assertions.assertThrows(IntegrationException.class,
+            () -> pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver)
+        );
     }
 
     @Test

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmYamlTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmYamlTransformerTest.java
@@ -1,5 +1,6 @@
 package com.synopsys.integration.detectable.detectables.pnpm.unit;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -7,14 +8,18 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.google.gson.Gson;
 import com.synopsys.integration.bdio.graph.DependencyGraph;
 import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectable.enums.DependencyType;
+import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLinkedPackageResolver;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmYamlTransformer;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.model.PnpmLockYaml;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.model.PnpmPackage;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonFiles;
+import com.synopsys.integration.detectable.detectables.yarn.packagejson.PackageJsonReader;
 import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.NameVersion;
@@ -23,10 +28,11 @@ public class PnpmYamlTransformerTest {
     private PnpmLockYaml pnpmLockYaml = createPnpmLockYaml();
     PnpmYamlTransformer pnpmTransformer = new PnpmYamlTransformer(new ExternalIdFactory());
     NameVersion projectNameVersion = new NameVersion("name", "version");
+    PnpmLinkedPackageResolver linkedPackageResolver = new PnpmLinkedPackageResolver(new File(""), new PackageJsonFiles(new PackageJsonReader(new Gson())));
 
     @Test
     public void testGenerateCodeLocation() throws IntegrationException {
-        CodeLocation codeLocation = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion);
+        CodeLocation codeLocation = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver);
 
         Assertions.assertEquals("name", codeLocation.getExternalId().get().getName());
         Assertions.assertEquals("version", codeLocation.getExternalId().get().getVersion());
@@ -42,14 +48,14 @@ public class PnpmYamlTransformerTest {
 
     @Test
     public void testExcludeDependencies() throws IntegrationException {
-        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion).getDependencyGraph();
+        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver).getDependencyGraph();
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootSize(2);
     }
 
     @Test
     public void testExcludeDevDependencies() throws IntegrationException {
-        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.OPTIONAL), projectNameVersion).getDependencyGraph();
+        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver).getDependencyGraph();
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootSize(2);
         graphAssert.hasNoDependency("devDep", "2.0.0");
@@ -57,7 +63,7 @@ public class PnpmYamlTransformerTest {
 
     @Test
     public void testExcludeOptionalDependencies() throws IntegrationException {
-        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV), projectNameVersion).getDependencyGraph();
+        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV), projectNameVersion, linkedPackageResolver).getDependencyGraph();
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootSize(2);
         graphAssert.hasNoDependency("optDep", "3.0.0");
@@ -68,7 +74,7 @@ public class PnpmYamlTransformerTest {
         PnpmLockYaml pnpmLockYaml = createPnpmLockYaml();
         pnpmLockYaml.packages = null;
         try {
-            pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion);
+            pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver);
         } catch (IntegrationException e) {
         }
     }
@@ -80,14 +86,14 @@ public class PnpmYamlTransformerTest {
         pnpmLockYaml.devDependencies = null;
         pnpmLockYaml.optionalDependencies = null;
         try {
-            pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion);
+            pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver);
         } catch (IntegrationException e) {
         }
     }
 
     @Test
     public void testNoFailureOnNullNameVersion() throws IntegrationException {
-        pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), null);
+        pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), null, linkedPackageResolver);
     }
 
     private PnpmLockYaml createPnpmLockYaml() {

--- a/detectable/src/test/resources/detectables/functional/pnpm/linkedProjectPackage/package.json
+++ b/detectable/src/test/resources/detectables/functional/pnpm/linkedProjectPackage/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "linkedProjectPackage",
+  "version": "1.0.0"
+}

--- a/detectable/src/test/resources/detectables/functional/pnpm/pnpm-lock.yaml
+++ b/detectable/src/test/resources/detectables/functional/pnpm/pnpm-lock.yaml
@@ -1,0 +1,48 @@
+lockfileVersion: 5.3
+
+importers:
+
+  .:
+    specifiers:
+      react: ^17.0.2
+      react-dom: ^17.0.2
+      react-is: ^17.0.2
+      styled-components: ^5.3.3
+      typescript: ^4.3.4
+    devDependencies:
+      '@babel/cli': 7.15.7_@babel+core@7.15.8
+      '@babel/code-frame': 7.10.4
+
+  packages/@styled-icons/bootstrap:
+    specifiers:
+      '@babel/runtime': ^7.15.4
+      '@styled-icons/pack-builder': ^1.0.0
+    dependencies:
+      '@babel/runtime': 7.15.4
+      '@styled-icons/styled-icon': link:../linkedProjectPackage
+
+packages:
+
+  /@babel/code-frame/7.10.4:
+    resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
+    dependencies:
+      '@babel/highlight': 7.14.5
+    dev: true
+
+  /@babel/cli/7.15.7_@babel+core@7.15.8:
+    resolution: {integrity: sha512-YW5wOprO2LzMjoWZ5ZG6jfbY9JnkDxuHDwvnrThnuYtByorova/I0HNXJedrUfwuXFQfYOjcqDA4PU3qlZGZjg==}
+    engines: {node: '>=6.9.0'}
+    hasBin: true
+    optionalDependencies:
+      '@babel/core': ^7.0.0-0
+    dev: true
+
+  /@babel/runtime/7.15.4:
+    resolution: {integrity: sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.7
+
+  /@babel/core/7.12.9:
+    resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
+    engines: {node: '>=6.9.0'}

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
@@ -112,6 +112,7 @@ public class DetectorRuleFactory {
         ruleSet.yield(npmShrinkwrap).to(lernaDetectable);
         ruleSet.yield(npmCli).to(lernaDetectable);
         ruleSet.yield(yarnLock).to(lernaDetectable);
+        ruleSet.yield(pnpmLock).to(lernaDetectable);
 
         ruleSet.yield(npmShrinkwrap).to(npmPackageLock);
         ruleSet.yield(npmCli).to(npmPackageLock);
@@ -122,7 +123,6 @@ public class DetectorRuleFactory {
         ruleSet.yield(npmShrinkwrap).to(yarnLock);
 
         ruleSet.yield(npmCli).to(pnpmLock);
-        //TODO- in at least one sample project, both lerna and pnpm were applicable.  In that case, Lerna wasn't extractable and thus Overall Status: FAILURE_DETECTOR.  Should one yield to the other?
 
         DetectorRule nugetSolution = ruleSet.addDetector(DetectorType.NUGET, "Solution", NugetSolutionDetectable.class, detectableFactory::createNugetSolutionDetectable).defaults().build();
         //The Project detectable is "notNestable" because it will falsely apply under a solution (the solution includes all of the projects).

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
@@ -122,6 +122,7 @@ public class DetectorRuleFactory {
         ruleSet.yield(npmShrinkwrap).to(yarnLock);
 
         ruleSet.yield(npmCli).to(pnpmLock);
+        //TODO- in at least one sample project, both lerna and pnpm were applicable.  In that case, Lerna wasn't extractable and thus Overall Status: FAILURE_DETECTOR.  Should one yield to the other?
 
         DetectorRule nugetSolution = ruleSet.addDetector(DetectorType.NUGET, "Solution", NugetSolutionDetectable.class, detectableFactory::createNugetSolutionDetectable).defaults().build();
         //The Project detectable is "notNestable" because it will falsely apply under a solution (the solution includes all of the projects).


### PR DESCRIPTION
Enhancement to pnpm support geared towards handling projects with multiple project packages (see https://github.com/remotion-dev/remotion for example), as well as resolving links to project packages.

In DetectorRuleFactory: TODO- in at least one sample project, both lerna and pnpm were applicable.  In that case, Lerna wasn't extractable and thus Overall Status: FAILURE_DETECTOR.  Should one yield to the other?