### PR TITLE
Sb conan page id generation

### DIFF
--- a/docs/markdown/packagemgrs/conan.md
+++ b/docs/markdown/packagemgrs/conan.md
@@ -42,7 +42,8 @@ For example, here is a conan.lock file entry for a component (zlib):
    },
 ```
 
-If you are using the Conan CLI detector, this data is found in the output of the `conan info` command.
+If you are using the Conan CLI detector instead of the Conan Lockfile detector, this data is found in the output of the `conan info` command
+instead of the conan.lock file..
 
 The format of the Conan "ref" field is: `<name>/<version>@<user>/<channel>#<recipe_revision>`
 
@@ -59,18 +60,14 @@ In the zlib example:
 <name>/<version>@<user>/<channel>#<recipe_revision>
 ```
 
-This is the default mode, and produced the best results during testing on sample projects. Because the KB evolves over time, however, it is possible that
-better results could be obtained by using package revision matching.
-
 ## Package revision matching
 
-Enhancements to the [blackduck_kb] are planned that, for Conan projects with lockfiles
-and the Conan revisions feature enabled,
-will enable more accurate matching that also considers package ID and package revision.
+For Conan projects with lockfiles and the Conan revisions feature enabled
+[solution_name] has an alternative mode, package revision matching, that includes
+the package ID and package revision in the KB external IDs that it constructs (in addition to the fields described above).
 (Package revision is provided by Conan lockfiles when the Conan revisions feature is enabled,
 but it is never provided by the *conan info* command, so this only affects the Conan Lockfile detector.)
-When this [blackduck_kb] enhancement becomes available,
-you will be able to improve match accuracy for projects with lockfiles by setting
+To enable package revision matching, set
 property *detect.conan.attempt.package.revision.match* to true.
 
 
@@ -79,7 +76,7 @@ In this scenario, [solution_name] constructs a KB external ID for namespace "con
 <name>/<version>@<user>/<channel>#<recipe_revision>:<package_id>#<package_revision>
 ```
 
-For the zlib example above the two additional fields used in the KB external ID would be::
+For the zlib example above the two additional fields used in the KB external ID would be:
 
 * package_id=d50a0d523d98c15bb147b18fa7d203887c38be8b
 * package_revision=da65bb160c07195dba18afb91259050d

--- a/docs/markdown/packagemgrs/conan.md
+++ b/docs/markdown/packagemgrs/conan.md
@@ -21,7 +21,7 @@ The Conan command *conan config get general.revisions_enabled* must produce a va
 
 When using the Conan CLI detector, be sure to use the *detect.conan.arguments* property to provide any additional arguments (profile settings, etc.) that the *conan info* command needs to produce accurate results.
 
-## Package revision matching (future enhancement)
+## KB external ID generation
 
 By default (property *detect.conan.attempt.package.revision.match* is set to false), the Conan detectors use the following dependency details to match components in the [blackduck_kb]:
 
@@ -29,14 +29,40 @@ By default (property *detect.conan.attempt.package.revision.match* is set to fal
 * version
 * user (defaults to "_")
 * channel (defaults to "_")
-* recipe revision
+* recipe_revision
+
+For example, here is a conan.lock file entry for a component (zlib):
+```
+   "2": {
+    "ref": "zlib/1.2.11#1a67b713610ae745694aa4df1725451d",
+    "options": "fPIC=True\nminizip=False\nshared=False",
+    "package_id": "d50a0d523d98c15bb147b18fa7d203887c38be8b",
+    "prev": "da65bb160c07195dba18afb91259050d",
+    "context": "host"
+   },
+```
+
+If you are using the Conan CLI detector, this data is found in the output of the `conan info` command.
+
+The format of the Conan "ref" field is: `<name>/<version>@<user>/<channel>#<recipe_revision>`
+
+In the zlib example:
+
+* name=zlib
+* version=1.2.11
+* user=_ (by default)
+* channel=_ (by default)
+* recipe_revision=1a67b713610ae745694aa4df1725451d
 
 [solution_name] constructs a KB external ID for namespace "conan" using these fields as follows:
 ```
 <name>/<version>@<user>/<channel>#<recipe_revision>
 ```
 
-This is the default mode, and currently (as of February 2021) produces the best results.
+This is the default mode, and produced the best results during testing on several sample projects. Because the KB evolves over time, however, it is possible that
+better results could be obtained by using package revision matching.
+
+## Package revision matching
 
 Enhancements to the [blackduck_kb] are planned that, for Conan projects with lockfiles
 and the Conan revisions feature enabled,
@@ -47,10 +73,16 @@ When this [blackduck_kb] enhancement becomes available,
 you will be able to improve match accuracy for projects with lockfiles by setting
 property *detect.conan.attempt.package.revision.match* to true.
 
+
 In this scenario, [solution_name] constructs a KB external ID for namespace "conan" as follows:
 ```
 <name>/<version>@<user>/<channel>#<recipe_revision>:<package_id>#<package_revision>
 ```
+
+For the zlib example above the two additional fields used in the KB external ID would be::
+
+* package_id=d50a0d523d98c15bb147b18fa7d203887c38be8b
+* package_revision=da65bb160c07195dba18afb91259050d
 
 ## Conan Detector Precedence
 
@@ -58,3 +90,8 @@ If a Conan lockfile (conan.lock) is found or provided, the Conan Lockfile detect
 
 If no Conan lockfile is found or provided, but a conanfile.txt or conanfile.py is found, the
 Conan CLI detector will run.
+
+## Customized user/channel values
+
+Some Conan users use modified versions of Open Source packages with custom user/channel values. These modified components will not match components in the KB.
+The KB requires a match on user and channel.

--- a/docs/markdown/packagemgrs/conan.md
+++ b/docs/markdown/packagemgrs/conan.md
@@ -59,7 +59,7 @@ In the zlib example:
 <name>/<version>@<user>/<channel>#<recipe_revision>
 ```
 
-This is the default mode, and produced the best results during testing on several sample projects. Because the KB evolves over time, however, it is possible that
+This is the default mode, and produced the best results during testing on sample projects. Because the KB evolves over time, however, it is possible that
 better results could be obtained by using package revision matching.
 
 ## Package revision matching


### PR DESCRIPTION
Made the following improvements to the Conan package manager page:
1. Clarified how KB external IDs are constructed, using an actual conan.lock entry example.
2. Removed the recommendation to use short form IDs and any mention of a future KB enhancement ('cause it has already happened).
