### PR TITLE
Sb identically named subprojects

### DIFF
--- a/docs/markdown/releasenotes.md
+++ b/docs/markdown/releasenotes.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## Version 7.9.0
+
+### New Features
+
+### Changed Features
+
+### Resolved issues
+* (IDETECT-2499) Fixed an issue in the Gradle Inspector that caused it to exclude all identically-named subprojects except one.
+
 ## Version 7.8.0
 
 ### New Features

--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -127,7 +127,7 @@ def generateRootProjectMetaData(Project project, String outputDirectoryPath) {
 
 def findProjectOutputFile(Project project, String outputDirectoryPath) {
     File outputDirectory = createTaskOutputDirectory(outputDirectoryPath)
-    String name = project.name.toString()
+    String name = project.toString()
 
     String nameForFile = new IntegrationEscapeUtil().replaceWithUnderscore(name)
     File outputFile = new File(outputDirectory, "${nameForFile}_dependencyGraph.txt")


### PR DESCRIPTION
Fixed support for identically-named subprojects in gradle inspector. Fix is to include project path (not simply name) in the output filenames, so they are unique.
