### PR TITLE
Jm codelocations

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLockYamlParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/PnpmLockYamlParser.java
@@ -50,10 +50,18 @@ public class PnpmLockYamlParser {
                     reportingProjectPackagePath = projectPackageName;
                 }
                 PnpmProjectPackage projectPackage = projectPackageInfo.getValue();
-                codeLocations.add(pnpmTransformer.generateCodeLocation(projectPackage, reportingProjectPackagePath, dependencyTypes, new NameVersion(projectPackageName, projectPackageVersion), pnpmLockYaml.packages, linkedPackageResolver));
+                codeLocations.add(pnpmTransformer.generateCodeLocation(
+                    projectPackage,
+                    pnpmLockYamlFile,
+                    reportingProjectPackagePath,
+                    dependencyTypes,
+                    new NameVersion(projectPackageName, projectPackageVersion),
+                    pnpmLockYaml.packages,
+                    linkedPackageResolver
+                ));
             }
         } else {
-            codeLocations.add(pnpmTransformer.generateCodeLocation(pnpmLockYaml, dependencyTypes, projectNameVersion, linkedPackageResolver));
+            codeLocations.add(pnpmTransformer.generateCodeLocation(pnpmLockYamlFile, pnpmLockYaml, dependencyTypes, projectNameVersion, linkedPackageResolver));
         }
         return codeLocations;
     }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmYamlTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmYamlTransformerTest.java
@@ -25,6 +25,7 @@ import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.NameVersion;
 
 public class PnpmYamlTransformerTest {
+    private final File pnpmLockYamlFile = new File("pnpm-lock.yaml");
     private PnpmLockYaml pnpmLockYaml = createPnpmLockYaml();
     PnpmYamlTransformer pnpmTransformer = new PnpmYamlTransformer(new ExternalIdFactory());
     NameVersion projectNameVersion = new NameVersion("name", "version");
@@ -32,7 +33,7 @@ public class PnpmYamlTransformerTest {
 
     @Test
     public void testGenerateCodeLocation() throws IntegrationException {
-        CodeLocation codeLocation = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver);
+        CodeLocation codeLocation = pnpmTransformer.generateCodeLocation(pnpmLockYamlFile, pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver);
 
         Assertions.assertEquals("name", codeLocation.getExternalId().get().getName());
         Assertions.assertEquals("version", codeLocation.getExternalId().get().getVersion());
@@ -48,14 +49,14 @@ public class PnpmYamlTransformerTest {
 
     @Test
     public void testExcludeDependencies() throws IntegrationException {
-        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver).getDependencyGraph();
+        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYamlFile, pnpmLockYaml, Arrays.asList(DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver).getDependencyGraph();
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootSize(2);
     }
 
     @Test
     public void testExcludeDevDependencies() throws IntegrationException {
-        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver).getDependencyGraph();
+        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYamlFile, pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver).getDependencyGraph();
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootSize(2);
         graphAssert.hasNoDependency("devDep", "2.0.0");
@@ -63,7 +64,7 @@ public class PnpmYamlTransformerTest {
 
     @Test
     public void testExcludeOptionalDependencies() throws IntegrationException {
-        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV), projectNameVersion, linkedPackageResolver).getDependencyGraph();
+        DependencyGraph dependencyGraph = pnpmTransformer.generateCodeLocation(pnpmLockYamlFile, pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV), projectNameVersion, linkedPackageResolver).getDependencyGraph();
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootSize(2);
         graphAssert.hasNoDependency("optDep", "3.0.0");
@@ -74,14 +75,14 @@ public class PnpmYamlTransformerTest {
         PnpmLockYaml pnpmLockYaml = createPnpmLockYaml();
         pnpmLockYaml.packages = null;
         try {
-            pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver);
+            pnpmTransformer.generateCodeLocation(pnpmLockYamlFile, pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), projectNameVersion, linkedPackageResolver);
         } catch (IntegrationException e) {
         }
     }
 
     @Test
     public void testNoFailureOnNullNameVersion() throws IntegrationException {
-        pnpmTransformer.generateCodeLocation(pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), null, linkedPackageResolver);
+        pnpmTransformer.generateCodeLocation(pnpmLockYamlFile, pnpmLockYaml, Arrays.asList(DependencyType.APP, DependencyType.DEV, DependencyType.OPTIONAL), null, linkedPackageResolver);
     }
 
     private PnpmLockYaml createPnpmLockYaml() {

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CreateBdioCodeLocationsFromDetectCodeLocationsOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CreateBdioCodeLocationsFromDetectCodeLocationsOperation.java
@@ -56,7 +56,7 @@ public class CreateBdioCodeLocationsFromDetectCodeLocationsOperation {
                 continue;
             }
             if (detectCodeLocation.getDependencyGraph().getRootDependencies().isEmpty()) {
-                logger.warn(String.format("Could not find any dependencies for code location %s", detectCodeLocation.getSourcePath()));
+                logger.debug(String.format("Could not find any dependencies for code location %s", detectCodeLocation.getSourcePath()));
             }
             validCodeLocations.add(detectCodeLocation);
         }

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CreateBdioCodeLocationsFromDetectCodeLocationsOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CreateBdioCodeLocationsFromDetectCodeLocationsOperation.java
@@ -11,7 +11,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
 import com.synopsys.integration.detect.workflow.file.DirectoryManager;
 import com.synopsys.integration.util.IntegrationEscapeUtil;
 import com.synopsys.integration.util.NameVersion;
@@ -27,7 +26,7 @@ public class CreateBdioCodeLocationsFromDetectCodeLocationsOperation {
         this.directoryManager = directoryManager;
     }
 
-    public BdioCodeLocationResult transformDetectCodeLocations(List<DetectCodeLocation> detectCodeLocations, String prefix, String suffix, NameVersion projectNameVersion) throws DetectUserFriendlyException {
+    public BdioCodeLocationResult transformDetectCodeLocations(List<DetectCodeLocation> detectCodeLocations, String prefix, String suffix, NameVersion projectNameVersion) {
         List<DetectCodeLocation> validDetectCodeLocations = findValidCodeLocations(detectCodeLocations);
         Map<DetectCodeLocation, String> codeLocationsAndNames = createCodeLocationNameMap(validDetectCodeLocations, directoryManager.getSourceDirectory(), projectNameVersion, prefix, suffix);
 
@@ -67,9 +66,7 @@ public class CreateBdioCodeLocationsFromDetectCodeLocationsOperation {
         Map<String, List<DetectCodeLocation>> codeLocationNameMap = new HashMap<>();
         for (Map.Entry<DetectCodeLocation, String> detectCodeLocationEntry : detectCodeLocationNameMap.entrySet()) {
             String codeLocationName = detectCodeLocationEntry.getValue();
-            if (!codeLocationNameMap.containsKey(codeLocationName)) {
-                codeLocationNameMap.put(codeLocationName, new ArrayList<>());
-            }
+            codeLocationNameMap.computeIfAbsent(codeLocationName, key -> new ArrayList<>());
             codeLocationNameMap.get(codeLocationName).add(detectCodeLocationEntry.getKey());
         }
         return codeLocationNameMap;


### PR DESCRIPTION
The log message `Could not find any dependencies for code location %s` is now at the DEBUG logging level.
PnpmLockDetectable now produces code locations with unique and useful source paths.

