### PR TITLE
Doc: Enhanced field value setting description

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -967,7 +967,8 @@ public class DetectProperties {
         new DetectProperty<>(new NullableStringProperty("detect.custom.fields.project"))
             .setInfo("Custom Fields", DetectPropertyFromVersion.VERSION_5_6_0)
             .setHelp(
-                "A  list of custom fields with a label and comma-separated value starting from index 0. For each index, provide one label and one value. For example, to set a custom field with label 'example' to 'one,two': `detect.custom.fields.project[0].label='example'` and `detect.custom.fields.project[0].value='one,two'`. To set another field, use index 1. Note that these will not show up in the detect configuration log.")
+                "A  list of custom fields with a label and comma-separated value starting from index 0. For each index, provide one label and one value. For example, to set a custom field with label 'example' to 'one,two': `detect.custom.fields.project[0].label='example'` and `detect.custom.fields.project[0].value='one,two'`. To set another field, use index 1. Note that these will not show up in the detect configuration log.",
+                "When assigning a value that contains a comma to a single-value field (such as a text field), append '[0]'' to the end of the value property name. For example, to set the value of the first field you are setting ('detect.custom.fields.version[0]'') to 'text1,text2', use 'detect.custom.fields.version[0].value[0]=text1,text2'.")
             .setGroups(DetectGroup.PROJECT, DetectGroup.PROJECT_SETTING)
             .setCategory(DetectCategory.Advanced);
 
@@ -976,7 +977,8 @@ public class DetectProperties {
         new DetectProperty<>(new NullableStringProperty("detect.custom.fields.version"))
             .setInfo("Custom Fields", DetectPropertyFromVersion.VERSION_5_6_0)
             .setHelp(
-                "A  list of custom fields with a label and comma-separated value starting from index 0. For each index, provide one label and one value. For example , to set a custom field with label 'example' to 'one,two': `detect.custom.fields.version[0].label='example'` and `detect.custom.fields.version[0].value='one,two'`. To set another field, use index 1. Note that these will not show up in the detect configuration log.")
+                "A  list of custom fields with a label and comma-separated value starting from index 0. For each index, provide one label and one value. For example , to set a custom field with label 'example' to 'one,two': `detect.custom.fields.version[0].label='example'` and `detect.custom.fields.version[0].value='one,two'`. To set another field, use index 1. Note that these will not show up in the detect configuration log.",
+                "When assigning a value that contains a comma to a single-value field (such as a text field), append '[0]'' to the end of the value property name. For example, to set the value of the first field you are setting ('detect.custom.fields.version[0]'') to 'text1,text2', use 'detect.custom.fields.version[0].value[0]=text1,text2'.")
             .setGroups(DetectGroup.PROJECT, DetectGroup.PROJECT_SETTING)
             .setCategory(DetectCategory.Advanced);
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -968,7 +968,7 @@ public class DetectProperties {
             .setInfo("Custom Fields", DetectPropertyFromVersion.VERSION_5_6_0)
             .setHelp(
                 "A  list of custom fields with a label and comma-separated value starting from index 0. For each index, provide one label and one value. For example, to set a custom field with label 'example' to 'one,two': `detect.custom.fields.project[0].label='example'` and `detect.custom.fields.project[0].value='one,two'`. To set another field, use index 1. Note that these will not show up in the detect configuration log.",
-                "When assigning a value that contains a comma to a single-value field (such as a text field), append '[0]'' to the end of the value property name. For example, to set the value of the first field you are setting ('detect.custom.fields.version[0]'') to 'text1,text2', use 'detect.custom.fields.version[0].value[0]=text1,text2'.")
+                "When assigning a value that contains a comma to a single-value field such as a text field, append '[0]' to the end of the value property name. For example, to set the value of the first field you are setting ('detect.custom.fields.version[0]') to 'text1,text2', use 'detect.custom.fields.version[0].value[0]=text1,text2'.")
             .setGroups(DetectGroup.PROJECT, DetectGroup.PROJECT_SETTING)
             .setCategory(DetectCategory.Advanced);
 
@@ -978,7 +978,7 @@ public class DetectProperties {
             .setInfo("Custom Fields", DetectPropertyFromVersion.VERSION_5_6_0)
             .setHelp(
                 "A  list of custom fields with a label and comma-separated value starting from index 0. For each index, provide one label and one value. For example , to set a custom field with label 'example' to 'one,two': `detect.custom.fields.version[0].label='example'` and `detect.custom.fields.version[0].value='one,two'`. To set another field, use index 1. Note that these will not show up in the detect configuration log.",
-                "When assigning a value that contains a comma to a single-value field (such as a text field), append '[0]'' to the end of the value property name. For example, to set the value of the first field you are setting ('detect.custom.fields.version[0]'') to 'text1,text2', use 'detect.custom.fields.version[0].value[0]=text1,text2'.")
+                "When assigning a value that contains a comma to a single-value field such as a text field, append '[0]' to the end of the value property name. For example, to set the value of the first field you are setting ('detect.custom.fields.version[0]') to 'text1,text2', use 'detect.custom.fields.version[0].value[0]=text1,text2'.")
             .setGroups(DetectGroup.PROJECT, DetectGroup.PROJECT_SETTING)
             .setCategory(DetectCategory.Advanced);
 


### PR DESCRIPTION
Doc (property description): Enhanced field value setting description to cover the "single value field value contains a comma" case