### PR TITLE
fix: Remove redundant "There was a problem" prefixes from Operation e…

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
@@ -12,6 +12,7 @@ import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
 public class OperationWrapper {
+    private static final String OPERATION_ERROR_MESSAGE_PREFIX = "There was a problem:";
     private final ExitCodeManager exitCodeManager;
 
     public OperationWrapper(ExitCodeManager exitCodeManager) {
@@ -40,14 +41,14 @@ public class OperationWrapper {
             successConsumer.run();
             return value;
         } catch (InterruptedException e) {
-            String errorReason = String.format("There was a problem: %s", e.getMessage());
+            String errorReason = String.format("%s %s", OPERATION_ERROR_MESSAGE_PREFIX, e.getMessage().replace(OPERATION_ERROR_MESSAGE_PREFIX, ""));
             operation.error(name, errorReason);
             // Restore interrupted state...
             Thread.currentThread().interrupt();
             errorConsumer.accept(e);
             throw new DetectUserFriendlyException(errorReason, e, ExitCodeType.FAILURE_GENERAL_ERROR);
         } catch (Exception e) {
-            String errorReason = String.format("There was a problem: %s", e.getMessage());
+            String errorReason = String.format("%s %s", OPERATION_ERROR_MESSAGE_PREFIX, e.getMessage().replace(OPERATION_ERROR_MESSAGE_PREFIX, ""));
             operation.error(name, errorReason);
             errorConsumer.accept(e);
             throw new DetectUserFriendlyException(errorReason, e, exitCodeManager.getExitCodeFromExceptionDetails(e));


### PR DESCRIPTION
When operations that are dependencies of other operations fail, the resulting error messages can get kind of ugly since OperationWrapper prepends error messages with "There was a problem: ".  For instance if Operation A depends on an input that comes from Operation B, and Operation B fails with error "Error", then the resulting error message for Operation A would be "There was a problem: There was a problem: Error".  This change would strip redundant prefixes so A's error message would be "There was a problem: Error".
