### PR TITLE
doc(release-notes): Added release note for new property

### DIFF
--- a/docs/markdown/releasenotes.md
+++ b/docs/markdown/releasenotes.md
@@ -7,6 +7,7 @@
 
 ### Changed features
 * The Go Mod Cli Detector no longer uses the "-u" flag when running **go list -m all**. This results in significantly faster scan times against Go Mod projects.
+* Deprecated the `detect.pnpm.dependency.types property` in favor of `detect.pnpm.dependency.types.excluded` for property consistency.
 
 ## Version 7.10.0
 


### PR DESCRIPTION
Completes DETECT-3063.
`detect.pnpm.dependency.types property` was deprecated for removal in Detect 8.0.0