### PR TITLE
Sb deprecate rename bazel property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 ext['groovy.version'] = '3.0.0'
 
 group = 'com.synopsys.integration'
-version = '7.11.0-SIGQA8-SNAPSHOT'
+version = '7.12.0-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/BazelDetectableOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/BazelDetectableOptions.java
@@ -6,13 +6,16 @@ import java.util.Set;
 
 public class BazelDetectableOptions {
     private final String targetName;
-    private final Set<WorkspaceRule> bazelDependencyRules;
+    private final Set<WorkspaceRule> workspaceRulesFromDeprecatedProperty;
+    private final Set<WorkspaceRule> workspaceRulesFromProperty;
     private final List<String> bazelCqueryAdditionalOptions;
 
-    public BazelDetectableOptions(String targetName, Set<WorkspaceRule> bazelDependencyRules,
+    public BazelDetectableOptions(String targetName, Set<WorkspaceRule> workspaceRulesFromDeprecatedProperty,
+        Set<WorkspaceRule> workspaceRulesFromProperty,
         List<String> bazelCqueryAdditionalOptions) {
         this.targetName = targetName;
-        this.bazelDependencyRules = bazelDependencyRules;
+        this.workspaceRulesFromDeprecatedProperty = workspaceRulesFromDeprecatedProperty;
+        this.workspaceRulesFromProperty = workspaceRulesFromProperty;
         this.bazelCqueryAdditionalOptions = bazelCqueryAdditionalOptions;
     }
 
@@ -24,7 +27,11 @@ public class BazelDetectableOptions {
         return bazelCqueryAdditionalOptions;
     }
 
-    public Set<WorkspaceRule> getBazelDependencyRules() {
-        return bazelDependencyRules;
+    public Set<WorkspaceRule> getWorkspaceRulesFromDeprecatedProperty() {
+        return workspaceRulesFromDeprecatedProperty;
+    }
+
+    public Set<WorkspaceRule> getWorkspaceRulesFromProperty() {
+        return workspaceRulesFromProperty;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/BazelExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/BazelExtractor.java
@@ -42,7 +42,8 @@ public class BazelExtractor {
     private final ToolVersionLogger toolVersionLogger;
     private final HaskellCabalLibraryJsonProtoParser haskellCabalLibraryJsonProtoParser;
     private final String bazelTarget;
-    private final Set<WorkspaceRule> providedDependencyRuleTypes;
+    private final Set<WorkspaceRule> workspaceRulesFromDeprecatedProperty;
+    private final Set<WorkspaceRule> workspaceRulesFromProperty;
     private final BazelVariableSubstitutor bazelVariableSubstitutor;
     private final BazelProjectNameGenerator bazelProjectNameGenerator;
 
@@ -53,7 +54,8 @@ public class BazelExtractor {
         ToolVersionLogger toolVersionLogger,
         HaskellCabalLibraryJsonProtoParser haskellCabalLibraryJsonProtoParser,
         String bazelTarget,
-        Set<WorkspaceRule> providedDependencyRuleTypes,
+        Set<WorkspaceRule> workspaceRulesFromDeprecatedProperty,
+        Set<WorkspaceRule> workspaceRulesFromProperty,
         BazelVariableSubstitutor bazelVariableSubstitutor,
         BazelProjectNameGenerator bazelProjectNameGenerator) {
         this.executableRunner = executableRunner;
@@ -63,7 +65,8 @@ public class BazelExtractor {
         this.toolVersionLogger = toolVersionLogger;
         this.haskellCabalLibraryJsonProtoParser = haskellCabalLibraryJsonProtoParser;
         this.bazelTarget = bazelTarget;
-        this.providedDependencyRuleTypes = providedDependencyRuleTypes;
+        this.workspaceRulesFromDeprecatedProperty = workspaceRulesFromDeprecatedProperty;
+        this.workspaceRulesFromProperty = workspaceRulesFromProperty;
         this.bazelVariableSubstitutor = bazelVariableSubstitutor;
         this.bazelProjectNameGenerator = bazelProjectNameGenerator;
     }
@@ -73,7 +76,7 @@ public class BazelExtractor {
         BazelCommandExecutor bazelCommandExecutor = new BazelCommandExecutor(executableRunner, workspaceDir, bazelExe);
         Pipelines pipelines = new Pipelines(bazelCommandExecutor, bazelVariableSubstitutor, externalIdFactory, haskellCabalLibraryJsonProtoParser);
         Set<WorkspaceRule> workspaceRulesFromFile = parseWorkspaceRulesFromFile(workspaceFile);
-        Set<WorkspaceRule> workspaceRulesToQuery = workspaceRuleChooser.choose(workspaceRulesFromFile, providedDependencyRuleTypes);
+        Set<WorkspaceRule> workspaceRulesToQuery = workspaceRuleChooser.choose(workspaceRulesFromFile, workspaceRulesFromDeprecatedProperty, workspaceRulesFromProperty);
         CodeLocation codeLocation = generateCodelocation(pipelines, workspaceRulesToQuery);
         return buildResults(codeLocation, bazelProjectNameGenerator.generateFromBazelTarget(bazelTarget));
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/pipeline/WorkspaceRuleChooser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/pipeline/WorkspaceRuleChooser.java
@@ -18,7 +18,7 @@ public class WorkspaceRuleChooser {
         } else if (!rulesFromWorkspaceFile.isEmpty()) {
             return rulesFromWorkspaceFile;
         } else {
-            throw new DetectableException("Unable to determine Bazel Workspace rule type; try setting it via the property");
+            throw new DetectableException("Unable to determine Bazel workspace rule type; try setting it via the property");
         }
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/pipeline/WorkspaceRuleChooser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/pipeline/WorkspaceRuleChooser.java
@@ -10,13 +10,15 @@ import com.synopsys.integration.detectable.detectables.bazel.WorkspaceRule;
 public class WorkspaceRuleChooser {
 
     @NotNull
-    public Set<WorkspaceRule> choose(Set<WorkspaceRule> rulesFromWorkspaceFile, Set<WorkspaceRule> rulesPropertyValues) throws DetectableException {
-        if (rulesPropertyValues != null && !rulesPropertyValues.isEmpty()) {
-            return rulesPropertyValues;
+    public Set<WorkspaceRule> choose(Set<WorkspaceRule> rulesFromWorkspaceFile, Set<WorkspaceRule> rulesFromDeprecatedProperty, Set<WorkspaceRule> rulesFromProperty) throws DetectableException {
+        if (rulesFromProperty != null && !rulesFromProperty.isEmpty()) {
+            return rulesFromProperty;
+        } else if (rulesFromDeprecatedProperty != null && !rulesFromDeprecatedProperty.isEmpty()) {
+            return rulesFromDeprecatedProperty;
         } else if (!rulesFromWorkspaceFile.isEmpty()) {
             return rulesFromWorkspaceFile;
         } else {
-            throw new DetectableException("Unable to determine BazelWorkspace dependency rule type; try setting it via the property");
+            throw new DetectableException("Unable to determine Bazel Workspace rule type; try setting it via the property");
         }
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -551,7 +551,7 @@ public class DetectableFactory {
         BazelVariableSubstitutor bazelVariableSubstitutor = new BazelVariableSubstitutor(bazelDetectableOptions.getTargetName().orElse(null), bazelDetectableOptions.getBazelCqueryAdditionalOptions());
         BazelProjectNameGenerator bazelProjectNameGenerator = new BazelProjectNameGenerator();
         return new BazelExtractor(executableRunner, externalIdFactory, bazelWorkspaceFileParser, workspaceRuleChooser, toolVersionLogger, haskellCabalLibraryJsonProtoParser,
-            bazelDetectableOptions.getTargetName().orElse(null), bazelDetectableOptions.getBazelDependencyRules(), bazelVariableSubstitutor,
+            bazelDetectableOptions.getTargetName().orElse(null), bazelDetectableOptions.getWorkspaceRulesFromDeprecatedProperty(), bazelDetectableOptions.getWorkspaceRulesFromProperty(), bazelVariableSubstitutor,
             bazelProjectNameGenerator);
     }
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bazel/functional/bazel/pipeline/WorkspaceRuleChooserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bazel/functional/bazel/pipeline/WorkspaceRuleChooserTest.java
@@ -18,43 +18,58 @@ class WorkspaceRuleChooserTest {
     private static final Set<WorkspaceRule> WORKSPACE_RULES_JUST_MAVEN_JAR = Sets.newHashSet(WorkspaceRule.MAVEN_JAR);
     private static final Set<WorkspaceRule> WORKSPACE_RULES_THREE = Sets.newHashSet(WorkspaceRule.MAVEN_INSTALL,
         WorkspaceRule.HASKELL_CABAL_LIBRARY, WorkspaceRule.MAVEN_JAR);
+    private static final Set<WorkspaceRule> WORKSPACE_RULES_HASKELL = Sets.newHashSet(WorkspaceRule.HASKELL_CABAL_LIBRARY);
 
     @Test
     void testOneRuleParsed() throws IntegrationException {
-        Set<WorkspaceRule> chosenWorkspaceRules = run(null, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
+        Set<WorkspaceRule> chosenWorkspaceRules = run(null, null, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
         assertEquals(1, chosenWorkspaceRules.size());
         assertEquals("maven_install", chosenWorkspaceRules.iterator().next().getName());
     }
 
     @Test
     void testThreeRulesParsed() throws IntegrationException {
-        Set<WorkspaceRule> chosenWorkspaceRules = run(null, WORKSPACE_RULES_THREE);
+        Set<WorkspaceRule> chosenWorkspaceRules = run(null, null, WORKSPACE_RULES_THREE);
         assertEquals(3, chosenWorkspaceRules.size());
     }
 
     @Test
-    void testOneProvidedSameOneParsed() throws IOException, IntegrationException {
-        Set<WorkspaceRule> chosenWorkspaceRules = run(WORKSPACE_RULES_JUST_MAVEN_INSTALL, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
+    void testOneProvidedSameOneParsed() throws IntegrationException {
+        Set<WorkspaceRule> chosenWorkspaceRules = run(null, WORKSPACE_RULES_JUST_MAVEN_INSTALL, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
         assertEquals(1, chosenWorkspaceRules.size());
         assertEquals("maven_install", chosenWorkspaceRules.iterator().next().getName());
     }
 
     @Test
-    void testOneRuleProvidedDifferentOneParsed() throws IOException, IntegrationException {
-        Set<WorkspaceRule> chosenWorkspaceRules = run(WORKSPACE_RULES_JUST_MAVEN_JAR, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
+    void testOneProvidedSameOneParsedDeprecatedProperty() throws IntegrationException {
+        Set<WorkspaceRule> chosenWorkspaceRules = run(WORKSPACE_RULES_JUST_MAVEN_INSTALL, null, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
+        assertEquals(1, chosenWorkspaceRules.size());
+        assertEquals("maven_install", chosenWorkspaceRules.iterator().next().getName());
+    }
+
+    @Test
+    void testOneProvidedSameOneParsedBothProperties() throws IntegrationException {
+        Set<WorkspaceRule> chosenWorkspaceRules = run(WORKSPACE_RULES_HASKELL, WORKSPACE_RULES_JUST_MAVEN_INSTALL, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
+        assertEquals(1, chosenWorkspaceRules.size());
+        assertEquals("maven_install", chosenWorkspaceRules.iterator().next().getName());
+    }
+
+    @Test
+    void testOneRuleProvidedDifferentOneParsed() throws IntegrationException {
+        Set<WorkspaceRule> chosenWorkspaceRules = run(null, WORKSPACE_RULES_JUST_MAVEN_JAR, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
         assertEquals(1, chosenWorkspaceRules.size());
         assertEquals("maven_jar", chosenWorkspaceRules.iterator().next().getName());
     }
 
     @Test
-    void testThreeProvidedOneParsed() throws IOException, IntegrationException {
-        Set<WorkspaceRule> chosenWorkspaceRules = run(WORKSPACE_RULES_THREE, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
+    void testThreeProvidedOneParsed() throws IntegrationException {
+        Set<WorkspaceRule> chosenWorkspaceRules = run(null, WORKSPACE_RULES_THREE, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
         assertEquals(3, chosenWorkspaceRules.size());
     }
 
-    private Set<WorkspaceRule> run(Set<WorkspaceRule> providedBazelDependencyRule, Set<WorkspaceRule> parsedWorkspaceRules) throws IntegrationException {
+    private Set<WorkspaceRule> run(Set<WorkspaceRule> workspaceRulesFromDeprecatedProperty, Set<WorkspaceRule> workspaceRulesFromProperty, Set<WorkspaceRule> parsedWorkspaceRules) throws IntegrationException {
         WorkspaceRuleChooser workspaceRuleChooser = new WorkspaceRuleChooser();
-        Set<WorkspaceRule> chosenWorkspaceRules = workspaceRuleChooser.choose(parsedWorkspaceRules, providedBazelDependencyRule);
+        Set<WorkspaceRule> chosenWorkspaceRules = workspaceRuleChooser.choose(parsedWorkspaceRules, workspaceRulesFromDeprecatedProperty, workspaceRulesFromProperty);
         return chosenWorkspaceRules;
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bazel/functional/bazel/pipeline/WorkspaceRuleChooserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bazel/functional/bazel/pipeline/WorkspaceRuleChooserTest.java
@@ -41,14 +41,14 @@ class WorkspaceRuleChooserTest {
     }
 
     @Test
-    void testOneProvidedSameOneParsedDeprecatedProperty() throws IntegrationException {
+    void testOneProvidedViaDeprecatedPropertySameOneParsed() throws IntegrationException {
         Set<WorkspaceRule> chosenWorkspaceRules = run(WORKSPACE_RULES_JUST_MAVEN_INSTALL, null, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
         assertEquals(1, chosenWorkspaceRules.size());
         assertEquals("maven_install", chosenWorkspaceRules.iterator().next().getName());
     }
 
     @Test
-    void testOneProvidedSameOneParsedBothProperties() throws IntegrationException {
+    void testPreferNewProperty() throws IntegrationException {
         Set<WorkspaceRule> chosenWorkspaceRules = run(WORKSPACE_RULES_HASKELL, WORKSPACE_RULES_JUST_MAVEN_INSTALL, WORKSPACE_RULES_JUST_MAVEN_INSTALL);
         assertEquals(1, chosenWorkspaceRules.size());
         assertEquals("maven_install", chosenWorkspaceRules.iterator().next().getName());

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bazel/unit/BazelDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bazel/unit/BazelDetectableTest.java
@@ -25,7 +25,7 @@ public class BazelDetectableTest {
         Mockito.when(fileFinder.findFile(new File("."), "WORKSPACE")).thenReturn(new File("src/test/resources/functional/bazel/WORKSPACE"));
         BazelExtractor bazelExtractor = null;
         BazelResolver bazelResolver = null;
-        BazelDetectableOptions bazelDetectableOptions = new BazelDetectableOptions("target", null, null);
+        BazelDetectableOptions bazelDetectableOptions = new BazelDetectableOptions("target", null, null, null);
         BazelDetectable detectable = new BazelDetectable(environment, fileFinder, bazelExtractor, bazelResolver, bazelDetectableOptions.getTargetName().orElse(null));
 
         assertTrue(detectable.applicable().getPassed());

--- a/docs/markdown/packagemgrs/bazel.md
+++ b/docs/markdown/packagemgrs/bazel.md
@@ -4,12 +4,13 @@
 
 [solution_name] supports dependencies specified in *maven_jar*, *maven_install*, and *haskell_cabal_library* workspace rules only.
 
-The Bazel tool attempts to run on your project if you provide a Bazel build target using the Bazel target property.
+The [solution_name] Bazel tool attempts to run on your project if you provide a Bazel build target using the Bazel target property.
 
 The Bazel tool also requires a bazel executable on $PATH.
 
-[solution_name] attempts to determine the workspace dependency rule (*maven_install*, *maven_jar*, or *haskell_cabal_library*) from the WORKSPACE file.
-In case it cannot, you can specify which rule you use with the Bazel dependency type property.
+By default, [solution_name] determines the set of supported workspace rules that your project uses by parsing the WORKSPACE file,
+and executes Bazel commands to discover dependencies for each supported workspace rule it finds.
+Alternatively, you can directly control the set of workspace rules [solution_name] uses by setting the Bazel workspace rule property.
 Refer to [Properties](../properties/detectors/bazel.md) for details.
 
 ## Processing for the *maven_install* workspace rule

--- a/docs/markdown/releasenotes.md
+++ b/docs/markdown/releasenotes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 7.12.0
+
+### Changed features
+
+* Added new property detect.bazel.workspace.rules to replace the now-deprecated detect.bazel.dependency.type property.
+
 ## Version 7.11.0
 
 ### New features

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -203,7 +203,7 @@ public class DetectProperties {
 
     public static final AllNoneEnumListProperty<WorkspaceRule> DETECT_BAZEL_WORKSPACE_RULES =
         AllNoneEnumListProperty.newBuilder("detect.bazel.workspace.rules", emptyList(), WorkspaceRule.class)
-            .setInfo("Bazel workspace rules override", DetectPropertyFromVersion.VERSION_7_12_0)
+            .setInfo("Bazel workspace rules", DetectPropertyFromVersion.VERSION_7_12_0)
             .setHelp("By default Detect discovers Bazel dependencies using all of the supported Bazel workspace rules that it finds in the WORKSPACE file. Alternatively you can use this property to specify the list of Bazel workspace rules Detect should use.")
             .setGroups(DetectGroup.BAZEL, DetectGroup.SOURCE_SCAN)
             .build();

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -203,8 +203,8 @@ public class DetectProperties {
 
     public static final AllNoneEnumListProperty<WorkspaceRule> DETECT_BAZEL_WORKSPACE_RULES =
         AllNoneEnumListProperty.newBuilder("detect.bazel.workspace.rules", emptyList(), WorkspaceRule.class)
-            .setInfo("Bazel workspace external dependency rule", DetectPropertyFromVersion.VERSION_7_12_0)
-            .setHelp("The Bazel workspace rule(s) used to pull in external dependencies. If not set, Detect will attempt to determine the rule(s) from the contents of the WORKSPACE file.")
+            .setInfo("Bazel workspace rules override", DetectPropertyFromVersion.VERSION_7_12_0)
+            .setHelp("By default Detect discovers Bazel dependencies using all of the supported Bazel workspace rules that it finds in the WORKSPACE file. Alternatively you can use this property to specify the list of Bazel workspace rules Detect should use.")
             .setGroups(DetectGroup.BAZEL, DetectGroup.SOURCE_SCAN)
             .build();
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -201,9 +201,9 @@ public class DetectProperties {
             .setGroups(DetectGroup.BAZEL, DetectGroup.SOURCE_SCAN)
             .build();
 
-    public static final AllNoneEnumListProperty<WorkspaceRule> DETECT_BAZEL_DEPENDENCY_RULE =
-        AllNoneEnumListProperty.newBuilder("detect.bazel.dependency.type", emptyList(), WorkspaceRule.class)
-            .setInfo("Bazel workspace external dependency rule", DetectPropertyFromVersion.VERSION_6_0_0)
+    public static final AllNoneEnumListProperty<WorkspaceRule> DETECT_BAZEL_WORKSPACE_RULES =
+        AllNoneEnumListProperty.newBuilder("detect.bazel.workspace.rules", emptyList(), WorkspaceRule.class)
+            .setInfo("Bazel workspace external dependency rule", DetectPropertyFromVersion.VERSION_7_12_0)
             .setHelp("The Bazel workspace rule(s) used to pull in external dependencies. If not set, Detect will attempt to determine the rule(s) from the contents of the WORKSPACE file.")
             .setGroups(DetectGroup.BAZEL, DetectGroup.SOURCE_SCAN)
             .build();
@@ -1546,6 +1546,15 @@ public class DetectProperties {
     // username/password ==> api token
     public static final String BDIO1_DEPRECATION_MESSAGE = "This property is being removed, along with the option to generate BDIO in BDIO1 format. In the future, BDIO2 format will be the only option.";
     public static final String AGGREGATION_MODE_DEPRECATION_MESSAGE = "This property is being removed, along with the ability to set the aggregation mode. Detect will only operate in SUBPROJECT aggregation mode to more accurately report the dependency graph.";
+    public static final String BAZEL_DEPENDENCY_TYPE_DEPRECATION_MESSAGE = "This property is being removed. Please use property 'detect.bazel.workspace.rules' instead.";
+
+    public static final AllNoneEnumListProperty<WorkspaceRule> DETECT_BAZEL_DEPENDENCY_RULE =
+        AllNoneEnumListProperty.newBuilder("detect.bazel.dependency.type", emptyList(), WorkspaceRule.class)
+            .setInfo("Bazel workspace external dependency rule", DetectPropertyFromVersion.VERSION_6_0_0)
+            .setHelp("The Bazel workspace rule(s) used to pull in external dependencies. If not set, Detect will attempt to determine the rule(s) from the contents of the WORKSPACE file.")
+            .setGroups(DetectGroup.BAZEL, DetectGroup.SOURCE_SCAN)
+            .setDeprecated(BAZEL_DEPENDENCY_TYPE_DEPRECATION_MESSAGE, DetectMajorVersion.EIGHT)
+            .build();
 
     @Deprecated
     public static final NullableStringProperty DETECT_BOM_AGGREGATE_NAME =

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectPropertyFromVersion.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectPropertyFromVersion.java
@@ -32,7 +32,8 @@ public enum DetectPropertyFromVersion implements PropertyVersion {
     VERSION_7_8_0("7.8.0"),
     VERSION_7_9_0("7.9.0"),
     VERSION_7_10_0("7.10.0"),
-    VERSION_7_11_0("7.11.0");
+    VERSION_7_11_0("7.11.0"),
+    VERSION_7_12_0("7.12.0");
 
     private final String version;
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -73,8 +73,9 @@ public class DetectableOptionFactory {
     public BazelDetectableOptions createBazelDetectableOptions() {
         String targetName = detectConfiguration.getNullableValue(DetectProperties.DETECT_BAZEL_TARGET);
         List<String> bazelCqueryAdditionalOptions = detectConfiguration.getValue(DetectProperties.DETECT_BAZEL_CQUERY_OPTIONS);
-        Set<WorkspaceRule> bazelDependencyRules = detectConfiguration.getValue(DetectProperties.DETECT_BAZEL_DEPENDENCY_RULE).representedValueSet();
-        return new BazelDetectableOptions(targetName, bazelDependencyRules, bazelCqueryAdditionalOptions);
+        Set<WorkspaceRule> workspaceRulesFromDeprecatedProperty = detectConfiguration.getValue(DetectProperties.DETECT_BAZEL_DEPENDENCY_RULE).representedValueSet();
+        Set<WorkspaceRule> workspaceRulesFromProperty = detectConfiguration.getValue(DetectProperties.DETECT_BAZEL_WORKSPACE_RULES).representedValueSet();
+        return new BazelDetectableOptions(targetName, workspaceRulesFromDeprecatedProperty, workspaceRulesFromProperty, bazelCqueryAdditionalOptions);
     }
 
     public BitbakeDetectableOptions createBitbakeDetectableOptions() {

--- a/src/test/java/com/synopsys/integration/detect/battery/detector/BazelBattery.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/detector/BazelBattery.java
@@ -20,7 +20,7 @@ class BazelBattery {
         DetectorBatteryTestRunner test = new DetectorBatteryTestRunner("bazel-maven-install", "bazel/maven-install");
         test.withToolsValue("BAZEL");
         test.property("detect.bazel.target", "//tests/integration:ArtifactExclusionsTest");
-        test.property("detect.bazel.dependency.type", "MAVEN_INSTALL");
+        test.property("detect.bazel.workspace.rules", "MAVEN_INSTALL");
         test.executableFromResourceFiles(DetectProperties.DETECT_BAZEL_PATH, BAZEL_MAVEN_INSTALL_OUTPUT_RESOURCE);
         test.sourceDirectoryNamed("bazel-maven-install");
         test.sourceFileNamed("WORKSPACE");
@@ -33,7 +33,7 @@ class BazelBattery {
         DetectorBatteryTestRunner test = new DetectorBatteryTestRunner("bazel-haskell-cabal-library", "bazel/haskell-cabal-library");
         test.withToolsValue("BAZEL");
         test.property("detect.bazel.target", "//cat_hs/lib/args:args");
-        test.property("detect.bazel.dependency.type", "HASKELL_CABAL_LIBRARY");
+        test.property("detect.bazel.workspace.rules", "HASKELL_CABAL_LIBRARY");
         test.executableFromResourceFiles(DetectProperties.DETECT_BAZEL_PATH, BAZEL_HASKELL_CABAL_LIBRARY_OUTPUT_RESOURCE);
         test.sourceDirectoryNamed("bazel-haskell-cabal-library");
         test.sourceFileNamed("WORKSPACE");
@@ -46,7 +46,7 @@ class BazelBattery {
         DetectorBatteryTestRunner test = new DetectorBatteryTestRunner("bazel-maven-jar", "bazel/maven-jar");
         test.withToolsValue("BAZEL");
         test.property("detect.bazel.target", "//:ProjectRunner");
-        test.property("detect.bazel.dependency.type", "MAVEN_JAR");
+        test.property("detect.bazel.workspace.rules", "MAVEN_JAR");
         test.executableFromResourceFiles(DetectProperties.DETECT_BAZEL_PATH,
             BAZEL_MAVEN_JAR_OUTPUT1_RESOURCE, BAZEL_MAVEN_JAR_OUTPUT2_RESOURCE, BAZEL_MAVEN_JAR_OUTPUT3_RESOURCE);
         test.sourceDirectoryNamed("bazel-maven-jar");
@@ -60,7 +60,7 @@ class BazelBattery {
         DetectorBatteryTestRunner test = new DetectorBatteryTestRunner("bazel-haskell-cabal-library-all", "bazel/haskell-cabal-library-all");
         test.withToolsValue("BAZEL");
         test.property("detect.bazel.target", "//cat_hs/lib/args:args");
-        test.property("detect.bazel.dependency.type", "ALL");
+        test.property("detect.bazel.workspace.rules", "ALL");
         test.executableFromResourceFiles(DetectProperties.DETECT_BAZEL_PATH,
             EMPTY_OUTPUT_RESOURCE,
             EMPTY_OUTPUT_RESOURCE,


### PR DESCRIPTION
Deprecated a poorly named bazel property, and added a better-named replacement