### PR TITLE
Sb fix bitbake layer list

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/BitbakeRecipesParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/BitbakeRecipesParser.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.detectable.detectables.bitbake.ShowRecipesResults;
@@ -68,7 +69,7 @@ public class BitbakeRecipesParser {
         }
     }
 
-    private void finishCurrentRecipe(final Map<String, List<String>> bitbakeRecipes, final Set<String> layerNames, final BitbakeRecipe currentRecipe) {
+    private void finishCurrentRecipe(Map<String, List<String>> bitbakeRecipes, Set<String> layerNames, @Nullable BitbakeRecipe currentRecipe) {
         if (currentRecipe != null) {
             bitbakeRecipes.put(currentRecipe.getName(), currentRecipe.getLayerNames());
             if (currentRecipe.getLayerNames() != null) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/GraphNodeLabelParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/GraphNodeLabelParser.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.detectable.detectables.bitbake.model.GraphNodeLabelDetails;
-import com.synopsys.integration.exception.IntegrationException;
 
 // Example of a GraphNode label value:
 // acl-native do_compile\n:2.3.1-r0\nvirtual:native:/workdir/poky/meta/recipes-support/attr/acl_2.3.1.bb
@@ -21,34 +20,30 @@ public class GraphNodeLabelParser {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public Optional<String> parseVersionFromLabel(String label) {
-        Optional<GraphNodeLabelDetails> labelDetails = parseLabelParts(label);
-        if (labelDetails.isPresent()) {
-            return Optional.of(labelDetails.get().getVersion());
-        }
-        return Optional.empty();
+        return parseLabelParts(label).map(GraphNodeLabelDetails::getVersion);
     }
 
     public Optional<String> parseLayerFromLabel(String label, Set<String> knownLayerNames) {
-        Optional<GraphNodeLabelDetails> labelDetails = parseLabelParts(label);
-        if (!labelDetails.isPresent()) {
+        Optional<String> recipeSpec = parseLabelParts(label)
+            .map(GraphNodeLabelDetails::getRecipeSpec);
+        if (!recipeSpec.isPresent()) {
             return Optional.empty();
         }
-        String recipeSpec = labelDetails.get().getRecipeSpec();
         for (String candidateLayerName : knownLayerNames) {
             String possibleLayerPathSubstring = LABEL_PATH_SEPARATOR + candidateLayerName + LABEL_PATH_SEPARATOR;
-            if (recipeSpec.contains(possibleLayerPathSubstring)) {
+            if (recipeSpec.get().contains(possibleLayerPathSubstring)) {
                 return Optional.of(candidateLayerName);
             }
         }
-        logger.warn("Graph Node recipe '%s' does not correspond to any known layer (%s)", label, knownLayerNames);
+        logger.warn("Graph Node recipe '{}' does not correspond to any known layer ({})", label, knownLayerNames);
         return Optional.empty();
     }
 
     @NotNull
-    private Optional<GraphNodeLabelDetails> parseLabelParts(final String label) {
+    private Optional<GraphNodeLabelDetails> parseLabelParts(String label) {
         String[] labelParts = label.split("\\\\n:|\\\\n");
         if (labelParts.length < 3) {
-            logger.warn("Error parsing Graph Node label '%s'; unexpected format.", label);
+            logger.warn("Error parsing Graph Node label '{}'; unexpected format.", label);
             return Optional.empty();
         }
         return Optional.of(new GraphNodeLabelDetails(labelParts[0], labelParts[1], labelParts[2]));

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/GraphNodeLabelParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/GraphNodeLabelParser.java
@@ -1,8 +1,11 @@
 package com.synopsys.integration.detectable.detectables.bitbake.parse;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.detectable.detectables.bitbake.model.GraphNodeLabelDetails;
 import com.synopsys.integration.exception.IntegrationException;
@@ -15,30 +18,39 @@ import com.synopsys.integration.exception.IntegrationException;
 //  virtual:native:/workdir/poky/meta/recipes-support/attr/acl_2.3.1.bb -> GraphNodeLabelDetails.recipeSpec
 public class GraphNodeLabelParser {
     private static final String LABEL_PATH_SEPARATOR = "/";
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public String parseVersionFromLabel(String label) throws IntegrationException {
-        GraphNodeLabelDetails labelDetails = parseLabelParts(label);
-        return labelDetails.getVersion();
+    public Optional<String> parseVersionFromLabel(String label) {
+        Optional<GraphNodeLabelDetails> labelDetails = parseLabelParts(label);
+        if (labelDetails.isPresent()) {
+            return Optional.of(labelDetails.get().getVersion());
+        }
+        return Optional.empty();
     }
 
-    public String parseLayerFromLabel(String label, Set<String> knownLayerNames) throws IntegrationException {
-        GraphNodeLabelDetails labelDetails = parseLabelParts(label);
-        String recipeSpec = labelDetails.getRecipeSpec();
+    public Optional<String> parseLayerFromLabel(String label, Set<String> knownLayerNames) {
+        Optional<GraphNodeLabelDetails> labelDetails = parseLabelParts(label);
+        if (!labelDetails.isPresent()) {
+            return Optional.empty();
+        }
+        String recipeSpec = labelDetails.get().getRecipeSpec();
         for (String candidateLayerName : knownLayerNames) {
             String possibleLayerPathSubstring = LABEL_PATH_SEPARATOR + candidateLayerName + LABEL_PATH_SEPARATOR;
             if (recipeSpec.contains(possibleLayerPathSubstring)) {
-                return candidateLayerName;
+                return Optional.of(candidateLayerName);
             }
         }
-        throw new IntegrationException(String.format("Graph Node recipe '%s' does not correspond to any known layer (%s)", label, knownLayerNames));
+        logger.warn("Graph Node recipe '%s' does not correspond to any known layer (%s)", label, knownLayerNames);
+        return Optional.empty();
     }
 
     @NotNull
-    private GraphNodeLabelDetails parseLabelParts(final String label) throws IntegrationException {
+    private Optional<GraphNodeLabelDetails> parseLabelParts(final String label) {
         String[] labelParts = label.split("\\\\n:|\\\\n");
         if (labelParts.length < 3) {
-            throw new IntegrationException(String.format("Error parsing Graph Node label '%s'; unexpected format.", label));
+            logger.warn("Error parsing Graph Node label '%s'; unexpected format.", label);
+            return Optional.empty();
         }
-        return new GraphNodeLabelDetails(labelParts[0], labelParts[1], labelParts[2]);
+        return Optional.of(new GraphNodeLabelDetails(labelParts[0], labelParts[1], labelParts[2]));
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/GraphParserTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/GraphParserTransformer.java
@@ -46,7 +46,7 @@ public class GraphParserTransformer {
     private Optional<String> parseVersionFromNode(GraphNode graphNode) throws IntegrationException {
         Optional<String> labelValue = getLabelAttribute(graphNode);
         if (labelValue.isPresent()) {
-            return Optional.of(graphNodeLabelParser.parseVersionFromLabel(labelValue.get()));
+            return graphNodeLabelParser.parseVersionFromLabel(labelValue.get());
         } else {
             return Optional.empty();
         }
@@ -55,7 +55,7 @@ public class GraphParserTransformer {
     private Optional<String> parseLayerFromNode(GraphNode graphNode, Set<String> knownLayerNames) throws IntegrationException {
         Optional<String> labelAttribute = getLabelAttribute(graphNode);
         if (labelAttribute.isPresent()) {
-            return Optional.of(graphNodeLabelParser.parseLayerFromLabel(labelAttribute.get(), knownLayerNames));
+            return graphNodeLabelParser.parseLayerFromLabel(labelAttribute.get(), knownLayerNames);
         } else {
             return Optional.empty();
         }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/GraphParserTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bitbake/parse/GraphParserTransformer.java
@@ -9,7 +9,6 @@ import com.paypal.digraph.parser.GraphEdge;
 import com.paypal.digraph.parser.GraphNode;
 import com.paypal.digraph.parser.GraphParser;
 import com.synopsys.integration.detectable.detectables.bitbake.model.BitbakeGraph;
-import com.synopsys.integration.exception.IntegrationException;
 
 public class GraphParserTransformer {
     private final GraphNodeLabelParser graphNodeLabelParser;
@@ -18,7 +17,7 @@ public class GraphParserTransformer {
         this.graphNodeLabelParser = graphNodeLabelParser;
     }
 
-    public BitbakeGraph transform(GraphParser graphParser, Set<String> layerNames) throws IntegrationException {
+    public BitbakeGraph transform(GraphParser graphParser, Set<String> layerNames) {
         BitbakeGraph bitbakeGraph = new BitbakeGraph();
 
         for (GraphNode graphNode : graphParser.getNodes().values()) {
@@ -43,7 +42,7 @@ public class GraphParserTransformer {
         return nodeIdPieces[0].replace("\"", "");
     }
 
-    private Optional<String> parseVersionFromNode(GraphNode graphNode) throws IntegrationException {
+    private Optional<String> parseVersionFromNode(GraphNode graphNode) {
         Optional<String> labelValue = getLabelAttribute(graphNode);
         if (labelValue.isPresent()) {
             return graphNodeLabelParser.parseVersionFromLabel(labelValue.get());
@@ -52,7 +51,7 @@ public class GraphParserTransformer {
         }
     }
 
-    private Optional<String> parseLayerFromNode(GraphNode graphNode, Set<String> knownLayerNames) throws IntegrationException {
+    private Optional<String> parseLayerFromNode(GraphNode graphNode, Set<String> knownLayerNames) {
         Optional<String> labelAttribute = getLabelAttribute(graphNode);
         if (labelAttribute.isPresent()) {
             return graphNodeLabelParser.parseLayerFromLabel(labelAttribute.get(), knownLayerNames);

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bitbake/unit/BitbakeRecipesParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bitbake/unit/BitbakeRecipesParserTest.java
@@ -1,0 +1,39 @@
+package com.synopsys.integration.detectable.detectables.bitbake.functional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detectable.detectables.bitbake.ShowRecipesResults;
+import com.synopsys.integration.detectable.detectables.bitbake.parse.BitbakeRecipesParser;
+
+public class BitbakeRecipesParserTest {
+
+    private List<String> showRecipesOutputLines = Arrays.asList(
+        "### Shell environment set up for builds. ###\n",
+            "=== Available recipes: ===\n",
+            "a2jmidid:\n",
+            "  meta-oe              9\n",
+            "abseil-cpp:\n",
+            "  meta-oe              git (skipped: abseil-cpp-20190808+gitAUTOINC+aa844899c9 Needs support for corei7 on x86_64)\n",
+            "acl:\n",
+            "  meta                 2.2.53\n",
+            "adcli:\n",
+            "  meta-networking      0.8.2"
+    );
+
+    @Test
+    void test() throws IOException {
+        BitbakeRecipesParser parser = new BitbakeRecipesParser();
+        ShowRecipesResults results = parser.parseShowRecipes(showRecipesOutputLines);
+        assertEquals(3, results.getLayerNames().size());
+        assertTrue(results.getLayerNames().contains("meta"));
+        assertEquals(4, results.getRecipesWithLayers().size());
+        assertTrue(results.getRecipesWithLayers().containsKey("adcli"));
+    }
+}

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bitbake/unit/GraphNodeLabelParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bitbake/unit/GraphNodeLabelParserTest.java
@@ -1,8 +1,10 @@
 package com.synopsys.integration.detectable.detectables.bitbake.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -19,9 +21,10 @@ public class GraphNodeLabelParserTest {
         Set<String> knownLayers = new HashSet<>();
         knownLayers.add("meta");
 
-        String version = parser.parseVersionFromLabel(labelValue);
+        Optional<String> version = parser.parseVersionFromLabel(labelValue);
 
-        assertEquals("2.3.1-r0", version);
+        assertTrue(version.isPresent());
+        assertEquals("2.3.1-r0", version.get());
     }
 
     @Test
@@ -31,8 +34,9 @@ public class GraphNodeLabelParserTest {
         Set<String> knownLayers = new HashSet<>();
         knownLayers.add("meta");
 
-        String layer = parser.parseLayerFromLabel(labelValue, knownLayers);
+        Optional<String> layer = parser.parseLayerFromLabel(labelValue, knownLayers);
 
-        assertEquals("meta", layer);
+        assertTrue(layer.isPresent());
+        assertEquals("meta", layer.get());
     }
 }

--- a/docs/markdown/releasenotes.md
+++ b/docs/markdown/releasenotes.md
@@ -16,8 +16,8 @@
 
 ## Resolved issues
 
-* (IDETECT-3016) Resolved an issue where proxies may block HEAD requests made by [solution_name] when attempting to download the Signature Scanner from Black Duck. Because the criteria that [solution_name] uses to download the Black Duck
-  Signature Scanner is new, the next run will re-download the Signature Scanner.
+* (IDETECT-3016) Resolved an issue where proxies may block HEAD requests made by [solution_name] when attempting to download the Signature Scanner from Black Duck. Because the criteria that [solution_name] uses to download the Black Duck Signature Scanner is new, the next run will re-download the Signature Scanner.
+* (IDETECT-3165) Resolved an issue that could cause the Bitbake detector to fail with error `Graph Node recipe ... does not correspond to any known layer`.
 
 ## Version 7.11.1
 


### PR DESCRIPTION
Bitbake: Fixed an bug in the code that derives the layer list from the show recipes output. Also make detector more tolerant of failures to identify a recipe's layer from the graph node (it will warn and skip the recipe rather than throwing an exception).
