### PR TITLE
doc: Added release note and doc for IDETECT-2970.

### DIFF
--- a/docs/markdown/downloadingandrunning/rapidscan.md
+++ b/docs/markdown/downloadingandrunning/rapidscan.md
@@ -2,7 +2,7 @@
 
 Rapid Scan or Rapid Scan Mode is a new way of running [solution_name] with Black Duck. This mode is designed to be as fast as possible and does not persist any data on Black Duck. Rapid Scan Mode has a unique set of restrictions, mode of configuration and set of results.  
 
-It is enabled by adding [--detect.blackduck.scan.mode=RAPID](../properties/configuration/blackduck-server.md#detect-scan-mode-advanced) to a run of detect.
+Enable this feature by adding [--detect.blackduck.scan.mode=RAPID](../properties/configuration/blackduck-server.md#detect-scan-mode-advanced) to a run of detect.
 
 ## Requirements and Limitations
 
@@ -82,9 +82,8 @@ The results are also printed in the logs:
 
 ## Rapid Scan Compare Mode
 
-Rapid scan can be configured to only return the difference in policy violations between previous rapid scans. This is a Black Duck feature that can be enabled by setting
---detect.blackduck.rapid.compare.mode to one of ALL, BOM_COMPARE and BOM_COMPARE_STRICT.
+You can configure Rapid scan to return only the difference in policy violations between previous rapid scans. To return only the difference in policy violations, configure detect.blackduck.rapid.compare.mode to BOM_COMPARE or BOM_COMPARE_STRICT.
 
-ALL evaluates all RAPID or FULL policies. BOM_COMPARE_STRICT will only show policy violations not present in an existing project version BOM. BOM_COMPARE depends on the type of
+ALL evaluates all RAPID or FULL policies. BOM_COMPARE_STRICT only shows policy violations not present in an existing project version BOM. BOM_COMPARE depends on the type of
 policy rule modes and behaves like ALL if the policy rule is only RAPID but like BOM_COMPARE_STRICT when the policy rule is RAPID and FULL. See the Black Duck documentation for
 complete details.

--- a/docs/markdown/downloadingandrunning/rapidscan.md
+++ b/docs/markdown/downloadingandrunning/rapidscan.md
@@ -80,3 +80,11 @@ The results are also printed in the logs:
 2021-07-20 13:25:18 EDT INFO  [main] --- 			Acorn 5.5.3 (npmjs:acorn/5.5.3)
 ```
 
+## Rapid Scan Compare Mode
+
+Rapid scan can be configured to only return the difference in policy violations between previous rapid scans. This is a Black Duck feature that can be enabled by setting
+--detect.blackduck.rapid.compare.mode to one of ALL, BOM_COMPARE and BOM_COMPARE_STRICT.
+
+ALL evaluates all RAPID or FULL policies. BOM_COMPARE_STRICT will only show policy violations not present in an existing project version BOM. BOM_COMPARE depends on the type of
+policy rule modes and behaves like ALL if the policy rule is only RAPID but like BOM_COMPARE_STRICT when the policy rule is RAPID and FULL. See the Black Duck documentation for
+complete details.

--- a/docs/markdown/releasenotes.md
+++ b/docs/markdown/releasenotes.md
@@ -7,6 +7,7 @@
 * Verified support for Java 16 and 17.
 * Added support for vendoring Go Mod dependencies using [detect.go.mod.dependency.types.excluded=VENDORED](properties/detectors/go.md#go-mod-dependency-types-excluded) to exclude *test* and *build system* dependencies from Go modules
   declaring a version prior to `Go 1.16`.
+* Added Rapid Compare Mode which enables returning only the differences in policy violations compared to a previous scan.
 
 ### Changed features
 


### PR DESCRIPTION
This is the documentation for Rapid mode compare mode. The black duck documentation is in HUB-32247. I tried to just provide the bare minimum and let you reference the Black Duck documentation for the full details.
