### PR TITLE
style(help): misc doc improvements (IDETECT-3097):

### DIFF
--- a/docs/markdown/downloadingandrunning/basics/runningwithblackduck.md
+++ b/docs/markdown/downloadingandrunning/basics/runningwithblackduck.md
@@ -27,7 +27,8 @@ and [Black Duck Signature Scanner properties](../../properties/configuration/sig
 ## Offline mode
 
 If you do not have a [blackduck_product_name] instance, or if your network is down, you can still run [solution_name] in offline mode.
-In offline mode, [solution_name] creates the BDIO content and the dry run [blackduck_signature_scan_act] output files without attempting to upload them to [blackduck_product_name].
+In offline mode, [solution_name] writes output files (.bdio files and, when Vulnerability Impact Analysis runs, .bdmu files) to subdirectories
+within the run directory without attempting to upload them to [blackduck_product_name]. You can find the value of the run directory in the [solution_name] log.
 You can run [solution_name] in offline mode using the [offline mode property](../../properties/configuration/blackduck-server.md#offline-mode).
 
 ## BDIO format

--- a/docs/markdown/gettingstarted/howitworks.md
+++ b/docs/markdown/gettingstarted/howitworks.md
@@ -7,7 +7,7 @@ This page provides an overview of how [solution_name] works.
 [solution_name] performs the following basic steps when scanning open source software, assuming you are connected to a [blackduck_product_name] instance.
 
 1. [solution_name] uses the project's package manager to derive the hierarchy of dependencies known to that package manager. For example, on a Maven project, [solution_name] executes an mvn dependency:tree command, and derives dependency information from the output.
-1. Runs the [blackduck_signature_scanner_name] on the project. This might identify additional dependencies not known to the package manager such as a .jar file copied into the project directory. The [blackduck_signature_scanner_name] only runs when there is a connection to [blackduck_product_name]
+1. Runs the [blackduck_signature_scanner_name] on the project. This might identify additional dependencies not known to the package manager such as a .jar file copied into the project directory.
 1. Uploads both sets of results (dependency details) to [blackduck_product_name] creating the project/version if it does not already exist. [blackduck_product_name] uses the uploaded dependency information to build the Bill Of Materials (BOM) for the project/version.
 
 In this case, the user has provided [blackduck_product_name] connection details through property settings to [solution_name], specifying that results (project dependency details) are to be uploaded to [blackduck_product_name]

--- a/docs/markdown/results/overview.md
+++ b/docs/markdown/results/overview.md
@@ -1,6 +1,8 @@
 # Viewing and Managing Scan Results
 
-To view and manage your [solution_name] scan results, do the following tasks.
+## Online mode
+
+To view and manage your [solution_name] scan results after running [solution_name] online, do the following tasks.
 
 - In the [solution_name] output, look for "Detect Result" and copy the Black Duck Project BOM URL as shown in the following example:
 
@@ -12,3 +14,15 @@ To view and manage your [solution_name] scan results, do the following tasks.
 - To find your scan in [blackduck_product_name], go to your [blackduck_product_name] instance and click Scans to see a list of scans on the Scans page.
 
 For help with viewing and analyzing your scan results go to the [blackduck_product_name] Help page navigation menu at https://{Your hub host}/doc/Welcome.htm
+
+## Offline mode
+
+To view and manage your [solution_name] scan results after running [solution_name] offline (with property *blackduck.offline.mode* set to *true*), do the following tasks.
+
+- In the [solution_name] output (near the beginning), look for the value of "Run directory". The output files will be written into subdirectories of the run directory. For example:
+
+````
+2022-03-07 15:46:29 EST INFO  [main] --- Run directory: /Users/billings/blackduck/runs/2022-03-07-20-46-29-611
+````
+
+Upload each of the output files (.bdio and .bdmu files, found in subdirectories of the run directory) into [blackduck_product_name] using the [blackduck_product_name] Scans page.

--- a/docs/markdown/troubleshooting/solutions.md
+++ b/docs/markdown/troubleshooting/solutions.md
@@ -45,23 +45,6 @@ will run the appropriate detector(s).
 
 See [detector search depth](../properties/configuration/paths.md#detector-search-depth) for more details.
 
-## Docker Inspector error fails after logging: "The [blackduck_product_name] url must be specified"
-
-### Symptom
-
-When running a version of [solution_name] prior to [solution_name] version 5.6.0, the [solution_name] Status block reports DOCKER: FAILURE, and the following error appears in the Docker Inspector log:
-Docker Inspector error: Error inspecting image: The [blackduck_product_name] url must be specified. Either an API token or a username/password must be specified.
-
-### Possible cause
-
-[solution_name] 5.5.1 and earlier have a bug that prevent them from working with Docker Inspector 8.2.0 and newer. The fix is in [solution_name] 5.6.0.
-
-### Solution
-
-There are two possible solutions:
-1. Upgrade to [solution_name] 5.6.0 or newer, or:
-1. Configure [solution_name] to use Docker Inspector 8.1.6 with the argument: --detect.docker.inspector.version=8.1.6
-
 ## [solution_name] fails and a TRACE log shows an HTTP response from [blackduck_product_name] of "402 Payment Required" or "502 Bad Gateway"
 
 ### Symptom

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1560,7 +1560,8 @@ public class DetectProperties {
             .setInfo("Detect Tools Excluded", DetectPropertyFromVersion.VERSION_5_0_0)
             .setHelp(
                 "The tools Detect should not allow, in a comma-separated list. Excluded tools will not be run even if all criteria for the tool is met. Exclusion rules always win.",
-                "This property and detect.tools provide control over which tools Detect runs."
+                "This property and detect.tools provide control over which tools Detect runs. " +
+                    "If neither detect.tools nor detect.tools.excluded are set, Detect will allow (run if applicable, based on the values of other properties) all Detect tools. If detect.tools is set, and detect.tools.excluded is not set, Detect will only allow to run those tools that are specified in the detect.tools list. If detect.tools.excluded is set, Detect will only allow those tools that are not specified in the detect.tools.excluded list."
             )
             .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
             .build();
@@ -1570,7 +1571,8 @@ public class DetectProperties {
             .setInfo("Detect Tools Included", DetectPropertyFromVersion.VERSION_5_0_0)
             .setHelp(
                 "The tools Detect should allow in a comma-separated list. Tools in this list (as long as they are not also in the excluded list) will be allowed to run if all criteria of the tool are met. Exclusion rules always win.",
-                "This property and detect.tools.excluded provide control over which tools Detect runs."
+                "This property and detect.tools.excluded provide control over which tools Detect runs. " +
+                    "If neither detect.tools nor detect.tools.excluded are set, Detect will allow (run if applicable, based on the values of other properties) all Detect tools. If detect.tools is set, and detect.tools.excluded is not set, Detect will only allow to run those tools that are specified in the detect.tools list. If detect.tools.excluded is set, Detect will only allow those tools that are not specified in the detect.tools.excluded list."
             )
             .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
             .build()


### PR DESCRIPTION
Getting Started > How it works: Remove the sentence "The Black Duck Signature Scanner only runs when there is a connection to Black Duck"
Explain default behavior for detect.tools and detect.tools.excluded in the property descriptions
Remove "Docker Inspector error fails after logging: The Black Duck url must be specified" from "Solutions to common problems"
Add to "Viewing and Managing Scan Results" an explanation of how to get scan results after running Detect offline