### PR TITLE
feat: Improve error message when DEEP_LICENSE is passed as a clone ca…

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/project/SyncProjectOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/project/SyncProjectOperation.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectCloneCategoriesType;
+import com.synopsys.integration.blackduck.exception.BlackDuckApiException;
 import com.synopsys.integration.blackduck.service.dataservice.ProjectService;
 import com.synopsys.integration.blackduck.service.model.ProjectSyncModel;
 import com.synopsys.integration.blackduck.service.model.ProjectVersionWrapper;
@@ -43,7 +44,17 @@ public class SyncProjectOperation {
             projectSyncOptions
         );
         boolean forceUpdate = projectSyncOptions.isForceProjectVersionUpdate();
-        return projectService.syncProjectAndVersion(projectSyncModel, forceUpdate);
+
+        //TODO- remove try-catch once there is a mechanism for validating property values against BD versions
+        try {
+            return projectService.syncProjectAndVersion(projectSyncModel, forceUpdate);
+        } catch (BlackDuckApiException e) {
+            if (projectSyncOptions.getCloneCategories().contains(ProjectCloneCategoriesType.DEEP_LICENSE)) {
+                String message = "Attempt to create or update project failed.  If you are using a Black Duck earlier than 2022.2.0, this may be because you passed DEEP_LICENSE as a project clone category, either explicitly or by passing ALL.";
+                throw new IntegrationException(message);
+            }
+            throw e;
+        }
     }
 
     public ProjectSyncModel createProjectSyncModel(

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/project/SyncProjectOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/project/SyncProjectOperation.java
@@ -51,7 +51,7 @@ public class SyncProjectOperation {
         } catch (BlackDuckApiException e) {
             if (projectSyncOptions.getCloneCategories().contains(ProjectCloneCategoriesType.DEEP_LICENSE)) {
                 String message = "Attempt to create or update project failed.  If you are using a Black Duck earlier than 2022.2.0, this may be because you passed DEEP_LICENSE as a project clone category, either explicitly or by passing ALL.";
-                throw new IntegrationException(message);
+                throw new IntegrationException(message, e);
             }
             throw e;
         }


### PR DESCRIPTION
Example of what log would look like when project sync fails and DEEP_LICENSE is passed as a clone category.

INFO  [main] --- ======== Detect Issues ========
INFO  [main] --- 
INFO  [main] --- EXCEPTIONS:
INFO  [main] --- 	Create or Locate Project
INFO  [main] --- 		Attempt to create or update project failed.  If you are using a Black Duck earlier than 2022.2.0, this may be because you passed DEEP_LICENSE as a project clone category, either explicitly or by passing ALL.
