### PR TITLE
Sb bazel fix for complex maven coordinates

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/pipeline/step/FinalStepTransformColonSeparatedGavsToMaven.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/pipeline/step/FinalStepTransformColonSeparatedGavsToMaven.java
@@ -37,7 +37,7 @@ public class FinalStepTransformColonSeparatedGavsToMaven implements FinalStep {
         String[] gavParts = artifactString.split(separatorRegex);
         String group = gavParts[0];
         String artifact = gavParts[1];
-        String version = gavParts[2];
+        String version = gavParts[gavParts.length - 1];
 
         logger.debug("Adding dependency from external id: {}:{}:{}", group, artifact, version);
         ExternalId externalId = externalIdFactory.createMavenExternalId(group, artifact, version);

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bazel/unit/FinalStepTransformColonSeparatedGavsToMavenTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/bazel/unit/FinalStepTransformColonSeparatedGavsToMavenTest.java
@@ -1,0 +1,55 @@
+package com.synopsys.integration.detectable.detectables.bazel.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.bdio.model.dependency.Dependency;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.detectable.detectable.exception.DetectableException;
+import com.synopsys.integration.detectable.detectables.bazel.pipeline.step.FinalStepTransformColonSeparatedGavsToMaven;
+
+public class FinalStepTransformColonSeparatedGavsToMavenTest {
+
+    @Test
+    void testThreePart() throws DetectableException {
+        ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+        FinalStepTransformColonSeparatedGavsToMaven step = new FinalStepTransformColonSeparatedGavsToMaven(externalIdFactory);
+        List<Dependency> deps = step.finish(Arrays.asList("xml-apis:xml-apis:1.4.01"));
+        assertEquals(1, deps.size());
+        String[] pieces = deps.get(0).getExternalId().getExternalIdPieces();
+        assertEquals(3, pieces.length);
+        assertEquals("xml-apis", pieces[0]);
+        assertEquals("xml-apis", pieces[1]);
+        assertEquals("1.4.01", pieces[2]);
+    }
+
+    @Test
+    void testFourPart() throws DetectableException {
+        ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+        FinalStepTransformColonSeparatedGavsToMaven step = new FinalStepTransformColonSeparatedGavsToMaven(externalIdFactory);
+        List<Dependency> deps = step.finish(Arrays.asList("org.bouncycastle:bcutil-jdk15on:jar:1.70"));
+        assertEquals(1, deps.size());
+        String[] pieces = deps.get(0).getExternalId().getExternalIdPieces();
+        assertEquals(3, pieces.length);
+        assertEquals("org.bouncycastle", pieces[0]);
+        assertEquals("bcutil-jdk15on", pieces[1]);
+        assertEquals("1.70", pieces[2]);
+    }
+
+    @Test
+    void testFivePart() throws DetectableException {
+        ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+        FinalStepTransformColonSeparatedGavsToMaven step = new FinalStepTransformColonSeparatedGavsToMaven(externalIdFactory);
+        List<Dependency> deps = step.finish(Arrays.asList("io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.58.Final"));
+        assertEquals(1, deps.size());
+        String[] pieces = deps.get(0).getExternalId().getExternalIdPieces();
+        assertEquals(3, pieces.length);
+        assertEquals("io.netty", pieces[0]);
+        assertEquals("netty-transport-native-epoll", pieces[1]);
+        assertEquals("4.1.58.Final", pieces[2]);
+    }
+}

--- a/docs/markdown/releasenotes.md
+++ b/docs/markdown/releasenotes.md
@@ -1,5 +1,15 @@
 # Release notes
 
+## Version 7.13.0
+
+### New features
+
+### Changed features
+
+### Resolved issues
+
+* (IDETECT-3184) Resolved an issue that prevented matches for Bazel maven_install components with complex (>3 parts) maven_coordinates values.
+
 ## Version 7.12.0
 
 ### New features

--- a/src/test/java/com/synopsys/integration/detect/battery/detector/BazelBattery.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/detector/BazelBattery.java
@@ -29,6 +29,19 @@ class BazelBattery {
     }
 
     @Test
+    void bazelMavenInstallComplexCoordinates() {
+        DetectorBatteryTestRunner test = new DetectorBatteryTestRunner("bazel-maven-install-complex", "bazel/maven-install-complex");
+        test.withToolsValue("BAZEL");
+        test.property("detect.bazel.target", "//tests/integration:ArtifactExclusionsTest");
+        test.property("detect.bazel.workspace.rules", "MAVEN_INSTALL");
+        test.executableFromResourceFiles(DetectProperties.DETECT_BAZEL_PATH, BAZEL_MAVEN_INSTALL_OUTPUT_RESOURCE);
+        test.sourceDirectoryNamed("bazel-maven-install-complex");
+        test.sourceFileNamed("WORKSPACE");
+        test.expectBdioResources();
+        test.run();
+    }
+
+    @Test
     void bazelHaskellCabalLibrary() {
         DetectorBatteryTestRunner test = new DetectorBatteryTestRunner("bazel-haskell-cabal-library", "bazel/haskell-cabal-library");
         test.withToolsValue("BAZEL");

--- a/src/test/resources/battery/bazel/maven-install-complex/bazel-maven-install-query.xout
+++ b/src/test/resources/battery/bazel/maven-install-complex/bazel-maven-install-query.xout
@@ -1,0 +1,4055 @@
+# /Users/brianhealey/g/daml/navigator/backend/BUILD.bazel:20:12
+java_import(
+  name = "frontend-resources",
+  visibility = ["//visibility:public"],
+  jars = ["//navigator/frontend:frontend.jar"],
+)
+# Rule frontend-resources instantiated at (most recent call last):
+#   /Users/brianhealey/g/daml/navigator/backend/BUILD.bazel:20:12 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3438:11
+jvm_import(
+  name = "com_typesafe_akka_akka_testkit_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-testkit_2.13:2.6.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-testkit_2.13/2.6.18/akka-testkit_2.13-2.6.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-testkit_2.13/2.6.18/akka-testkit_2.13-2.6.18-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_actor_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_typesafe_akka_akka_testkit_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3438:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2152:11
+jvm_import(
+  name = "com_fasterxml_jackson_core_jackson_core",
+  tags = ["maven_coordinates=com.fasterxml.jackson.core:jackson-core:2.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.0/jackson-core-2.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.0/jackson-core-2.12.0-sources.jar",
+  deps = [],
+)
+# Rule com_fasterxml_jackson_core_jackson_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2152:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7447:11
+jvm_import(
+  name = "org_scalatest_scalatest_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest_2.13/3.2.9/scalatest_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest_2.13/3.2.9/scalatest_2.13-3.2.9-sources.jar",
+  deps = ["@maven//:org_scalatest_scalatest_funsuite_2_13", "@maven//:org_scalatest_scalatest_core_2_13", "@maven//:org_scalatest_scalatest_featurespec_2_13", "@maven//:org_scalatest_scalatest_freespec_2_13", "@maven//:org_scalatest_scalatest_refspec_2_13", "@maven//:org_scalatest_scalatest_propspec_2_13", "@maven//:org_scalatest_scalatest_mustmatchers_2_13", "@maven//:org_scalatest_scalatest_flatspec_2_13", "@maven//:org_scalatest_scalatest_wordspec_2_13", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalatest_scalatest_diagrams_2_13", "@maven//:org_scalatest_scalatest_shouldmatchers_2_13", "@maven//:org_scalatest_scalatest_funspec_2_13", "@maven//:org_scalatest_scalatest_matchers_core_2_13"],
+)
+# Rule org_scalatest_scalatest_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7447:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8162:11
+jvm_import(
+  name = "org_tpolecat_typename_2_13",
+  tags = ["maven_coordinates=org.tpolecat:typename_2.13:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/typename_2.13/1.0.0/typename_2.13-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/typename_2.13/1.0.0/typename_2.13-1.0.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect"],
+)
+# Rule org_tpolecat_typename_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8162:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3394:11
+jvm_import(
+  name = "com_typesafe_akka_akka_stream_testkit_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-stream-testkit_2.13:2.6.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream-testkit_2.13/2.6.18/akka-stream-testkit_2.13-2.6.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream-testkit_2.13/2.6.18/akka-stream-testkit_2.13-2.6.18-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_stream_2_13", "@maven//:com_typesafe_akka_akka_testkit_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_typesafe_akka_akka_stream_testkit_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3394:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2233:11
+jvm_import(
+  name = "com_github_ben_manes_caffeine_caffeine",
+  tags = ["maven_coordinates=com.github.ben-manes.caffeine:caffeine:2.8.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.8.0/caffeine-2.8.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/2.8.0/caffeine-2.8.0-sources.jar",
+  deps = ["@maven//:com_google_errorprone_error_prone_annotations", "@maven//:org_checkerframework_checker_qual"],
+)
+# Rule com_github_ben_manes_caffeine_caffeine instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2233:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2662:11
+jvm_import(
+  name = "com_lihaoyi_geny_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:geny_2.13:0.6.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/geny_2.13/0.6.2/geny_2.13-0.6.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/geny_2.13/0.6.2/geny_2.13-0.6.2-sources.jar",
+  deps = [],
+)
+# Rule com_lihaoyi_geny_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2662:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3479:11
+jvm_import(
+  name = "com_typesafe_config",
+  tags = ["maven_coordinates=com.typesafe:config:1.4.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/config/1.4.1/config-1.4.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/config/1.4.1/config-1.4.1-sources.jar",
+  deps = [],
+)
+# Rule com_typesafe_config instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3479:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3415:11
+jvm_import(
+  name = "com_typesafe_akka_akka_stream_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-stream_2.13:2.6.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.13/2.6.18/akka-stream_2.13-2.6.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.13/2.6.18/akka-stream_2.13-2.6.18-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_protobuf_v3_2_13", "@maven//:com_typesafe_akka_akka_actor_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_reactivestreams_reactive_streams", "@maven//:com_typesafe_ssl_config_core_2_13"],
+)
+# Rule com_typesafe_akka_akka_stream_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3415:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4263:11
+jvm_import(
+  name = "io_github_paoloboni_spray_json_derived_codecs_2_13",
+  tags = ["maven_coordinates=io.github.paoloboni:spray-json-derived-codecs_2.13:2.3.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/github/paoloboni/spray-json-derived-codecs_2.13/2.3.4/spray-json-derived-codecs_2.13-2.3.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/github/paoloboni/spray-json-derived-codecs_2.13/2.3.4/spray-json-derived-codecs_2.13-2.3.4-sources.jar",
+  deps = ["@maven//:com_chuusai_shapeless_2_13", "@maven//:io_spray_spray_json_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_github_paoloboni_spray_json_derived_codecs_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4263:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2253:11
+jvm_import(
+  name = "com_github_pureconfig_pureconfig_core_2_13",
+  tags = ["maven_coordinates=com.github.pureconfig:pureconfig-core_2.13:0.14.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-core_2.13/0.14.0/pureconfig-core_2.13-0.14.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-core_2.13/0.14.0/pureconfig-core_2.13-0.14.0-sources.jar",
+  deps = ["@maven//:com_github_pureconfig_pureconfig_macros_2_13", "@maven//:com_typesafe_config", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_github_pureconfig_pureconfig_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2253:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4024:11
+jvm_import(
+  name = "io_gatling_gatling_core",
+  tags = ["maven_coordinates=io.gatling:gatling-core:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-core/3.5.1/gatling-core-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-core/3.5.1/gatling-core-3.5.1-sources.jar",
+  deps = ["@maven//:org_scala_lang_modules_scala_parser_combinators_2_13", "@maven//:io_pebbletemplates_pebble", "@maven//:com_github_scopt_scopt_2_13", "@maven//:net_sf_saxon_Saxon_HE", "@maven//:io_gatling_gatling_commons", "@maven//:io_gatling_gatling_jsonpath", "@maven//:io_burt_jmespath_jackson", "@maven//:com_typesafe_akka_akka_slf4j_2_13", "@maven//:com_softwaremill_quicklens_quicklens_2_13", "@maven//:com_fasterxml_jackson_core_jackson_databind", "@maven//:com_typesafe_akka_akka_actor_2_13", "@maven//:org_simpleflatmapper_lightning_csv", "@maven//:org_jodd_jodd_lagarto", "@maven//:io_netty_netty_handler", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:com_github_ben_manes_caffeine_caffeine"],
+)
+# Rule io_gatling_gatling_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4024:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3275:11
+jvm_import(
+  name = "com_typesafe_akka_akka_http_spray_json_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-http-spray-json_2.13:10.2.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-spray-json_2.13/10.2.8/akka-http-spray-json_2.13-10.2.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-spray-json_2.13/10.2.8/akka-http-spray-json_2.13-10.2.8-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_http_2_13", "@maven//:io_spray_spray_json_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_typesafe_akka_akka_http_spray_json_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3275:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8385:11
+jvm_import(
+  name = "org_typelevel_paiges_core_2_13",
+  tags = ["maven_coordinates=org.typelevel:paiges-core_2.13:0.3.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/paiges-core_2.13/0.3.2/paiges-core_2.13-0.3.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/paiges-core_2.13/0.3.2/paiges-core_2.13-0.3.2-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_typelevel_paiges_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8385:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2486:11
+jvm_import(
+  name = "com_google_guava_failureaccess",
+  tags = ["maven_coordinates=com.google.guava:failureaccess:1.0.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar",
+  deps = [],
+)
+# Rule com_google_guava_failureaccess instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2486:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7625:11
+jvm_import(
+  name = "org_scalaz_scalaz_scalacheck_binding_2_13",
+  tags = ["maven_coordinates=org.scalaz:scalaz-scalacheck-binding_2.13:7.2.33-scalacheck-1.15"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-scalacheck-binding_2.13/7.2.33-scalacheck-1.15/scalaz-scalacheck-binding_2.13-7.2.33-scalacheck-1.15.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-scalacheck-binding_2.13/7.2.33-scalacheck-1.15/scalaz-scalacheck-binding_2.13-7.2.33-scalacheck-1.15-sources.jar",
+  deps = ["@maven//:org_scalacheck_scalacheck_2_13", "@maven//:org_scalaz_scalaz_concurrent_2_13", "@maven//:org_scalaz_scalaz_core_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalaz_scalaz_iteratee_2_13"],
+)
+# Rule org_scalaz_scalaz_scalacheck_binding_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7625:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4195:11
+jvm_import(
+  name = "io_gatling_gatling_netty_util",
+  tags = ["maven_coordinates=io.gatling:gatling-netty-util:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-netty-util/3.5.1/gatling-netty-util-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-netty-util/3.5.1/gatling-netty-util-3.5.1-sources.jar",
+  deps = ["@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_transport_native_epoll_linux_x86_64", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_netty_util instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4195:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2623:11
+jvm_import(
+  name = "com_lihaoyi_fansi_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:fansi_2.13:0.3.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/fansi_2.13/0.3.0/fansi_2.13-0.3.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/fansi_2.13/0.3.0/fansi_2.13-0.3.0-sources.jar",
+  deps = ["@maven//:com_lihaoyi_sourcecode_2_13"],
+)
+# Rule com_lihaoyi_fansi_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2623:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2895:11
+jvm_import(
+  name = "com_sparkjava_spark_core",
+  tags = ["maven_coordinates=com.sparkjava:spark-core:2.9.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/sparkjava/spark-core/2.9.1/spark-core-2.9.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/sparkjava/spark-core/2.9.1/spark-core-2.9.1-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_websocket_websocket_server", "@maven//:org_slf4j_slf4j_api", "@maven//:org_eclipse_jetty_websocket_websocket_servlet", "@maven//:org_eclipse_jetty_jetty_server", "@maven//:org_eclipse_jetty_jetty_webapp"],
+)
+# Rule com_sparkjava_spark_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2895:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6689:11
+jvm_import(
+  name = "org_playframework_anorm_anorm_2_13",
+  tags = ["maven_coordinates=org.playframework.anorm:anorm_2.13:2.6.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/playframework/anorm/anorm_2.13/2.6.8/anorm_2.13-2.6.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/playframework/anorm/anorm_2.13/2.6.8/anorm_2.13-2.6.8-sources.jar",
+  deps = ["@maven//:org_scala_lang_modules_scala_parser_combinators_2_13", "@maven//:joda_time_joda_time", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_playframework_anorm_anorm_tokenizer_2_13", "@maven//:org_joda_joda_convert"],
+)
+# Rule org_playframework_anorm_anorm_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6689:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4899:11
+jvm_import(
+  name = "io_opentelemetry_opentelemetry_sdk_trace",
+  tags = ["maven_coordinates=io.opentelemetry:opentelemetry-sdk-trace:1.1.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.1.0/opentelemetry-sdk-trace-1.1.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/1.1.0/opentelemetry-sdk-trace-1.1.0-sources.jar",
+  deps = ["@maven//:io_opentelemetry_opentelemetry_api", "@maven//:io_opentelemetry_opentelemetry_api_metrics", "@maven//:io_opentelemetry_opentelemetry_sdk_common", "@maven//:io_opentelemetry_opentelemetry_semconv"],
+)
+# Rule io_opentelemetry_opentelemetry_sdk_trace instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4899:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2605:11
+jvm_import(
+  name = "com_h2database_h2",
+  tags = ["maven_coordinates=com.h2database:h2:2.1.210"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/h2database/h2/2.1.210/h2-2.1.210.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/h2database/h2/2.1.210/h2-2.1.210-sources.jar",
+  deps = [],
+)
+# Rule com_h2database_h2 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2605:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7426:11
+jvm_import(
+  name = "org_scalatest_scalatest_wordspec_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-wordspec_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-wordspec_2.13/3.2.9/scalatest-wordspec_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-wordspec_2.13/3.2.9/scalatest-wordspec_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_wordspec_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7426:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4110:11
+jvm_import(
+  name = "io_gatling_gatling_http",
+  tags = ["maven_coordinates=io.gatling:gatling-http:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-http/3.5.1/gatling-http-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-http/3.5.1/gatling-http-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_core", "@maven//:io_gatling_gatling_http_client", "@maven//:net_sf_saxon_Saxon_HE", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_http instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4110:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2432:11
+jvm_import(
+  name = "com_google_code_findbugs_jsr305",
+  tags = ["maven_coordinates=com.google.code.findbugs:jsr305:3.0.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar",
+  deps = [],
+)
+# Rule com_google_code_findbugs_jsr305 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2432:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5645:11
+jvm_import(
+  name = "org_awaitility_awaitility",
+  tags = ["maven_coordinates=org.awaitility:awaitility:3.1.6"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/awaitility/awaitility/3.1.6/awaitility-3.1.6.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/awaitility/awaitility/3.1.6/awaitility-3.1.6-sources.jar",
+  deps = ["@maven//:org_hamcrest_hamcrest_core", "@maven//:org_hamcrest_hamcrest_library", "@maven//:org_objenesis_objenesis"],
+)
+# Rule org_awaitility_awaitility instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5645:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6391:11
+jvm_import(
+  name = "org_junit_platform_junit_platform_commons",
+  tags = ["maven_coordinates=org.junit.platform:junit-platform-commons:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.0.0/junit-platform-commons-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.0.0/junit-platform-commons-1.0.0-sources.jar",
+  deps = ["@maven//:org_apiguardian_apiguardian_api"],
+)
+# Rule org_junit_platform_junit_platform_commons instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6391:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7172:11
+jvm_import(
+  name = "org_scalatest_scalatest_core_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-core_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-core_2.13/3.2.9/scalatest-core_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-core_2.13/3.2.9/scalatest-core_2.13-3.2.9-sources.jar",
+  deps = ["@maven//:org_scalactic_scalactic_2_13", "@maven//:org_scala_lang_modules_scala_xml_2_13", "@maven//:org_scalatest_scalatest_compatible", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scalatest_scalatest_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7172:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3684:11
+jvm_import(
+  name = "io_circe_circe_core_2_13",
+  tags = ["maven_coordinates=io.circe:circe-core_2.13:0.13.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-core_2.13/0.13.0/circe-core_2.13-0.13.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-core_2.13/0.13.0/circe-core_2.13-0.13.0-sources.jar",
+  deps = ["@maven//:io_circe_circe_numbers_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_typelevel_cats_core_2_13"],
+)
+# Rule io_circe_circe_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3684:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4284:11
+jvm_import(
+  name = "io_grpc_grpc_api",
+  tags = ["maven_coordinates=io.grpc:grpc-api:1.44.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-api/1.44.0/grpc-api-1.44.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-api/1.44.0/grpc-api-1.44.0-sources.jar",
+  deps = ["@maven//:com_google_code_findbugs_jsr305", "@maven//:com_google_errorprone_error_prone_annotations", "@maven//:com_google_guava_guava", "@maven//:io_grpc_grpc_context"],
+)
+# Rule io_grpc_grpc_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4284:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7237:11
+jvm_import(
+  name = "org_scalatest_scalatest_flatspec_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-flatspec_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-flatspec_2.13/3.2.9/scalatest-flatspec_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-flatspec_2.13/3.2.9/scalatest-flatspec_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_flatspec_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7237:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7523:11
+jvm_import(
+  name = "org_scalatestplus_testng_6_7_2_13",
+  tags = ["maven_coordinates=org.scalatestplus:testng-6-7_2.13:3.2.9.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatestplus/testng-6-7_2.13/3.2.9.0/testng-6-7_2.13-3.2.9.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatestplus/testng-6-7_2.13/3.2.9.0/testng-6-7_2.13-3.2.9.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalatest_scalatest_core_2_13", "@maven//:org_testng_testng"],
+)
+# Rule org_scalatestplus_testng_6_7_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7523:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7093:11
+jvm_import(
+  name = "org_scalactic_scalactic_2_13",
+  tags = ["maven_coordinates=org.scalactic:scalactic_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalactic/scalactic_2.13/3.2.9/scalactic_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalactic/scalactic_2.13/3.2.9/scalactic_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect"],
+)
+# Rule org_scalactic_scalactic_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7093:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7501:11
+jvm_import(
+  name = "org_scalatestplus_selenium_3_141_2_13",
+  tags = ["maven_coordinates=org.scalatestplus:selenium-3-141_2.13:3.2.9.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatestplus/selenium-3-141_2.13/3.2.9.0/selenium-3-141_2.13-3.2.9.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatestplus/selenium-3-141_2.13/3.2.9.0/selenium-3-141_2.13-3.2.9.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalatest_scalatest_core_2_13", "@maven//:org_seleniumhq_selenium_htmlunit_driver", "@maven//:org_seleniumhq_selenium_selenium_java"],
+)
+# Rule org_scalatestplus_selenium_3_141_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7501:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3827:11
+jvm_import(
+  name = "io_dropwizard_metrics_metrics_graphite",
+  tags = ["maven_coordinates=io.dropwizard.metrics:metrics-graphite:4.1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-graphite/4.1.2/metrics-graphite-4.1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-graphite/4.1.2/metrics-graphite-4.1.2-sources.jar",
+  deps = ["@maven//:com_rabbitmq_amqp_client", "@maven//:io_dropwizard_metrics_metrics_core", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule io_dropwizard_metrics_metrics_graphite instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3827:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3127:11
+jvm_import(
+  name = "com_thesamet_scalapb_scalapb_runtime_grpc_2_13",
+  tags = ["maven_coordinates=com.thesamet.scalapb:scalapb-runtime-grpc_2.13:0.11.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime-grpc_2.13/0.11.8/scalapb-runtime-grpc_2.13-0.11.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime-grpc_2.13/0.11.8/scalapb-runtime-grpc_2.13-0.11.8-sources.jar",
+  deps = ["@maven//:org_scala_lang_modules_scala_collection_compat_2_13", "@maven//:io_grpc_grpc_stub", "@maven//:io_grpc_grpc_protobuf", "@maven//:com_thesamet_scalapb_scalapb_runtime_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_thesamet_scalapb_scalapb_runtime_grpc_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3127:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3537:11
+jvm_import(
+  name = "commons_codec_commons_codec",
+  tags = ["maven_coordinates=commons-codec:commons-codec:1.14"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.14/commons-codec-1.14.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/commons-codec/commons-codec/1.14/commons-codec-1.14-sources.jar",
+  deps = [],
+)
+# Rule commons_codec_commons_codec instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3537:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4704:11
+jvm_import(
+  name = "io_netty_netty_tcnative_boringssl_static",
+  tags = ["maven_coordinates=io.netty:netty-tcnative-boringssl-static:2.0.46.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-tcnative-boringssl-static/2.0.46.Final/netty-tcnative-boringssl-static-2.0.46.Final.jar"],
+  deps = ["@maven//:io_netty_netty_tcnative_classes"],
+)
+# Rule io_netty_netty_tcnative_boringssl_static instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4704:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6771:11
+jvm_import(
+  name = "org_reactivestreams_reactive_streams",
+  tags = ["maven_coordinates=org.reactivestreams:reactive-streams:1.0.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2-sources.jar",
+  deps = [],
+)
+# Rule org_reactivestreams_reactive_streams instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6771:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5115:11
+jvm_import(
+  name = "io_spray_spray_json_2_13",
+  tags = ["maven_coordinates=io.spray:spray-json_2.13:1.3.5"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/spray/spray-json_2.13/1.3.5/spray-json_2.13-1.3.5.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/spray/spray-json_2.13/1.3.5/spray-json_2.13-1.3.5-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_spray_spray_json_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5115:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2587:11
+jvm_import(
+  name = "com_google_protobuf_protobuf_java",
+  tags = ["maven_coordinates=com.google.protobuf:protobuf-java:3.19.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.19.3/protobuf-java-3.19.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.19.3/protobuf-java-3.19.3-sources.jar",
+  deps = [],
+)
+# Rule com_google_protobuf_protobuf_java instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2587:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6789:11
+jvm_import(
+  name = "org_reflections_reflections",
+  tags = ["maven_coordinates=org.reflections:reflections:0.9.12"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/reflections/reflections/0.9.12/reflections-0.9.12.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/reflections/reflections/0.9.12/reflections-0.9.12-sources.jar",
+  deps = ["@maven//:org_javassist_javassist"],
+)
+# Rule org_reflections_reflections instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6789:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5812:11
+jvm_import(
+  name = "org_codehaus_janino_janino",
+  tags = ["maven_coordinates=org.codehaus.janino:janino:3.1.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/codehaus/janino/janino/3.1.4/janino-3.1.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/codehaus/janino/janino/3.1.4/janino-3.1.4-sources.jar",
+  deps = ["@maven//:org_codehaus_janino_commons_compiler"],
+)
+# Rule org_codehaus_janino_janino instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5812:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3234:11
+jvm_import(
+  name = "com_typesafe_akka_akka_actor_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-actor_2.13:2.6.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.13/2.6.18/akka-actor_2.13-2.6.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.13/2.6.18/akka-actor_2.13-2.6.18-sources.jar",
+  deps = ["@maven//:com_typesafe_config", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scala_lang_modules_scala_java8_compat_2_13"],
+)
+# Rule com_typesafe_akka_akka_actor_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3234:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2955:11
+jvm_import(
+  name = "com_squareup_javapoet",
+  tags = ["maven_coordinates=com.squareup:javapoet:1.11.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1-sources.jar",
+  deps = [],
+)
+# Rule com_squareup_javapoet instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2955:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2450:11
+jvm_import(
+  name = "com_google_code_gson_gson",
+  tags = ["maven_coordinates=com.google.code.gson:gson:2.8.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2-sources.jar",
+  deps = [],
+)
+# Rule com_google_code_gson_gson instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2450:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4999:11
+jvm_import(
+  name = "io_prometheus_simpleclient",
+  tags = ["maven_coordinates=io.prometheus:simpleclient:0.8.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/prometheus/simpleclient/0.8.1/simpleclient-0.8.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/prometheus/simpleclient/0.8.1/simpleclient-0.8.1-sources.jar",
+  deps = [],
+)
+# Rule io_prometheus_simpleclient instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4999:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3045:11
+jvm_import(
+  name = "com_thesamet_scalapb_compilerplugin_2_13",
+  tags = ["maven_coordinates=com.thesamet.scalapb:compilerplugin_2.13:0.11.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/compilerplugin_2.13/0.11.8/compilerplugin_2.13-0.11.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/compilerplugin_2.13/0.11.8/compilerplugin_2.13-0.11.8-sources.jar",
+  deps = ["@maven//:com_google_protobuf_protobuf_java", "@maven//:com_thesamet_scalapb_protoc_gen_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13"],
+)
+# Rule com_thesamet_scalapb_compilerplugin_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3045:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3316:11
+jvm_import(
+  name = "com_typesafe_akka_akka_http_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-http_2.13:10.2.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http_2.13/10.2.8/akka-http_2.13-10.2.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http_2.13/10.2.8/akka-http_2.13-10.2.8-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_http_core_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_typesafe_akka_akka_http_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3316:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2680:11
+jvm_import(
+  name = "com_lihaoyi_os_lib_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:os-lib_2.13:0.7.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_2.13/0.7.1/os-lib_2.13-0.7.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_2.13/0.7.1/os-lib_2.13-0.7.1-sources.jar",
+  deps = ["@maven//:com_lihaoyi_geny_2_13"],
+)
+# Rule com_lihaoyi_os_lib_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2680:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6533:11
+jvm_import(
+  name = "org_mockito_mockito_scala_2_13",
+  tags = ["maven_coordinates=org.mockito:mockito-scala_2.13:1.16.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/mockito/mockito-scala_2.13/1.16.3/mockito-scala_2.13-1.16.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/mockito/mockito-scala_2.13/1.16.3/mockito-scala_2.13-1.16.3-sources.jar",
+  deps = ["@maven//:org_scala_lang_modules_scala_parallel_collections_2_13", "@maven//:ru_vyarus_generics_resolver", "@maven//:org_scalactic_scalactic_2_13", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_mockito_mockito_core"],
+)
+# Rule org_mockito_mockito_scala_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6533:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5776:11
+jvm_import(
+  name = "org_checkerframework_checker",
+  tags = ["maven_coordinates=org.checkerframework:checker:2.5.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/checkerframework/checker/2.5.4/checker-2.5.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/checkerframework/checker/2.5.4/checker-2.5.4-sources.jar",
+  deps = [],
+)
+# Rule org_checkerframework_checker instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5776:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3107:11
+jvm_import(
+  name = "com_thesamet_scalapb_protoc_gen_2_13",
+  tags = ["maven_coordinates=com.thesamet.scalapb:protoc-gen_2.13:0.9.5"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/protoc-gen_2.13/0.9.5/protoc-gen_2.13-0.9.5.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/protoc-gen_2.13/0.9.5/protoc-gen_2.13-0.9.5-sources.jar",
+  deps = ["@maven//:com_thesamet_scalapb_protoc_bridge_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_thesamet_scalapb_protoc_gen_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3107:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5683:11
+jvm_import(
+  name = "org_bouncycastle_bcpkix_jdk15on",
+  tags = ["maven_coordinates=org.bouncycastle:bcpkix-jdk15on:1.70"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk15on/1.70/bcpkix-jdk15on-1.70.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk15on/1.70/bcpkix-jdk15on-1.70-sources.jar",
+  deps = ["@maven//:org_bouncycastle_bcprov_jdk15on", "@maven//:org_bouncycastle_bcutil_jdk15on"],
+)
+# Rule org_bouncycastle_bcpkix_jdk15on instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5683:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3087:11
+jvm_import(
+  name = "com_thesamet_scalapb_protoc_bridge_2_13",
+  tags = ["maven_coordinates=com.thesamet.scalapb:protoc-bridge_2.13:0.9.5"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/protoc-bridge_2.13/0.9.5/protoc-bridge_2.13-0.9.5.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/protoc-bridge_2.13/0.9.5/protoc-bridge_2.13-0.9.5-sources.jar",
+  deps = ["@maven//:dev_dirs_directories", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_thesamet_scalapb_protoc_bridge_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3087:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8200:11
+jvm_import(
+  name = "org_typelevel_cats_core_2_13",
+  tags = ["maven_coordinates=org.typelevel:cats-core_2.13:2.6.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-core_2.13/2.6.1/cats-core_2.13-2.6.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-core_2.13/2.6.1/cats-core_2.13-2.6.1-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_typelevel_cats_kernel_2_13", "@maven//:org_typelevel_simulacrum_scalafix_annotations_2_13"],
+)
+# Rule org_typelevel_cats_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8200:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7154:11
+jvm_import(
+  name = "org_scalatest_scalatest_compatible",
+  tags = ["maven_coordinates=org.scalatest:scalatest-compatible:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-compatible/3.2.9/scalatest-compatible-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-compatible/3.2.9/scalatest-compatible-3.2.9-sources.jar",
+  deps = [],
+)
+# Rule org_scalatest_scalatest_compatible instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7154:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3373:11
+jvm_import(
+  name = "com_typesafe_akka_akka_slf4j_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-slf4j_2.13:2.6.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-slf4j_2.13/2.6.18/akka-slf4j_2.13-2.6.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-slf4j_2.13/2.6.18/akka-slf4j_2.13-2.6.18-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_actor_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule com_typesafe_akka_akka_slf4j_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3373:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3150:11
+jvm_import(
+  name = "com_thesamet_scalapb_scalapb_runtime_2_13",
+  tags = ["maven_coordinates=com.thesamet.scalapb:scalapb-runtime_2.13:0.11.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime_2.13/0.11.8/scalapb-runtime_2.13-0.11.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/scalapb-runtime_2.13/0.11.8/scalapb-runtime_2.13-0.11.8-sources.jar",
+  deps = ["@maven//:com_google_protobuf_protobuf_java", "@maven//:com_thesamet_scalapb_lenses_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13"],
+)
+# Rule com_thesamet_scalapb_scalapb_runtime_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3150:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3868:11
+jvm_import(
+  name = "io_dropwizard_metrics_metrics_jvm",
+  tags = ["maven_coordinates=io.dropwizard.metrics:metrics-jvm:4.1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jvm/4.1.2/metrics-jvm-4.1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jvm/4.1.2/metrics-jvm-4.1.2-sources.jar",
+  deps = ["@maven//:io_dropwizard_metrics_metrics_core", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule io_dropwizard_metrics_metrics_jvm instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3868:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5356:11
+jvm_import(
+  name = "net_logstash_logback_logstash_logback_encoder",
+  tags = ["maven_coordinates=net.logstash.logback:logstash-logback-encoder:6.6"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/logstash/logback/logstash-logback-encoder/6.6/logstash-logback-encoder-6.6.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/logstash/logback/logstash-logback-encoder/6.6/logstash-logback-encoder-6.6-sources.jar",
+  deps = ["@maven//:com_fasterxml_jackson_core_jackson_databind"],
+)
+# Rule net_logstash_logback_logstash_logback_encoder instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5356:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7321:11
+jvm_import(
+  name = "org_scalatest_scalatest_matchers_core_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-matchers-core_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-matchers-core_2.13/3.2.9/scalatest-matchers-core_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-matchers-core_2.13/3.2.9/scalatest-matchers-core_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_matchers_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7321:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3705:11
+jvm_import(
+  name = "io_circe_circe_generic_2_13",
+  tags = ["maven_coordinates=io.circe:circe-generic_2.13:0.13.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-generic_2.13/0.13.0/circe-generic_2.13-0.13.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-generic_2.13/0.13.0/circe-generic_2.13-0.13.0-sources.jar",
+  deps = ["@maven//:com_chuusai_shapeless_2_13", "@maven//:io_circe_circe_core_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_circe_circe_generic_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3705:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6731:11
+jvm_import(
+  name = "org_reactivestreams_reactive_streams_examples",
+  tags = ["maven_coordinates=org.reactivestreams:reactive-streams-examples:1.0.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams-examples/1.0.2/reactive-streams-examples-1.0.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams-examples/1.0.2/reactive-streams-examples-1.0.2-sources.jar",
+  deps = ["@maven//:org_reactivestreams_reactive_streams"],
+)
+# Rule org_reactivestreams_reactive_streams_examples instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6731:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3787:11
+jvm_import(
+  name = "io_circe_circe_yaml_2_13",
+  tags = ["maven_coordinates=io.circe:circe-yaml_2.13:0.13.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-yaml_2.13/0.13.0/circe-yaml_2.13-0.13.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-yaml_2.13/0.13.0/circe-yaml_2.13-0.13.0-sources.jar",
+  deps = ["@maven//:io_circe_circe_core_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_yaml_snakeyaml"],
+)
+# Rule io_circe_circe_yaml_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3787:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4942:11
+jvm_import(
+  name = "io_opentelemetry_opentelemetry_semconv",
+  tags = ["maven_coordinates=io.opentelemetry:opentelemetry-semconv:1.1.0-alpha"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-semconv/1.1.0-alpha/opentelemetry-semconv-1.1.0-alpha.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-semconv/1.1.0-alpha/opentelemetry-semconv-1.1.0-alpha-sources.jar",
+  deps = ["@maven//:io_opentelemetry_opentelemetry_api"],
+)
+# Rule io_opentelemetry_opentelemetry_semconv instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4942:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4636:11
+jvm_import(
+  name = "io_netty_netty_handler",
+  tags = ["maven_coordinates=io.netty:netty-handler:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-handler/4.1.72.Final/netty-handler-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-handler/4.1.72.Final/netty-handler-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_transport", "@maven//:io_netty_netty_tcnative_classes", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_resolver", "@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_codec"],
+)
+# Rule io_netty_netty_handler instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4636:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6370:11
+jvm_import(
+  name = "org_junit_jupiter_junit_jupiter_engine",
+  tags = ["maven_coordinates=org.junit.jupiter:junit-jupiter-engine:5.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.0.0/junit-jupiter-engine-5.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.0.0/junit-jupiter-engine-5.0.0-sources.jar",
+  deps = ["@maven//:org_apiguardian_apiguardian_api", "@maven//:org_junit_jupiter_junit_jupiter_api", "@maven//:org_junit_platform_junit_platform_engine"],
+)
+# Rule org_junit_jupiter_junit_jupiter_engine instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6370:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7405:11
+jvm_import(
+  name = "org_scalatest_scalatest_shouldmatchers_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-shouldmatchers_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-shouldmatchers_2.13/3.2.9/scalatest-shouldmatchers_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-shouldmatchers_2.13/3.2.9/scalatest-shouldmatchers_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_matchers_core_2_13"],
+)
+# Rule org_scalatest_scalatest_shouldmatchers_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7405:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6887:11
+jvm_import(
+  name = "org_sangria_graphql_sangria_2_13",
+  tags = ["maven_coordinates=org.sangria-graphql:sangria_2.13:2.0.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria_2.13/2.0.1/sangria_2.13-2.0.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria_2.13/2.0.1/sangria_2.13-2.0.1-sources.jar",
+  deps = ["@maven//:org_sangria_graphql_sangria_streaming_api_2_13", "@maven//:org_sangria_graphql_macro_visit_2_13", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_sangria_graphql_sangria_marshalling_api_2_13", "@maven//:org_parboiled_parboiled_2_13"],
+)
+# Rule org_sangria_graphql_sangria_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6887:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2057:11
+jvm_import(
+  name = "com_auth0_jwks_rsa",
+  tags = ["maven_coordinates=com.auth0:jwks-rsa:0.11.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/auth0/jwks-rsa/0.11.0/jwks-rsa-0.11.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/auth0/jwks-rsa/0.11.0/jwks-rsa-0.11.0-sources.jar",
+  deps = ["@maven//:com_fasterxml_jackson_core_jackson_databind", "@maven//:com_google_guava_guava", "@maven//:commons_codec_commons_codec", "@maven//:commons_io_commons_io"],
+)
+# Rule com_auth0_jwks_rsa instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2057:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8221:11
+jvm_import(
+  name = "org_typelevel_cats_effect_2_13",
+  tags = ["maven_coordinates=org.typelevel:cats-effect_2.13:2.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-effect_2.13/2.5.1/cats-effect_2.13-2.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-effect_2.13/2.5.1/cats-effect_2.13-2.5.1-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_typelevel_cats_core_2_13"],
+)
+# Rule org_typelevel_cats_effect_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8221:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2294:11
+jvm_import(
+  name = "com_github_pureconfig_pureconfig_generic_2_13",
+  tags = ["maven_coordinates=com.github.pureconfig:pureconfig-generic_2.13:0.14.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-generic_2.13/0.14.0/pureconfig-generic_2.13-0.14.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-generic_2.13/0.14.0/pureconfig-generic_2.13-0.14.0-sources.jar",
+  deps = ["@maven//:com_chuusai_shapeless_2_13", "@maven//:com_github_pureconfig_pureconfig_core_2_13", "@maven//:com_github_pureconfig_pureconfig_generic_base_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_github_pureconfig_pureconfig_generic_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2294:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2802:11
+jvm_import(
+  name = "com_lihaoyi_upickle_core_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:upickle-core_2.13:1.2.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/upickle-core_2.13/1.2.0/upickle-core_2.13-1.2.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/upickle-core_2.13/1.2.0/upickle-core_2.13-1.2.0-sources.jar",
+  deps = ["@maven//:com_lihaoyi_geny_2_13", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13"],
+)
+# Rule com_lihaoyi_upickle_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2802:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6968:11
+jvm_import(
+  name = "org_scala_lang_modules_scala_parser_combinators_2_13",
+  tags = ["maven_coordinates=org.scala-lang.modules:scala-parser-combinators_2.13:1.1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scala_lang_modules_scala_parser_combinators_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6968:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4079:11
+jvm_import(
+  name = "io_gatling_gatling_http_client",
+  tags = ["maven_coordinates=io.gatling:gatling-http-client:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-http-client/3.5.1/gatling-http-client-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-http-client/3.5.1/gatling-http-client-3.5.1-sources.jar",
+  deps = ["@maven//:io_netty_netty_transport_native_epoll_linux_x86_64", "@maven//:io_netty_netty_resolver_dns", "@maven//:com_typesafe_scala_logging_scala_logging_2_13", "@maven//:ch_qos_logback_logback_classic", "@maven//:org_slf4j_slf4j_api", "@maven//:io_gatling_gatling_netty_util", "@maven//:io_netty_netty_handler", "@maven//:io_netty_netty_tcnative_boringssl_static", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_codec_http2", "@maven//:io_netty_netty_codec_http", "@maven//:io_netty_netty_handler_proxy"],
+)
+# Rule io_gatling_gatling_http_client instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4079:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6493:11
+jvm_import(
+  name = "org_mockito_mockito_core",
+  tags = ["maven_coordinates=org.mockito:mockito-core:3.6.28"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/mockito/mockito-core/3.6.28/mockito-core-3.6.28.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/mockito/mockito-core/3.6.28/mockito-core-3.6.28-sources.jar",
+  deps = ["@maven//:net_bytebuddy_byte_buddy", "@maven//:net_bytebuddy_byte_buddy_agent", "@maven//:org_objenesis_objenesis"],
+)
+# Rule org_mockito_mockito_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6493:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4349:11
+jvm_import(
+  name = "io_grpc_grpc_netty",
+  tags = ["maven_coordinates=io.grpc:grpc-netty:1.44.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty/1.44.0/grpc-netty-1.44.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-netty/1.44.0/grpc-netty-1.44.0-sources.jar",
+  deps = ["@maven//:io_perfmark_perfmark_api", "@maven//:com_google_errorprone_error_prone_annotations", "@maven//:io_grpc_grpc_core", "@maven//:io_netty_netty_codec_http2", "@maven//:com_google_guava_guava", "@maven//:io_netty_netty_handler_proxy"],
+)
+# Rule io_grpc_grpc_netty instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4349:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7688:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_api",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-api:3.141.59"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.141.59/selenium-api-3.141.59.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/3.141.59/selenium-api-3.141.59-sources.jar",
+  deps = [],
+)
+# Rule org_seleniumhq_selenium_selenium_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7688:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7073:11
+jvm_import(
+  name = "org_scalacheck_scalacheck_2_13",
+  tags = ["maven_coordinates=org.scalacheck:scalacheck_2.13:1.15.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalacheck/scalacheck_2.13/1.15.4/scalacheck_2.13-1.15.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalacheck/scalacheck_2.13/1.15.4/scalacheck_2.13-1.15.4-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scala_sbt_test_interface"],
+)
+# Rule org_scalacheck_scalacheck_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7073:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6712:11
+jvm_import(
+  name = "org_postgresql_postgresql",
+  tags = ["maven_coordinates=org.postgresql:postgresql:42.2.25"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/postgresql/postgresql/42.2.25/postgresql-42.2.25.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/postgresql/postgresql/42.2.25/postgresql-42.2.25-sources.jar",
+  deps = ["@maven//:org_checkerframework_checker_qual"],
+)
+# Rule org_postgresql_postgresql instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6712:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6828:11
+jvm_import(
+  name = "org_sangria_graphql_sangria_marshalling_api_2_13",
+  tags = ["maven_coordinates=org.sangria-graphql:sangria-marshalling-api_2.13:1.0.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_2.13/1.0.4/sangria-marshalling-api_2.13-1.0.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_2.13/1.0.4/sangria-marshalling-api_2.13-1.0.4-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_sangria_graphql_sangria_marshalling_api_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6828:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6451:11
+jvm_import(
+  name = "org_junit_platform_junit_platform_runner",
+  tags = ["maven_coordinates=org.junit.platform:junit-platform-runner:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-runner/1.0.0/junit-platform-runner-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-runner/1.0.0/junit-platform-runner-1.0.0-sources.jar",
+  deps = ["@maven//:junit_junit", "@maven//:org_apiguardian_apiguardian_api", "@maven//:org_junit_platform_junit_platform_launcher", "@maven//:org_junit_platform_junit_platform_suite_api"],
+)
+# Rule org_junit_platform_junit_platform_runner instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6451:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8241:11
+jvm_import(
+  name = "org_typelevel_cats_free_2_13",
+  tags = ["maven_coordinates=org.typelevel:cats-free_2.13:2.6.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-free_2.13/2.6.1/cats-free_2.13-2.6.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-free_2.13/2.6.1/cats-free_2.13-2.6.1-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_typelevel_cats_core_2_13", "@maven//:org_typelevel_simulacrum_scalafix_annotations_2_13"],
+)
+# Rule org_typelevel_cats_free_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8241:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5550:11
+jvm_import(
+  name = "org_apache_commons_commons_text",
+  tags = ["maven_coordinates=org.apache.commons:commons-text:1.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-text/1.4/commons-text-1.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-text/1.4/commons-text-1.4-sources.jar",
+  deps = ["@maven//:org_apache_commons_commons_lang3"],
+)
+# Rule org_apache_commons_commons_text instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5550:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2170:11
+jvm_import(
+  name = "com_fasterxml_jackson_core_jackson_databind",
+  tags = ["maven_coordinates=com.fasterxml.jackson.core:jackson-databind:2.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.0/jackson-databind-2.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.0/jackson-databind-2.12.0-sources.jar",
+  deps = ["@maven//:com_fasterxml_jackson_core_jackson_annotations", "@maven//:com_fasterxml_jackson_core_jackson_core"],
+)
+# Rule com_fasterxml_jackson_core_jackson_databind instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2170:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8091:11
+jvm_import(
+  name = "org_tpolecat_doobie_free_2_13",
+  tags = ["maven_coordinates=org.tpolecat:doobie-free_2.13:0.13.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-free_2.13/0.13.4/doobie-free_2.13-0.13.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-free_2.13/0.13.4/doobie-free_2.13-0.13.4-sources.jar",
+  deps = ["@maven//:org_typelevel_cats_core_2_13", "@maven//:co_fs2_fs2_core_2_13", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13", "@maven//:org_typelevel_cats_free_2_13", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_typelevel_cats_effect_2_13"],
+)
+# Rule org_tpolecat_doobie_free_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8091:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2037:11
+jvm_import(
+  name = "com_auth0_java_jwt",
+  tags = ["maven_coordinates=com.auth0:java-jwt:3.10.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/auth0/java-jwt/3.10.3/java-jwt-3.10.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/auth0/java-jwt/3.10.3/java-jwt-3.10.3-sources.jar",
+  deps = ["@maven//:com_fasterxml_jackson_core_jackson_databind", "@maven//:commons_codec_commons_codec"],
+)
+# Rule com_auth0_java_jwt instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2037:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5036:11
+jvm_import(
+  name = "io_prometheus_simpleclient_dropwizard",
+  tags = ["maven_coordinates=io.prometheus:simpleclient_dropwizard:0.8.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/prometheus/simpleclient_dropwizard/0.8.1/simpleclient_dropwizard-0.8.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/prometheus/simpleclient_dropwizard/0.8.1/simpleclient_dropwizard-0.8.1-sources.jar",
+  deps = ["@maven//:io_dropwizard_metrics_metrics_core", "@maven//:io_prometheus_simpleclient"],
+)
+# Rule io_prometheus_simpleclient_dropwizard instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5036:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:1957:11
+jvm_import(
+  name = "ch_qos_logback_logback_classic",
+  tags = ["maven_coordinates=ch.qos.logback:logback-classic:1.2.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.8/logback-classic-1.2.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.8/logback-classic-1.2.8-sources.jar",
+  deps = ["@maven//:ch_qos_logback_logback_core", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule ch_qos_logback_logback_classic instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:1957:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3808:11
+jvm_import(
+  name = "io_dropwizard_metrics_metrics_core",
+  tags = ["maven_coordinates=io.dropwizard.metrics:metrics-core:4.1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-core/4.1.2/metrics-core-4.1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-core/4.1.2/metrics-core-4.1.2-sources.jar",
+  deps = ["@maven//:org_slf4j_slf4j_api"],
+)
+# Rule io_dropwizard_metrics_metrics_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3808:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8326:11
+jvm_import(
+  name = "org_typelevel_discipline_core_2_13",
+  tags = ["maven_coordinates=org.typelevel:discipline-core_2.13:1.1.5"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/discipline-core_2.13/1.1.5/discipline-core_2.13-1.1.5.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/discipline-core_2.13/1.1.5/discipline-core_2.13-1.1.5-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalacheck_scalacheck_2_13"],
+)
+# Rule org_typelevel_discipline_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8326:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2783:11
+jvm_import(
+  name = "com_lihaoyi_ujson_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:ujson_2.13:1.2.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/ujson_2.13/1.2.0/ujson_2.13-1.2.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/ujson_2.13/1.2.0/ujson_2.13-1.2.0-sources.jar",
+  deps = ["@maven//:com_lihaoyi_upickle_core_2_13"],
+)
+# Rule com_lihaoyi_ujson_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2783:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3848:11
+jvm_import(
+  name = "io_dropwizard_metrics_metrics_jmx",
+  tags = ["maven_coordinates=io.dropwizard.metrics:metrics-jmx:4.1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jmx/4.1.2/metrics-jmx-4.1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jmx/4.1.2/metrics-jmx-4.1.2-sources.jar",
+  deps = ["@maven//:io_dropwizard_metrics_metrics_core", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule io_dropwizard_metrics_metrics_jmx instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3848:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5262:11
+jvm_import(
+  name = "junit_junit",
+  tags = ["maven_coordinates=junit:junit:4.12"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12-sources.jar",
+  deps = ["@maven//:org_hamcrest_hamcrest_core"],
+)
+# Rule junit_junit instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5262:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4306:11
+jvm_import(
+  name = "io_grpc_grpc_context",
+  tags = ["maven_coordinates=io.grpc:grpc-context:1.44.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-context/1.44.0/grpc-context-1.44.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-context/1.44.0/grpc-context-1.44.0-sources.jar",
+  deps = [],
+)
+# Rule io_grpc_grpc_context instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4306:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6949:11
+jvm_import(
+  name = "org_scala_lang_modules_scala_parallel_collections_2_13",
+  tags = ["maven_coordinates=org.scala-lang.modules:scala-parallel-collections_2.13:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parallel-collections_2.13/1.0.0/scala-parallel-collections_2.13-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parallel-collections_2.13/1.0.0/scala-parallel-collections_2.13-1.0.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scala_lang_modules_scala_parallel_collections_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6949:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8139:11
+jvm_import(
+  name = "org_tpolecat_doobie_postgres_2_13",
+  tags = ["maven_coordinates=org.tpolecat:doobie-postgres_2.13:0.13.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-postgres_2.13/0.13.4/doobie-postgres_2.13-0.13.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-postgres_2.13/0.13.4/doobie-postgres_2.13-0.13.4-sources.jar",
+  deps = ["@maven//:org_tpolecat_doobie_core_2_13", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13", "@maven//:co_fs2_fs2_io_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_postgresql_postgresql"],
+)
+# Rule org_tpolecat_doobie_postgres_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8139:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3766:11
+jvm_import(
+  name = "io_circe_circe_parser_2_13",
+  tags = ["maven_coordinates=io.circe:circe-parser_2.13:0.13.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-parser_2.13/0.13.0/circe-parser_2.13-0.13.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-parser_2.13/0.13.0/circe-parser_2.13-0.13.0-sources.jar",
+  deps = ["@maven//:io_circe_circe_core_2_13", "@maven//:io_circe_circe_jawn_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_circe_circe_parser_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3766:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8460:11
+jvm_import(
+  name = "org_wartremover_wartremover_2_13_8",
+  tags = ["maven_coordinates=org.wartremover:wartremover_2.13.8:2.4.16"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/wartremover/wartremover_2.13.8/2.4.16/wartremover_2.13.8-2.4.16.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/wartremover/wartremover_2.13.8/2.4.16/wartremover_2.13.8-2.4.16-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_wartremover_wartremover_2_13_8 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8460:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5096:11
+jvm_import(
+  name = "io_reactivex_rxjava2_rxjava",
+  tags = ["maven_coordinates=io.reactivex.rxjava2:rxjava:2.2.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/reactivex/rxjava2/rxjava/2.2.1/rxjava-2.2.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/reactivex/rxjava2/rxjava/2.2.1/rxjava-2.2.1-sources.jar",
+  deps = ["@maven//:org_reactivestreams_reactive_streams"],
+)
+# Rule io_reactivex_rxjava2_rxjava instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5096:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4822:11
+jvm_import(
+  name = "io_opentelemetry_opentelemetry_api",
+  tags = ["maven_coordinates=io.opentelemetry:opentelemetry-api:1.1.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-api/1.1.0/opentelemetry-api-1.1.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-api/1.1.0/opentelemetry-api-1.1.0-sources.jar",
+  deps = ["@maven//:io_opentelemetry_opentelemetry_context"],
+)
+# Rule io_opentelemetry_opentelemetry_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4822:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3255:11
+jvm_import(
+  name = "com_typesafe_akka_akka_http_core_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-http-core_2.13:10.2.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.13/10.2.8/akka-http-core_2.13-10.2.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.13/10.2.8/akka-http-core_2.13-10.2.8-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_parsing_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_typesafe_akka_akka_http_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3255:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6631:11
+jvm_import(
+  name = "org_pcollections_pcollections",
+  tags = ["maven_coordinates=org.pcollections:pcollections:2.1.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/pcollections/pcollections/2.1.3/pcollections-2.1.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/pcollections/pcollections/2.1.3/pcollections-2.1.3-sources.jar",
+  deps = [],
+)
+# Rule org_pcollections_pcollections instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6631:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3956:11
+jvm_import(
+  name = "io_gatling_gatling_commons_shared_unstable",
+  tags = ["maven_coordinates=io.gatling:gatling-commons-shared-unstable:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-commons-shared-unstable/3.5.1/gatling-commons-shared-unstable-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-commons-shared-unstable/3.5.1/gatling-commons-shared-unstable-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_commons_shared", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_commons_shared_unstable instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3956:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4442:11
+jvm_import(
+  name = "io_grpc_grpc_stub",
+  tags = ["maven_coordinates=io.grpc:grpc-stub:1.44.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-stub/1.44.0/grpc-stub-1.44.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-stub/1.44.0/grpc-stub-1.44.0-sources.jar",
+  deps = ["@maven//:com_google_errorprone_error_prone_annotations", "@maven//:com_google_guava_guava", "@maven//:io_grpc_grpc_api"],
+)
+# Rule io_grpc_grpc_stub instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4442:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2376:11
+jvm_import(
+  name = "com_github_scopt_scopt_2_13",
+  tags = ["maven_coordinates=com.github.scopt:scopt_2.13:4.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/github/scopt/scopt_2.13/4.0.0/scopt_2.13-4.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/github/scopt/scopt_2.13/4.0.0/scopt_2.13-4.0.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_github_scopt_scopt_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2376:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3212:11
+jvm_import(
+  name = "com_typesafe_akka_akka_actor_typed_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-actor-typed_2.13:2.6.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor-typed_2.13/2.6.18/akka-actor-typed_2.13-2.6.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor-typed_2.13/2.6.18/akka-actor-typed_2.13-2.6.18-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_actor_2_13", "@maven//:com_typesafe_akka_akka_slf4j_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule com_typesafe_akka_akka_actor_typed_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3212:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6349:11
+jvm_import(
+  name = "org_junit_jupiter_junit_jupiter_api",
+  tags = ["maven_coordinates=org.junit.jupiter:junit-jupiter-api:5.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.0.0/junit-jupiter-api-5.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.0.0/junit-jupiter-api-5.0.0-sources.jar",
+  deps = ["@maven//:org_apiguardian_apiguardian_api", "@maven//:org_junit_platform_junit_platform_commons", "@maven//:org_opentest4j_opentest4j"],
+)
+# Rule org_junit_jupiter_junit_jupiter_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6349:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3888:11
+jvm_import(
+  name = "io_gatling_highcharts_gatling_charts_highcharts",
+  tags = ["maven_coordinates=io.gatling.highcharts:gatling-charts-highcharts:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/3.5.1/gatling-charts-highcharts-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/3.5.1/gatling-charts-highcharts-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_app", "@maven//:io_gatling_gatling_recorder", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_highcharts_gatling_charts_highcharts instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3888:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2504:11
+jvm_import(
+  name = "com_google_guava_guava",
+  tags = ["maven_coordinates=com.google.guava:guava:31.0.1-jre"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre-sources.jar",
+  deps = ["@maven//:com_google_guava_listenablefuture", "@maven//:com_google_j2objc_j2objc_annotations", "@maven//:com_google_code_findbugs_jsr305", "@maven//:com_google_errorprone_error_prone_annotations", "@maven//:org_checkerframework_checker_qual", "@maven//:com_google_guava_failureaccess"],
+)
+# Rule com_google_guava_guava instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2504:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7480:11
+jvm_import(
+  name = "org_scalatestplus_scalacheck_1_15_2_13",
+  tags = ["maven_coordinates=org.scalatestplus:scalacheck-1-15_2.13:3.2.9.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatestplus/scalacheck-1-15_2.13/3.2.9.0/scalacheck-1-15_2.13-3.2.9.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatestplus/scalacheck-1-15_2.13/3.2.9.0/scalacheck-1-15_2.13-3.2.9.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalacheck_scalacheck_2_13", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatestplus_scalacheck_1_15_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7480:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3458:11
+jvm_import(
+  name = "com_typesafe_scala_logging_scala_logging_2_13",
+  tags = ["maven_coordinates=com.typesafe.scala-logging:scala-logging_2.13:3.9.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.13/3.9.2/scala-logging_2.13-3.9.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/scala-logging/scala-logging_2.13/3.9.2/scala-logging_2.13-3.9.2-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule com_typesafe_scala_logging_scala_logging_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3458:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8046:11
+jvm_import(
+  name = "org_testng_testng",
+  tags = ["maven_coordinates=org.testng:testng:6.7"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/testng/testng/6.7/testng-6.7.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/testng/testng/6.7/testng-6.7-sources.jar",
+  deps = ["@maven//:com_beust_jcommander", "@maven//:junit_junit", "@maven//:org_beanshell_bsh", "@maven//:org_yaml_snakeyaml"],
+)
+# Rule org_testng_testng instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8046:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8068:11
+jvm_import(
+  name = "org_tpolecat_doobie_core_2_13",
+  tags = ["maven_coordinates=org.tpolecat:doobie-core_2.13:0.13.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-core_2.13/0.13.4/doobie-core_2.13-0.13.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-core_2.13/0.13.4/doobie-core_2.13-0.13.4-sources.jar",
+  deps = ["@maven//:org_tpolecat_doobie_free_2_13", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13", "@maven//:org_tpolecat_typename_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:com_chuusai_shapeless_2_13"],
+)
+# Rule org_tpolecat_doobie_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8068:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4879:11
+jvm_import(
+  name = "io_opentelemetry_opentelemetry_sdk_testing",
+  tags = ["maven_coordinates=io.opentelemetry:opentelemetry-sdk-testing:1.1.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-testing/1.1.0/opentelemetry-sdk-testing-1.1.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-testing/1.1.0/opentelemetry-sdk-testing-1.1.0-sources.jar",
+  deps = ["@maven//:io_opentelemetry_opentelemetry_api", "@maven//:io_opentelemetry_opentelemetry_sdk"],
+)
+# Rule io_opentelemetry_opentelemetry_sdk_testing instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4879:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3555:11
+jvm_import(
+  name = "commons_io_commons_io",
+  tags = ["maven_coordinates=commons-io:commons-io:2.5"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/commons-io/commons-io/2.5/commons-io-2.5-sources.jar",
+  deps = [],
+)
+# Rule commons_io_commons_io instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3555:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3336:11
+jvm_import(
+  name = "com_typesafe_akka_akka_parsing_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-parsing_2.13:10.2.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-parsing_2.13/10.2.8/akka-parsing_2.13-10.2.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-parsing_2.13/10.2.8/akka-parsing_2.13-10.2.8-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_typesafe_akka_akka_parsing_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3336:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:1977:11
+jvm_import(
+  name = "ch_qos_logback_logback_core",
+  tags = ["maven_coordinates=ch.qos.logback:logback-core:1.2.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.8/logback-core-1.2.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.8/logback-core-1.2.8-sources.jar",
+  deps = [],
+)
+# Rule ch_qos_logback_logback_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:1977:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3067:11
+jvm_import(
+  name = "com_thesamet_scalapb_lenses_2_13",
+  tags = ["maven_coordinates=com.thesamet.scalapb:lenses_2.13:0.11.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/lenses_2.13/0.11.8/lenses_2.13-0.11.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/thesamet/scalapb/lenses_2.13/0.11.8/lenses_2.13-0.11.8-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13"],
+)
+# Rule com_thesamet_scalapb_lenses_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3067:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6669:11
+jvm_import(
+  name = "org_playframework_anorm_anorm_tokenizer_2_13",
+  tags = ["maven_coordinates=org.playframework.anorm:anorm-tokenizer_2.13:2.6.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/playframework/anorm/anorm-tokenizer_2.13/2.6.8/anorm-tokenizer_2.13-2.6.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/playframework/anorm/anorm-tokenizer_2.13/2.6.8/anorm-tokenizer_2.13-2.6.8-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect"],
+)
+# Rule org_playframework_anorm_anorm_tokenizer_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6669:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7565:11
+jvm_import(
+  name = "org_scalaz_scalaz_core_2_13",
+  tags = ["maven_coordinates=org.scalaz:scalaz-core_2.13:7.2.33"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-core_2.13/7.2.33/scalaz-core_2.13-7.2.33.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-core_2.13/7.2.33/scalaz-core_2.13-7.2.33-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scalaz_scalaz_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7565:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2097:11
+jvm_import(
+  name = "com_chuusai_shapeless_2_13",
+  tags = ["maven_coordinates=com.chuusai:shapeless_2.13:2.3.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.3/shapeless_2.13-2.3.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.3/shapeless_2.13-2.3.3-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_chuusai_shapeless_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2097:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2642:11
+jvm_import(
+  name = "com_lihaoyi_fastparse_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:fastparse_2.13:2.3.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.13/2.3.0/fastparse_2.13-2.3.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.13/2.3.0/fastparse_2.13-2.3.0-sources.jar",
+  deps = ["@maven//:com_lihaoyi_geny_2_13", "@maven//:com_lihaoyi_sourcecode_2_13"],
+)
+# Rule com_lihaoyi_fastparse_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2642:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8302:11
+jvm_import(
+  name = "org_typelevel_cats_laws_2_13",
+  tags = ["maven_coordinates=org.typelevel:cats-laws_2.13:2.6.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-laws_2.13/2.6.1/cats-laws_2.13-2.6.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-laws_2.13/2.6.1/cats-laws_2.13-2.6.1-sources.jar",
+  deps = ["@maven//:org_typelevel_simulacrum_scalafix_annotations_2_13", "@maven//:org_typelevel_cats_core_2_13", "@maven//:org_typelevel_cats_kernel_laws_2_13", "@maven//:org_typelevel_discipline_core_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_typelevel_cats_kernel_2_13"],
+)
+# Rule org_typelevel_cats_laws_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8302:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8480:11
+jvm_import(
+  name = "org_xerial_sqlite_jdbc",
+  tags = ["maven_coordinates=org.xerial:sqlite-jdbc:3.36.0.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.36.0.1/sqlite-jdbc-3.36.0.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.36.0.1/sqlite-jdbc-3.36.0.1-sources.jar",
+  deps = [],
+)
+# Rule org_xerial_sqlite_jdbc instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8480:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/canton/BUILD.bazel:4:12
+java_import(
+  name = "lib",
+  jars = ["@canton//:lib/canton-community-1.0.0-SNAPSHOT.jar"],
+)
+# Rule lib instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/canton/BUILD.bazel:4:12 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7893:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_remote_driver",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-remote-driver:3.141.59"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.141.59/selenium-remote-driver-3.141.59.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-remote-driver/3.141.59/selenium-remote-driver-3.141.59-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_remote_driver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7893:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7133:11
+jvm_import(
+  name = "org_scalameta_munit_2_13",
+  tags = ["maven_coordinates=org.scalameta:munit_2.13:0.7.26"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalameta/munit_2.13/0.7.26/munit_2.13-0.7.26.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalameta/munit_2.13/0.7.26/munit_2.13-0.7.26-sources.jar",
+  deps = ["@maven//:junit_junit", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalameta_junit_interface"],
+)
+# Rule org_scalameta_munit_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7133:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3518:11
+jvm_import(
+  name = "com_zaxxer_HikariCP",
+  tags = ["maven_coordinates=com.zaxxer:HikariCP:3.2.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/zaxxer/HikariCP/3.2.0/HikariCP-3.2.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/zaxxer/HikariCP/3.2.0/HikariCP-3.2.0-sources.jar",
+  deps = ["@maven//:org_slf4j_slf4j_api"],
+)
+# Rule com_zaxxer_HikariCP instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3518:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4594:11
+jvm_import(
+  name = "io_netty_netty_common",
+  tags = ["maven_coordinates=io.netty:netty-common:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-common/4.1.72.Final/netty-common-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-common/4.1.72.Final/netty-common-4.1.72.Final-sources.jar",
+  deps = [],
+)
+# Rule io_netty_netty_common instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4594:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2840:11
+jvm_import(
+  name = "com_oracle_database_jdbc_ojdbc8",
+  tags = ["maven_coordinates=com.oracle.database.jdbc:ojdbc8:19.8.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/19.8.0.0/ojdbc8-19.8.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/19.8.0.0/ojdbc8-19.8.0.0-sources.jar",
+  deps = [],
+)
+# Rule com_oracle_database_jdbc_ojdbc8 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2840:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8116:11
+jvm_import(
+  name = "org_tpolecat_doobie_hikari_2_13",
+  tags = ["maven_coordinates=org.tpolecat:doobie-hikari_2.13:0.13.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-hikari_2.13/0.13.4/doobie-hikari_2.13-0.13.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/tpolecat/doobie-hikari_2.13/0.13.4/doobie-hikari_2.13-0.13.4-sources.jar",
+  deps = ["@maven//:org_tpolecat_doobie_core_2_13", "@maven//:com_zaxxer_HikariCP", "@maven//:org_slf4j_slf4j_api", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_tpolecat_doobie_hikari_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8116:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5703:11
+jvm_import(
+  name = "org_bouncycastle_bcprov_jdk15on",
+  tags = ["maven_coordinates=org.bouncycastle:bcprov-jdk15on:1.70"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70-sources.jar",
+  deps = [],
+)
+# Rule org_bouncycastle_bcprov_jdk15on instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5703:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3998:11
+jvm_import(
+  name = "io_gatling_gatling_commons",
+  tags = ["maven_coordinates=io.gatling:gatling-commons:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-commons/3.5.1/gatling-commons-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-commons/3.5.1/gatling-commons-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_commons_shared", "@maven//:com_typesafe_config", "@maven//:org_typelevel_spire_macros_2_13", "@maven//:com_typesafe_scala_logging_scala_logging_2_13", "@maven//:ch_qos_logback_logback_classic", "@maven//:org_slf4j_slf4j_api", "@maven//:io_gatling_gatling_commons_shared_unstable", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_commons instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3998:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6129:11
+jvm_import(
+  name = "org_flywaydb_flyway_core",
+  tags = ["maven_coordinates=org.flywaydb:flyway-core:8.4.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/flywaydb/flyway-core/8.4.1/flyway-core-8.4.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/flywaydb/flyway-core/8.4.1/flyway-core-8.4.1-sources.jar",
+  deps = [],
+)
+# Rule org_flywaydb_flyway_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6129:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5056:11
+jvm_import(
+  name = "io_prometheus_simpleclient_httpserver",
+  tags = ["maven_coordinates=io.prometheus:simpleclient_httpserver:0.8.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/prometheus/simpleclient_httpserver/0.8.1/simpleclient_httpserver-0.8.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/prometheus/simpleclient_httpserver/0.8.1/simpleclient_httpserver-0.8.1-sources.jar",
+  deps = ["@maven//:io_prometheus_simpleclient", "@maven//:io_prometheus_simpleclient_common"],
+)
+# Rule io_prometheus_simpleclient_httpserver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5056:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3909:11
+jvm_import(
+  name = "io_gatling_gatling_app",
+  tags = ["maven_coordinates=io.gatling:gatling-app:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-app/3.5.1/gatling-app-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-app/3.5.1/gatling-app-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_jms", "@maven//:io_gatling_gatling_graphite", "@maven//:io_gatling_gatling_charts", "@maven//:io_gatling_gatling_core", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:io_gatling_gatling_redis", "@maven//:io_gatling_gatling_jdbc", "@maven//:io_gatling_gatling_http"],
+)
+# Rule io_gatling_gatling_app instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3909:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6750:11
+jvm_import(
+  name = "org_reactivestreams_reactive_streams_tck",
+  tags = ["maven_coordinates=org.reactivestreams:reactive-streams-tck:1.0.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams-tck/1.0.2/reactive-streams-tck-1.0.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams-tck/1.0.2/reactive-streams-tck-1.0.2-sources.jar",
+  deps = ["@maven//:org_reactivestreams_reactive_streams", "@maven//:org_reactivestreams_reactive_streams_examples", "@maven//:org_testng_testng"],
+)
+# Rule org_reactivestreams_reactive_streams_tck instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6750:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4394:11
+jvm_import(
+  name = "io_grpc_grpc_protobuf",
+  tags = ["maven_coordinates=io.grpc:grpc-protobuf:1.44.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.44.0/grpc-protobuf-1.44.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.44.0/grpc-protobuf-1.44.0-sources.jar",
+  deps = ["@maven//:io_grpc_grpc_protobuf_lite", "@maven//:com_google_code_findbugs_jsr305", "@maven//:io_grpc_grpc_api", "@maven//:com_google_protobuf_protobuf_java", "@maven//:com_google_api_grpc_proto_google_common_protos", "@maven//:com_google_guava_guava"],
+)
+# Rule io_grpc_grpc_protobuf instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4394:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4782:11
+jvm_import(
+  name = "io_netty_netty_transport",
+  tags = ["maven_coordinates=io.netty:netty-transport:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-transport/4.1.72.Final/netty-transport-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-transport/4.1.72.Final/netty-transport-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_resolver"],
+)
+# Rule io_netty_netty_transport instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4782:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6275:11
+jvm_import(
+  name = "org_jline_jline",
+  tags = ["maven_coordinates=org.jline:jline:3.7.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/jline/jline/3.7.1/jline-3.7.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/jline/jline/3.7.1/jline-3.7.1-sources.jar",
+  deps = [],
+)
+# Rule org_jline_jline instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6275:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2973:11
+jvm_import(
+  name = "com_storm_enroute_scalameter_core_2_13",
+  tags = ["maven_coordinates=com.storm-enroute:scalameter-core_2.13:0.19"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/storm-enroute/scalameter-core_2.13/0.19/scalameter-core_2.13-0.19.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/storm-enroute/scalameter-core_2.13/0.19/scalameter-core_2.13-0.19-sources.jar",
+  deps = ["@maven//:org_scala_lang_modules_scala_parser_combinators_2_13", "@maven//:org_ow2_asm_asm", "@maven//:org_jline_jline", "@maven//:org_scala_lang_modules_scala_xml_2_13", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_apache_commons_commons_math3", "@maven//:org_apache_commons_commons_lang3"],
+)
+# Rule com_storm_enroute_scalameter_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2973:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5153:11
+jvm_import(
+  name = "javax_annotation_javax_annotation_api",
+  tags = ["maven_coordinates=javax.annotation:javax.annotation-api:1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2-sources.jar",
+  deps = [],
+)
+# Rule javax_annotation_javax_annotation_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5153:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2739:11
+jvm_import(
+  name = "com_lihaoyi_sjsonnet_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:sjsonnet_2.13:0.3.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/sjsonnet_2.13/0.3.0/sjsonnet_2.13-0.3.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/sjsonnet_2.13/0.3.0/sjsonnet_2.13-0.3.0-sources.jar",
+  deps = ["@maven//:com_lihaoyi_pprint_2_13", "@maven//:com_github_scopt_scopt_2_13", "@maven//:com_lihaoyi_os_lib_2_13", "@maven//:org_scala_lang_modules_scala_collection_compat_2_13", "@maven//:org_tukaani_xz", "@maven//:com_lihaoyi_fastparse_2_13", "@maven//:com_lihaoyi_ujson_2_13", "@maven//:com_lihaoyi_scalatags_2_13"],
+)
+# Rule com_lihaoyi_sjsonnet_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2739:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8365:11
+jvm_import(
+  name = "org_typelevel_kind_projector_2_13_8",
+  tags = ["maven_coordinates=org.typelevel:kind-projector_2.13.8:0.13.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/kind-projector_2.13.8/0.13.2/kind-projector_2.13.8-0.13.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/kind-projector_2.13.8/0.13.2/kind-projector_2.13.8-0.13.2-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_typelevel_kind_projector_2_13_8 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8365:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2413:11
+jvm_import(
+  name = "com_google_api_grpc_proto_google_common_protos",
+  tags = ["maven_coordinates=com.google.api.grpc:proto-google-common-protos:2.0.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.1/proto-google-common-protos-2.0.1-sources.jar",
+  deps = ["@maven//:com_google_protobuf_protobuf_java"],
+)
+# Rule com_google_api_grpc_proto_google_common_protos instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2413:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8009:11
+jvm_import(
+  name = "org_slf4j_slf4j_api",
+  tags = ["maven_coordinates=org.slf4j:slf4j-api:1.7.26"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.26/slf4j-api-1.7.26-sources.jar",
+  deps = [],
+)
+# Rule org_slf4j_slf4j_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8009:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4463:11
+jvm_import(
+  name = "io_netty_netty_buffer",
+  tags = ["maven_coordinates=io.netty:netty-buffer:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-buffer/4.1.72.Final/netty-buffer-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-buffer/4.1.72.Final/netty-buffer-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_common"],
+)
+# Rule io_netty_netty_buffer instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4463:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4841:11
+jvm_import(
+  name = "io_opentelemetry_opentelemetry_context",
+  tags = ["maven_coordinates=io.opentelemetry:opentelemetry-context:1.1.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-context/1.1.0/opentelemetry-context-1.1.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-context/1.1.0/opentelemetry-context-1.1.0-sources.jar",
+  deps = [],
+)
+# Rule io_opentelemetry_opentelemetry_context instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4841:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2999:11
+jvm_import(
+  name = "com_storm_enroute_scalameter_2_13",
+  tags = ["maven_coordinates=com.storm-enroute:scalameter_2.13:0.19"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/storm-enroute/scalameter_2.13/0.19/scalameter_2.13-0.19.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/storm-enroute/scalameter_2.13/0.19/scalameter_2.13-0.19-sources.jar",
+  deps = ["@maven//:org_scala_lang_modules_scala_parser_combinators_2_13", "@maven//:org_jline_jline", "@maven//:org_scala_lang_modules_scala_xml_2_13", "@maven//:commons_io_commons_io", "@maven//:com_fasterxml_jackson_module_jackson_module_scala_2_13", "@maven//:org_scala_sbt_test_interface", "@maven//:io_spray_spray_json_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_apache_commons_commons_math3", "@maven//:com_storm_enroute_scalameter_core_2_13"],
+)
+# Rule com_storm_enroute_scalameter_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2999:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3190:11
+jvm_import(
+  name = "com_typesafe_akka_akka_actor_testkit_typed_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-actor-testkit-typed_2.13:2.6.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor-testkit-typed_2.13/2.6.18/akka-actor-testkit-typed_2.13-2.6.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor-testkit-typed_2.13/2.6.18/akka-actor-testkit-typed_2.13-2.6.18-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_actor_typed_2_13", "@maven//:com_typesafe_akka_akka_slf4j_2_13", "@maven//:com_typesafe_akka_akka_testkit_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_typesafe_akka_akka_actor_testkit_typed_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3190:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8283:11
+jvm_import(
+  name = "org_typelevel_cats_kernel_2_13",
+  tags = ["maven_coordinates=org.typelevel:cats-kernel_2.13:2.6.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-kernel_2.13/2.6.1/cats-kernel_2.13-2.6.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-kernel_2.13/2.6.1/cats-kernel_2.13-2.6.1-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_typelevel_cats_kernel_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8283:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3296:11
+jvm_import(
+  name = "com_typesafe_akka_akka_http_testkit_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-http-testkit_2.13:10.2.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-testkit_2.13/10.2.8/akka-http-testkit_2.13-10.2.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-testkit_2.13/10.2.8/akka-http-testkit_2.13-10.2.8-sources.jar",
+  deps = ["@maven//:com_typesafe_akka_akka_http_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_typesafe_akka_akka_http_testkit_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3296:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7258:11
+jvm_import(
+  name = "org_scalatest_scalatest_freespec_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-freespec_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-freespec_2.13/3.2.9/scalatest-freespec_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-freespec_2.13/3.2.9/scalatest-freespec_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_freespec_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7258:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4324:11
+jvm_import(
+  name = "io_grpc_grpc_core",
+  tags = ["maven_coordinates=io.grpc:grpc-core:1.44.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.44.0/grpc-core-1.44.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-core/1.44.0/grpc-core-1.44.0-sources.jar",
+  deps = ["@maven//:com_google_android_annotations", "@maven//:org_codehaus_mojo_animal_sniffer_annotations", "@maven//:io_perfmark_perfmark_api", "@maven//:io_grpc_grpc_api", "@maven//:com_google_errorprone_error_prone_annotations", "@maven//:com_google_code_gson_gson", "@maven//:com_google_guava_guava"],
+)
+# Rule io_grpc_grpc_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4324:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2699:11
+jvm_import(
+  name = "com_lihaoyi_pprint_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:pprint_2.13:0.7.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.13/0.7.1/pprint_2.13-0.7.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/pprint_2.13/0.7.1/pprint_2.13-0.7.1-sources.jar",
+  deps = ["@maven//:com_lihaoyi_fansi_2_13", "@maven//:com_lihaoyi_sourcecode_2_13"],
+)
+# Rule com_lihaoyi_pprint_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2699:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4418:11
+jvm_import(
+  name = "io_grpc_grpc_services",
+  tags = ["maven_coordinates=io.grpc:grpc-services:1.44.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-services/1.44.0/grpc-services-1.44.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-services/1.44.0/grpc-services-1.44.0-sources.jar",
+  deps = ["@maven//:io_grpc_grpc_stub", "@maven//:com_google_errorprone_error_prone_annotations", "@maven//:io_grpc_grpc_protobuf", "@maven//:com_google_protobuf_protobuf_java_util", "@maven//:io_grpc_grpc_core", "@maven//:com_google_guava_guava"],
+)
+# Rule io_grpc_grpc_services instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4418:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6293:11
+jvm_import(
+  name = "org_joda_joda_convert",
+  tags = ["maven_coordinates=org.joda:joda-convert:2.2.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/joda/joda-convert/2.2.1/joda-convert-2.2.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/joda/joda-convert/2.2.1/joda-convert-2.2.1-sources.jar",
+  deps = [],
+)
+# Rule org_joda_joda_convert instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6293:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5299:11
+jvm_import(
+  name = "net_bytebuddy_byte_buddy",
+  tags = ["maven_coordinates=net.bytebuddy:byte-buddy:1.10.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.10.18/byte-buddy-1.10.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.10.18/byte-buddy-1.10.18-sources.jar",
+  deps = [],
+)
+# Rule net_bytebuddy_byte_buddy instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5299:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6410:11
+jvm_import(
+  name = "org_junit_platform_junit_platform_engine",
+  tags = ["maven_coordinates=org.junit.platform:junit-platform-engine:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.0.0/junit-platform-engine-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.0.0/junit-platform-engine-1.0.0-sources.jar",
+  deps = ["@maven//:org_apiguardian_apiguardian_api", "@maven//:org_junit_platform_junit_platform_commons", "@maven//:org_opentest4j_opentest4j"],
+)
+# Rule org_junit_platform_junit_platform_engine instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6410:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3497:11
+jvm_import(
+  name = "com_typesafe_ssl_config_core_2_13",
+  tags = ["maven_coordinates=com.typesafe:ssl-config-core_2.13:0.4.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/ssl-config-core_2.13/0.4.2/ssl-config-core_2.13-0.4.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/ssl-config-core_2.13/0.4.2/ssl-config-core_2.13-0.4.2-sources.jar",
+  deps = ["@maven//:com_typesafe_config", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scala_lang_modules_scala_parser_combinators_2_13"],
+)
+# Rule com_typesafe_ssl_config_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3497:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4174:11
+jvm_import(
+  name = "io_gatling_gatling_jsonpath",
+  tags = ["maven_coordinates=io.gatling:gatling-jsonpath:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-jsonpath/3.5.1/gatling-jsonpath-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-jsonpath/3.5.1/gatling-jsonpath-3.5.1-sources.jar",
+  deps = ["@maven//:com_fasterxml_jackson_core_jackson_databind", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scala_lang_modules_scala_parser_combinators_2_13"],
+)
+# Rule io_gatling_gatling_jsonpath instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4174:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7113:11
+jvm_import(
+  name = "org_scalameta_junit_interface",
+  tags = ["maven_coordinates=org.scalameta:junit-interface:0.7.26"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalameta/junit-interface/0.7.26/junit-interface-0.7.26.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalameta/junit-interface/0.7.26/junit-interface-0.7.26-sources.jar",
+  deps = ["@maven//:junit_junit", "@maven//:org_scala_sbt_test_interface"],
+)
+# Rule org_scalameta_junit_interface instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7113:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4216:11
+jvm_import(
+  name = "io_gatling_gatling_recorder",
+  tags = ["maven_coordinates=io.gatling:gatling-recorder:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-recorder/3.5.1/gatling-recorder-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-recorder/3.5.1/gatling-recorder-3.5.1-sources.jar",
+  deps = ["@maven//:org_scala_lang_modules_scala_swing_2_13", "@maven//:com_fasterxml_jackson_core_jackson_databind", "@maven//:io_gatling_gatling_core", "@maven//:com_typesafe_akka_akka_actor_2_13", "@maven//:org_bouncycastle_bcpkix_jdk15on", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:io_netty_netty_codec_http", "@maven//:io_gatling_gatling_http"],
+)
+# Rule io_gatling_gatling_recorder instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4216:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7216:11
+jvm_import(
+  name = "org_scalatest_scalatest_featurespec_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-featurespec_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_2.13/3.2.9/scalatest-featurespec_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_2.13/3.2.9/scalatest-featurespec_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_featurespec_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7216:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2336:11
+jvm_import(
+  name = "com_github_pureconfig_pureconfig_macros_2_13",
+  tags = ["maven_coordinates=com.github.pureconfig:pureconfig-macros_2.13:0.14.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-macros_2.13/0.14.0/pureconfig-macros_2.13-0.14.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-macros_2.13/0.14.0/pureconfig-macros_2.13-0.14.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_github_pureconfig_pureconfig_macros_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2336:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2210:11
+jvm_import(
+  name = "com_fasterxml_jackson_module_jackson_module_scala_2_13",
+  tags = ["maven_coordinates=com.fasterxml.jackson.module:jackson-module-scala_2.13:2.9.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_2.13/2.9.9/jackson-module-scala_2.13-2.9.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_2.13/2.9.9/jackson-module-scala_2.13-2.9.9-sources.jar",
+  deps = ["@maven//:com_fasterxml_jackson_core_jackson_core", "@maven//:com_fasterxml_jackson_core_jackson_databind", "@maven//:com_fasterxml_jackson_module_jackson_module_paranamer", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:com_fasterxml_jackson_core_jackson_annotations"],
+)
+# Rule com_fasterxml_jackson_module_jackson_module_scala_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2210:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2395:11
+jvm_import(
+  name = "com_google_android_annotations",
+  tags = ["maven_coordinates=com.google.android:annotations:4.1.1.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4-sources.jar",
+  deps = [],
+)
+# Rule com_google_android_annotations instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2395:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5794:11
+jvm_import(
+  name = "org_codehaus_janino_commons_compiler",
+  tags = ["maven_coordinates=org.codehaus.janino:commons-compiler:3.1.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/codehaus/janino/commons-compiler/3.1.4/commons-compiler-3.1.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/codehaus/janino/commons-compiler/3.1.4/commons-compiler-3.1.4-sources.jar",
+  deps = [],
+)
+# Rule org_codehaus_janino_commons_compiler instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5794:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4660:11
+jvm_import(
+  name = "io_netty_netty_resolver_dns",
+  tags = ["maven_coordinates=io.netty:netty-resolver-dns:4.1.58.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.1.58.Final/netty-resolver-dns-4.1.58.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.1.58.Final/netty-resolver-dns-4.1.58.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_transport", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_handler", "@maven//:io_netty_netty_resolver", "@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_codec_dns", "@maven//:io_netty_netty_codec"],
+)
+# Rule io_netty_netty_resolver_dns instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4660:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8498:11
+jvm_import(
+  name = "org_yaml_snakeyaml",
+  tags = ["maven_coordinates=org.yaml:snakeyaml:1.26"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/1.26/snakeyaml-1.26.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/1.26/snakeyaml-1.26-sources.jar",
+  deps = [],
+)
+# Rule org_yaml_snakeyaml instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8498:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5281:11
+jvm_import(
+  name = "net_bytebuddy_byte_buddy_agent",
+  tags = ["maven_coordinates=net.bytebuddy:byte-buddy-agent:1.10.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.18/byte-buddy-agent-1.10.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.18/byte-buddy-agent-1.10.18-sources.jar",
+  deps = [],
+)
+# Rule net_bytebuddy_byte_buddy_agent instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5281:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8262:11
+jvm_import(
+  name = "org_typelevel_cats_kernel_laws_2_13",
+  tags = ["maven_coordinates=org.typelevel:cats-kernel-laws_2.13:2.6.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-kernel-laws_2.13/2.6.1/cats-kernel-laws_2.13-2.6.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/cats-kernel-laws_2.13/2.6.1/cats-kernel-laws_2.13-2.6.1-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_typelevel_cats_kernel_2_13", "@maven//:org_typelevel_discipline_core_2_13"],
+)
+# Rule org_typelevel_cats_kernel_laws_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8262:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4373:11
+jvm_import(
+  name = "io_grpc_grpc_protobuf_lite",
+  tags = ["maven_coordinates=io.grpc:grpc-protobuf-lite:1.44.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.44.0/grpc-protobuf-lite-1.44.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.44.0/grpc-protobuf-lite-1.44.0-sources.jar",
+  deps = ["@maven//:com_google_code_findbugs_jsr305", "@maven//:com_google_guava_guava", "@maven//:io_grpc_grpc_api"],
+)
+# Rule io_grpc_grpc_protobuf_lite instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4373:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6557:11
+jvm_import(
+  name = "org_objenesis_objenesis",
+  tags = ["maven_coordinates=org.objenesis:objenesis:3.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/objenesis/objenesis/3.1/objenesis-3.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/objenesis/objenesis/3.1/objenesis-3.1-sources.jar",
+  deps = [],
+)
+# Rule org_objenesis_objenesis instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6557:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6311:11
+jvm_import(
+  name = "org_jodd_jodd_lagarto",
+  tags = ["maven_coordinates=org.jodd:jodd-lagarto:6.0.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/jodd/jodd-lagarto/6.0.3/jodd-lagarto-6.0.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/jodd/jodd-lagarto/6.0.3/jodd-lagarto-6.0.3-sources.jar",
+  deps = ["@maven//:org_jodd_jodd_util", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule org_jodd_jodd_lagarto instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6311:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5721:11
+jvm_import(
+  name = "org_bouncycastle_bcutil_jdk15on",
+  tags = ["maven_coordinates=org.bouncycastle:bcutil-jdk15on:jar:1.70"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/bouncycastle/bcutil-jdk15on/1.70/bcutil-jdk15on-1.70.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/bouncycastle/bcutil-jdk15on/1.70/bcutil-jdk15on-1.70-sources.jar",
+  deps = ["@maven//:org_bouncycastle_bcprov_jdk15on"],
+)
+# Rule org_bouncycastle_bcutil_jdk15on instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5721:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6593:11
+jvm_import(
+  name = "org_ow2_asm_asm",
+  tags = ["maven_coordinates=org.ow2.asm:asm:5.0.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/ow2/asm/asm/5.0.4/asm-5.0.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/ow2/asm/asm/5.0.4/asm-5.0.4-sources.jar",
+  deps = [],
+)
+# Rule org_ow2_asm_asm instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6593:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6930:11
+jvm_import(
+  name = "org_scala_lang_modules_scala_java8_compat_2_13",
+  tags = ["maven_coordinates=org.scala-lang.modules:scala-java8-compat_2.13:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.13/1.0.0/scala-java8-compat_2.13-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.13/1.0.0/scala-java8-compat_2.13-1.0.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scala_lang_modules_scala_java8_compat_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6930:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4961:11
+jvm_import(
+  name = "io_pebbletemplates_pebble",
+  tags = ["maven_coordinates=io.pebbletemplates:pebble:3.1.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/pebbletemplates/pebble/3.1.4/pebble-3.1.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/pebbletemplates/pebble/3.1.4/pebble-3.1.4-sources.jar",
+  deps = ["@maven//:org_slf4j_slf4j_api", "@maven//:org_unbescape_unbescape"],
+)
+# Rule io_pebbletemplates_pebble instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4961:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2545:11
+jvm_import(
+  name = "com_google_j2objc_j2objc_annotations",
+  tags = ["maven_coordinates=com.google.j2objc:j2objc-annotations:1.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3-sources.jar",
+  deps = [],
+)
+# Rule com_google_j2objc_j2objc_annotations instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2545:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7667:11
+jvm_import(
+  name = "org_seleniumhq_selenium_htmlunit_driver",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:htmlunit-driver:2.39.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/htmlunit-driver/2.39.0/htmlunit-driver-2.39.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/htmlunit-driver/2.39.0/htmlunit-driver-2.39.0-sources.jar",
+  deps = ["@maven//:net_sourceforge_htmlunit_htmlunit", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:org_seleniumhq_selenium_selenium_support"],
+)
+# Rule org_seleniumhq_selenium_htmlunit_driver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7667:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4803:11
+jvm_import(
+  name = "io_opentelemetry_opentelemetry_api_metrics",
+  tags = ["maven_coordinates=io.opentelemetry:opentelemetry-api-metrics:1.1.0-alpha"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-api-metrics/1.1.0-alpha/opentelemetry-api-metrics-1.1.0-alpha.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-api-metrics/1.1.0-alpha/opentelemetry-api-metrics-1.1.0-alpha-sources.jar",
+  deps = ["@maven//:io_opentelemetry_opentelemetry_api"],
+)
+# Rule io_opentelemetry_opentelemetry_api_metrics instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4803:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3627:11
+jvm_import(
+  name = "eu_rekawek_toxiproxy_toxiproxy_java",
+  tags = ["maven_coordinates=eu.rekawek.toxiproxy:toxiproxy-java:2.1.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/eu/rekawek/toxiproxy/toxiproxy-java/2.1.3/toxiproxy-java-2.1.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/eu/rekawek/toxiproxy/toxiproxy-java/2.1.3/toxiproxy-java-2.1.3-sources.jar",
+  deps = ["@maven//:com_google_code_gson_gson"],
+)
+# Rule eu_rekawek_toxiproxy_toxiproxy_java instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3627:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4058:11
+jvm_import(
+  name = "io_gatling_gatling_graphite",
+  tags = ["maven_coordinates=io.gatling:gatling-graphite:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-graphite/3.5.1/gatling-graphite-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-graphite/3.5.1/gatling-graphite-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_core", "@maven//:org_hdrhistogram_HdrHistogram", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_graphite instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4058:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5934:11
+jvm_import(
+  name = "org_eclipse_jetty_websocket_websocket_servlet",
+  tags = ["maven_coordinates=org.eclipse.jetty.websocket:websocket-servlet:9.4.18.v20190429"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-servlet/9.4.18.v20190429/websocket-servlet-9.4.18.v20190429.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-servlet/9.4.18.v20190429/websocket-servlet-9.4.18.v20190429-sources.jar",
+  deps = ["@maven//:javax_servlet_javax_servlet_api", "@maven//:org_eclipse_jetty_websocket_websocket_api"],
+)
+# Rule org_eclipse_jetty_websocket_websocket_servlet instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5934:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7826:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_java",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-java:3.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/3.12.0/selenium-java-3.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/3.12.0/selenium-java-3.12.0-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:org_seleniumhq_selenium_selenium_opera_driver", "@maven//:commons_logging_commons_logging", "@maven//:org_seleniumhq_selenium_selenium_remote_driver", "@maven//:org_seleniumhq_selenium_selenium_chrome_driver", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:commons_codec_commons_codec", "@maven//:org_apache_httpcomponents_httpcore", "@maven//:org_seleniumhq_selenium_selenium_edge_driver", "@maven//:org_apache_httpcomponents_httpclient", "@maven//:org_seleniumhq_selenium_selenium_ie_driver", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:org_seleniumhq_selenium_selenium_firefox_driver", "@maven//:org_seleniumhq_selenium_selenium_safari_driver", "@maven//:com_google_code_gson_gson", "@maven//:org_seleniumhq_selenium_selenium_support", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_java instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7826:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4132:11
+jvm_import(
+  name = "io_gatling_gatling_jdbc",
+  tags = ["maven_coordinates=io.gatling:gatling-jdbc:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-jdbc/3.5.1/gatling-jdbc-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-jdbc/3.5.1/gatling-jdbc-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_core", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_jdbc instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4132:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4612:11
+jvm_import(
+  name = "io_netty_netty_handler_proxy",
+  tags = ["maven_coordinates=io.netty:netty-handler-proxy:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.72.Final/netty-handler-proxy-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.72.Final/netty-handler-proxy-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_transport", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_codec_http", "@maven//:io_netty_netty_codec_socks", "@maven//:io_netty_netty_codec"],
+)
+# Rule io_netty_netty_handler_proxy instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4612:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6808:11
+jvm_import(
+  name = "org_sangria_graphql_macro_visit_2_13",
+  tags = ["maven_coordinates=org.sangria-graphql:macro-visit_2.13:0.1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/sangria-graphql/macro-visit_2.13/0.1.2/macro-visit_2.13-0.1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/sangria-graphql/macro-visit_2.13/0.1.2/macro-visit_2.13-0.1.2-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect"],
+)
+# Rule org_sangria_graphql_macro_visit_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6808:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6611:11
+jvm_import(
+  name = "org_parboiled_parboiled_2_13",
+  tags = ["maven_coordinates=org.parboiled:parboiled_2.13:2.1.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/parboiled/parboiled_2.13/2.1.8/parboiled_2.13-2.1.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/parboiled/parboiled_2.13/2.1.8/parboiled_2.13-2.1.8-sources.jar",
+  deps = ["@maven//:com_chuusai_shapeless_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_parboiled_parboiled_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6611:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2563:11
+jvm_import(
+  name = "com_google_protobuf_protobuf_java_util",
+  tags = ["maven_coordinates=com.google.protobuf:protobuf-java-util:3.19.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.19.2/protobuf-java-util-3.19.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.19.2/protobuf-java-util-3.19.2-sources.jar",
+  deps = ["@maven//:com_google_j2objc_j2objc_annotations", "@maven//:com_google_code_findbugs_jsr305", "@maven//:com_google_errorprone_error_prone_annotations", "@maven//:com_google_protobuf_protobuf_java", "@maven//:com_google_code_gson_gson", "@maven//:com_google_guava_guava"],
+)
+# Rule com_google_protobuf_protobuf_java_util instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2563:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5627:11
+jvm_import(
+  name = "org_apiguardian_apiguardian_api",
+  tags = ["maven_coordinates=org.apiguardian:apiguardian-api:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0-sources.jar",
+  deps = [],
+)
+# Rule org_apiguardian_apiguardian_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5627:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6911:11
+jvm_import(
+  name = "org_scala_lang_modules_scala_collection_compat_2_13",
+  tags = ["maven_coordinates=org.scala-lang.modules:scala-collection-compat_2.13:2.6.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/2.6.0/scala-collection-compat_2.13-2.6.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_2.13/2.6.0/scala-collection-compat_2.13-2.6.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scala_lang_modules_scala_collection_compat_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6911:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2765:11
+jvm_import(
+  name = "com_lihaoyi_sourcecode_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:sourcecode_2.13:0.2.7"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/0.2.7/sourcecode_2.13-0.2.7.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/0.2.7/sourcecode_2.13-0.2.7-sources.jar",
+  deps = [],
+)
+# Rule com_lihaoyi_sourcecode_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2765:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2274:11
+jvm_import(
+  name = "com_github_pureconfig_pureconfig_generic_base_2_13",
+  tags = ["maven_coordinates=com.github.pureconfig:pureconfig-generic-base_2.13:0.14.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-generic-base_2.13/0.14.0/pureconfig-generic-base_2.13-0.14.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/github/pureconfig/pureconfig-generic-base_2.13/0.14.0/pureconfig-generic-base_2.13-0.14.0-sources.jar",
+  deps = ["@maven//:com_github_pureconfig_pureconfig_core_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_github_pureconfig_pureconfig_generic_base_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2274:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4740:11
+jvm_import(
+  name = "io_netty_netty_transport_native_epoll_linux_x86_64",
+  tags = ["maven_coordinates=io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.58.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.58.Final/netty-transport-native-epoll-4.1.58.Final-linux-x86_64.jar"],
+  deps = ["@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_transport", "@maven//:io_netty_netty_transport_native_unix_common"],
+)
+# Rule io_netty_netty_transport_native_epoll_linux_x86_64 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4740:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7195:11
+jvm_import(
+  name = "org_scalatest_scalatest_diagrams_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-diagrams_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-diagrams_2.13/3.2.9/scalatest-diagrams_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-diagrams_2.13/3.2.9/scalatest-diagrams_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_diagrams_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7195:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4859:11
+jvm_import(
+  name = "io_opentelemetry_opentelemetry_sdk_common",
+  tags = ["maven_coordinates=io.opentelemetry:opentelemetry-sdk-common:1.1.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-common/1.1.0/opentelemetry-sdk-common-1.1.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-common/1.1.0/opentelemetry-sdk-common-1.1.0-sources.jar",
+  deps = ["@maven//:io_opentelemetry_opentelemetry_api", "@maven//:io_opentelemetry_opentelemetry_semconv"],
+)
+# Rule io_opentelemetry_opentelemetry_sdk_common instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4859:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7604:11
+jvm_import(
+  name = "org_scalaz_scalaz_iteratee_2_13",
+  tags = ["maven_coordinates=org.scalaz:scalaz-iteratee_2.13:7.2.33"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-iteratee_2.13/7.2.33/scalaz-iteratee_2.13-7.2.33.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-iteratee_2.13/7.2.33/scalaz-iteratee_2.13-7.2.33-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalaz_scalaz_core_2_13", "@maven//:org_scalaz_scalaz_effect_2_13"],
+)
+# Rule org_scalaz_scalaz_iteratee_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7604:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7055:11
+jvm_import(
+  name = "org_scala_sbt_test_interface",
+  tags = ["maven_coordinates=org.scala-sbt:test-interface:1.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar",
+  deps = [],
+)
+# Rule org_scala_sbt_test_interface instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7055:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6090:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_webapp",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-webapp:9.4.18.v20190429"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-webapp/9.4.18.v20190429/jetty-webapp-9.4.18.v20190429.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-webapp/9.4.18.v20190429/jetty-webapp-9.4.18.v20190429-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_servlet", "@maven//:org_eclipse_jetty_jetty_xml"],
+)
+# Rule org_eclipse_jetty_jetty_webapp instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6090:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6032:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_server",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-server:9.4.18.v20190429"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/9.4.18.v20190429/jetty-server-9.4.18.v20190429.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/9.4.18.v20190429/jetty-server-9.4.18.v20190429-sources.jar",
+  deps = ["@maven//:javax_servlet_javax_servlet_api", "@maven//:org_eclipse_jetty_jetty_http", "@maven//:org_eclipse_jetty_jetty_io"],
+)
+# Rule org_eclipse_jetty_jetty_server instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6032:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2017:11
+jvm_import(
+  name = "co_fs2_fs2_io_2_13",
+  tags = ["maven_coordinates=co.fs2:fs2-io_2.13:2.5.6"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/co/fs2/fs2-io_2.13/2.5.6/fs2-io_2.13-2.5.6.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/co/fs2/fs2-io_2.13/2.5.6/fs2-io_2.13-2.5.6-sources.jar",
+  deps = ["@maven//:co_fs2_fs2_core_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule co_fs2_fs2_io_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2017:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7972:11
+jvm_import(
+  name = "org_simpleflatmapper_lightning_csv",
+  tags = ["maven_coordinates=org.simpleflatmapper:lightning-csv:8.2.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/simpleflatmapper/lightning-csv/8.2.3/lightning-csv-8.2.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/simpleflatmapper/lightning-csv/8.2.3/lightning-csv-8.2.3-sources.jar",
+  deps = ["@maven//:org_simpleflatmapper_sfm_util"],
+)
+# Rule org_simpleflatmapper_lightning_csv instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7972:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5496:11
+jvm_import(
+  name = "org_apache_commons_commons_lang3",
+  tags = ["maven_coordinates=org.apache.commons:commons-lang3:3.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar",
+  deps = [],
+)
+# Rule org_apache_commons_commons_lang3 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5496:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4528:11
+jvm_import(
+  name = "io_netty_netty_codec_http",
+  tags = ["maven_coordinates=io.netty:netty-codec-http:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.72.Final/netty-codec-http-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.72.Final/netty-codec-http-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_transport", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_handler", "@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_codec"],
+)
+# Rule io_netty_netty_codec_http instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4528:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4981:11
+jvm_import(
+  name = "io_perfmark_perfmark_api",
+  tags = ["maven_coordinates=io.perfmark:perfmark-api:0.23.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/perfmark/perfmark-api/0.23.0/perfmark-api-0.23.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/perfmark/perfmark-api/0.23.0/perfmark-api-0.23.0-sources.jar",
+  deps = [],
+)
+# Rule io_perfmark_perfmark_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4981:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2876:11
+jvm_import(
+  name = "com_softwaremill_quicklens_quicklens_2_13",
+  tags = ["maven_coordinates=com.softwaremill.quicklens:quicklens_2.13:1.6.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/softwaremill/quicklens/quicklens_2.13/1.6.1/quicklens_2.13-1.6.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/softwaremill/quicklens/quicklens_2.13/1.6.1/quicklens_2.13-1.6.1-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule com_softwaremill_quicklens_quicklens_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2876:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2468:11
+jvm_import(
+  name = "com_google_errorprone_error_prone_annotations",
+  tags = ["maven_coordinates=com.google.errorprone:error_prone_annotations:2.9.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.9.0/error_prone_annotations-2.9.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.9.0/error_prone_annotations-2.9.0-sources.jar",
+  deps = [],
+)
+# Rule com_google_errorprone_error_prone_annotations instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2468:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3609:11
+jvm_import(
+  name = "dev_dirs_directories",
+  tags = ["maven_coordinates=dev.dirs:directories:26"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/dev/dirs/directories/26/directories-26.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/dev/dirs/directories/26/directories-26-sources.jar",
+  deps = [],
+)
+# Rule dev_dirs_directories instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3609:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6431:11
+jvm_import(
+  name = "org_junit_platform_junit_platform_launcher",
+  tags = ["maven_coordinates=org.junit.platform:junit-platform-launcher:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/1.0.0/junit-platform-launcher-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/1.0.0/junit-platform-launcher-1.0.0-sources.jar",
+  deps = ["@maven//:org_apiguardian_apiguardian_api", "@maven//:org_junit_platform_junit_platform_engine"],
+)
+# Rule org_junit_platform_junit_platform_launcher instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6431:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2134:11
+jvm_import(
+  name = "com_fasterxml_jackson_core_jackson_annotations",
+  tags = ["maven_coordinates=com.fasterxml.jackson.core:jackson-annotations:2.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.12.0/jackson-annotations-2.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.12.0/jackson-annotations-2.12.0-sources.jar",
+  deps = [],
+)
+# Rule com_fasterxml_jackson_core_jackson_annotations instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2134:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6473:11
+jvm_import(
+  name = "org_junit_platform_junit_platform_suite_api",
+  tags = ["maven_coordinates=org.junit.platform:junit-platform-suite-api:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.0.0/junit-platform-suite-api-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.0.0/junit-platform-suite-api-1.0.0-sources.jar",
+  deps = ["@maven//:org_apiguardian_apiguardian_api", "@maven//:org_junit_platform_junit_platform_commons"],
+)
+# Rule org_junit_platform_junit_platform_suite_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6473:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3747:11
+jvm_import(
+  name = "io_circe_circe_numbers_2_13",
+  tags = ["maven_coordinates=io.circe:circe-numbers_2.13:0.13.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-numbers_2.13/0.13.0/circe-numbers_2.13-0.13.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-numbers_2.13/0.13.0/circe-numbers_2.13-0.13.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_circe_circe_numbers_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3747:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2937:11
+jvm_import(
+  name = "com_squareup_okio_okio",
+  tags = ["maven_coordinates=com.squareup.okio:okio:1.14.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/squareup/okio/okio/1.14.0/okio-1.14.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/squareup/okio/okio/1.14.0/okio-1.14.0-sources.jar",
+  deps = [],
+)
+# Rule com_squareup_okio_okio instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2937:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7384:11
+jvm_import(
+  name = "org_scalatest_scalatest_refspec_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-refspec_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-refspec_2.13/3.2.9/scalatest-refspec_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-refspec_2.13/3.2.9/scalatest-refspec_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_refspec_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7384:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5911:11
+jvm_import(
+  name = "org_eclipse_jetty_websocket_websocket_server",
+  tags = ["maven_coordinates=org.eclipse.jetty.websocket:websocket-server:9.4.18.v20190429"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-server/9.4.18.v20190429/websocket-server-9.4.18.v20190429.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-server/9.4.18.v20190429/websocket-server-9.4.18.v20190429-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_websocket_websocket_servlet", "@maven//:org_eclipse_jetty_jetty_http", "@maven//:org_eclipse_jetty_websocket_websocket_client", "@maven//:org_eclipse_jetty_websocket_websocket_common", "@maven//:org_eclipse_jetty_jetty_servlet"],
+)
+# Rule org_eclipse_jetty_websocket_websocket_server instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5911:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5375:11
+jvm_import(
+  name = "net_sf_saxon_Saxon_HE",
+  tags = ["maven_coordinates=net.sf.saxon:Saxon-HE:10.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/10.3/Saxon-HE-10.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/10.3/Saxon-HE-10.3-sources.jar",
+  deps = [],
+)
+# Rule net_sf_saxon_Saxon_HE instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5375:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4573:11
+jvm_import(
+  name = "io_netty_netty_codec",
+  tags = ["maven_coordinates=io.netty:netty-codec:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec/4.1.72.Final/netty-codec-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec/4.1.72.Final/netty-codec-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_transport"],
+)
+# Rule io_netty_netty_codec instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4573:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2079:11
+jvm_import(
+  name = "com_beust_jcommander",
+  tags = ["maven_coordinates=com.beust:jcommander:1.12"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/beust/jcommander/1.12/jcommander-1.12.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/beust/jcommander/1.12/jcommander-1.12-sources.jar",
+  deps = [],
+)
+# Rule com_beust_jcommander instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2079:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6868:11
+jvm_import(
+  name = "org_sangria_graphql_sangria_streaming_api_2_13",
+  tags = ["maven_coordinates=org.sangria-graphql:sangria-streaming-api_2.13:1.0.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-streaming-api_2.13/1.0.1/sangria-streaming-api_2.13-1.0.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/sangria-graphql/sangria-streaming-api_2.13/1.0.1/sangria-streaming-api_2.13-1.0.1-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_sangria_graphql_sangria_streaming_api_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6868:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8404:11
+jvm_import(
+  name = "org_typelevel_simulacrum_scalafix_annotations_2_13",
+  tags = ["maven_coordinates=org.typelevel:simulacrum-scalafix-annotations_2.13:0.5.4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/simulacrum-scalafix-annotations_2.13/0.5.4/simulacrum-scalafix-annotations_2.13-0.5.4.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/simulacrum-scalafix-annotations_2.13/0.5.4/simulacrum-scalafix-annotations_2.13-0.5.4-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_typelevel_simulacrum_scalafix_annotations_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8404:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8182:11
+jvm_import(
+  name = "org_tukaani_xz",
+  tags = ["maven_coordinates=org.tukaani:xz:1.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/tukaani/xz/1.8/xz-1.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/tukaani/xz/1.8/xz-1.8-sources.jar",
+  deps = [],
+)
+# Rule org_tukaani_xz instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8182:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2918:11
+jvm_import(
+  name = "com_squareup_okhttp3_okhttp",
+  tags = ["maven_coordinates=com.squareup.okhttp3:okhttp:3.11.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.11.0/okhttp-3.11.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/3.11.0/okhttp-3.11.0-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio"],
+)
+# Rule com_squareup_okhttp3_okhttp instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2918:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8516:11
+jvm_import(
+  name = "ru_vyarus_generics_resolver",
+  tags = ["maven_coordinates=ru.vyarus:generics-resolver:3.0.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/ru/vyarus/generics-resolver/3.0.3/generics-resolver-3.0.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/ru/vyarus/generics-resolver/3.0.3/generics-resolver-3.0.3-sources.jar",
+  deps = [],
+)
+# Rule ru_vyarus_generics_resolver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8516:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4921:11
+jvm_import(
+  name = "io_opentelemetry_opentelemetry_sdk",
+  tags = ["maven_coordinates=io.opentelemetry:opentelemetry-sdk:1.1.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk/1.1.0/opentelemetry-sdk-1.1.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk/1.1.0/opentelemetry-sdk-1.1.0-sources.jar",
+  deps = ["@maven//:io_opentelemetry_opentelemetry_api", "@maven//:io_opentelemetry_opentelemetry_sdk_common", "@maven//:io_opentelemetry_opentelemetry_sdk_trace"],
+)
+# Rule io_opentelemetry_opentelemetry_sdk instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4921:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7363:11
+jvm_import(
+  name = "org_scalatest_scalatest_propspec_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-propspec_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-propspec_2.13/3.2.9/scalatest-propspec_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-propspec_2.13/3.2.9/scalatest-propspec_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_propspec_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7363:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5225:11
+jvm_import(
+  name = "joda_time_joda_time",
+  tags = ["maven_coordinates=joda-time:joda-time:2.10.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/joda-time/joda-time/2.10.8/joda-time-2.10.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/joda-time/joda-time/2.10.8/joda-time-2.10.8-sources.jar",
+  deps = [],
+)
+# Rule joda_time_joda_time instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5225:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8423:11
+jvm_import(
+  name = "org_typelevel_spire_macros_2_13",
+  tags = ["maven_coordinates=org.typelevel:spire-macros_2.13:0.17.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/spire-macros_2.13/0.17.0/spire-macros_2.13-0.17.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/spire-macros_2.13/0.17.0/spire-macros_2.13-0.17.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_typelevel_spire_macros_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8423:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2719:11
+jvm_import(
+  name = "com_lihaoyi_scalatags_2_13",
+  tags = ["maven_coordinates=com.lihaoyi:scalatags_2.13:0.9.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/scalatags_2.13/0.9.1/scalatags_2.13-0.9.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/lihaoyi/scalatags_2.13/0.9.1/scalatags_2.13-0.9.1-sources.jar",
+  deps = ["@maven//:com_lihaoyi_geny_2_13", "@maven//:com_lihaoyi_sourcecode_2_13"],
+)
+# Rule com_lihaoyi_scalatags_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2719:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3976:11
+jvm_import(
+  name = "io_gatling_gatling_commons_shared",
+  tags = ["maven_coordinates=io.gatling:gatling-commons-shared:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-commons-shared/3.5.1/gatling-commons-shared-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-commons-shared/3.5.1/gatling-commons-shared-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_netty_util", "@maven//:io_suzaku_boopickle_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect"],
+)
+# Rule io_gatling_gatling_commons_shared instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3976:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7544:11
+jvm_import(
+  name = "org_scalaz_scalaz_concurrent_2_13",
+  tags = ["maven_coordinates=org.scalaz:scalaz-concurrent_2.13:7.2.33"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-concurrent_2.13/7.2.33/scalaz-concurrent_2.13-7.2.33.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-concurrent_2.13/7.2.33/scalaz-concurrent_2.13-7.2.33-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalaz_scalaz_core_2_13", "@maven//:org_scalaz_scalaz_effect_2_13"],
+)
+# Rule org_scalaz_scalaz_concurrent_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7544:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6220:11
+jvm_import(
+  name = "org_javassist_javassist",
+  tags = ["maven_coordinates=org.javassist:javassist:3.26.0-GA"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/javassist/javassist/3.26.0-GA/javassist-3.26.0-GA.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/javassist/javassist/3.26.0-GA/javassist-3.26.0-GA-sources.jar",
+  deps = [],
+)
+# Rule org_javassist_javassist instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6220:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5514:11
+jvm_import(
+  name = "org_apache_commons_commons_math3",
+  tags = ["maven_coordinates=org.apache.commons:commons-math3:3.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-math3/3.2/commons-math3-3.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-math3/3.2/commons-math3-3.2-sources.jar",
+  deps = [],
+)
+# Rule org_apache_commons_commons_math3 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5514:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3664:11
+jvm_import(
+  name = "io_burt_jmespath_jackson",
+  tags = ["maven_coordinates=io.burt:jmespath-jackson:0.5.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/burt/jmespath-jackson/0.5.0/jmespath-jackson-0.5.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/burt/jmespath-jackson/0.5.0/jmespath-jackson-0.5.0-sources.jar",
+  deps = ["@maven//:com_fasterxml_jackson_core_jackson_databind", "@maven//:io_burt_jmespath_core"],
+)
+# Rule io_burt_jmespath_jackson instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3664:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5666:11
+jvm_import(
+  name = "org_beanshell_bsh",
+  tags = ["maven_coordinates=org.beanshell:bsh:2.0b4"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/beanshell/bsh/2.0b4/bsh-2.0b4.jar"],
+  deps = [],
+)
+# Rule org_beanshell_bsh instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5666:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4152:11
+jvm_import(
+  name = "io_gatling_gatling_jms",
+  tags = ["maven_coordinates=io.gatling:gatling-jms:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-jms/3.5.1/gatling-jms-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-jms/3.5.1/gatling-jms-3.5.1-sources.jar",
+  deps = ["@maven//:com_eatthepath_fast_uuid", "@maven//:io_gatling_gatling_core", "@maven//:javax_jms_javax_jms_api", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_jms instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4152:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6165:11
+jvm_import(
+  name = "org_hamcrest_hamcrest_core",
+  tags = ["maven_coordinates=org.hamcrest:hamcrest-core:1.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar",
+  deps = [],
+)
+# Rule org_hamcrest_hamcrest_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6165:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2528:11
+jvm_import(
+  name = "com_google_guava_listenablefuture",
+  tags = ["maven_coordinates=com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"],
+  deps = [],
+)
+# Rule com_google_guava_listenablefuture instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2528:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7006:11
+jvm_import(
+  name = "org_scala_lang_modules_scala_xml_2_13",
+  tags = ["maven_coordinates=org.scala-lang.modules:scala-xml_2.13:1.3.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.3.0/scala-xml_2.13-1.3.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.3.0/scala-xml_2.13-1.3.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scala_lang_modules_scala_xml_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7006:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2858:11
+jvm_import(
+  name = "com_rabbitmq_amqp_client",
+  tags = ["maven_coordinates=com.rabbitmq:amqp-client:5.5.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.5.3/amqp-client-5.5.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/rabbitmq/amqp-client/5.5.3/amqp-client-5.5.3-sources.jar",
+  deps = [],
+)
+# Rule com_rabbitmq_amqp_client instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2858:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4685:11
+jvm_import(
+  name = "io_netty_netty_resolver",
+  tags = ["maven_coordinates=io.netty:netty-resolver:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-resolver/4.1.72.Final/netty-resolver-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-resolver/4.1.72.Final/netty-resolver-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_common"],
+)
+# Rule io_netty_netty_resolver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4685:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5758:11
+jvm_import(
+  name = "org_checkerframework_checker_qual",
+  tags = ["maven_coordinates=org.checkerframework:checker-qual:3.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0-sources.jar",
+  deps = [],
+)
+# Rule org_checkerframework_checker_qual instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5758:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7279:11
+jvm_import(
+  name = "org_scalatest_scalatest_funspec_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-funspec_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-funspec_2.13/3.2.9/scalatest-funspec_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-funspec_2.13/3.2.9/scalatest-funspec_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_funspec_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7279:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6575:11
+jvm_import(
+  name = "org_opentest4j_opentest4j",
+  tags = ["maven_coordinates=org.opentest4j:opentest4j:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/opentest4j/opentest4j/1.0.0/opentest4j-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/opentest4j/opentest4j/1.0.0/opentest4j-1.0.0-sources.jar",
+  deps = [],
+)
+# Rule org_opentest4j_opentest4j instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6575:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4242:11
+jvm_import(
+  name = "io_gatling_gatling_redis",
+  tags = ["maven_coordinates=io.gatling:gatling-redis:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-redis/3.5.1/gatling-redis-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-redis/3.5.1/gatling-redis-3.5.1-sources.jar",
+  deps = ["@maven//:io_gatling_gatling_core", "@maven//:net_debasishg_redisclient_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_redis instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4242:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5017:11
+jvm_import(
+  name = "io_prometheus_simpleclient_common",
+  tags = ["maven_coordinates=io.prometheus:simpleclient_common:0.8.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/prometheus/simpleclient_common/0.8.1/simpleclient_common-0.8.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/prometheus/simpleclient_common/0.8.1/simpleclient_common-0.8.1-sources.jar",
+  deps = ["@maven//:io_prometheus_simpleclient"],
+)
+# Rule io_prometheus_simpleclient_common instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5017:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:1995:11
+jvm_import(
+  name = "co_fs2_fs2_core_2_13",
+  tags = ["maven_coordinates=co.fs2:fs2-core_2.13:2.5.6"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/co/fs2/fs2-core_2.13/2.5.6/fs2-core_2.13-2.5.6.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/co/fs2/fs2-core_2.13/2.5.6/fs2-core_2.13-2.5.6-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scodec_scodec_bits_2_13", "@maven//:org_typelevel_cats_core_2_13", "@maven//:org_typelevel_cats_effect_2_13"],
+)
+# Rule co_fs2_fs2_core_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:1995:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4504:11
+jvm_import(
+  name = "io_netty_netty_codec_http2",
+  tags = ["maven_coordinates=io.netty:netty-codec-http2:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.72.Final/netty-codec-http2-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.72.Final/netty-codec-http2-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_transport", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_handler", "@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_codec_http", "@maven//:io_netty_netty_codec"],
+)
+# Rule io_netty_netty_codec_http2 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4504:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7342:11
+jvm_import(
+  name = "org_scalatest_scalatest_mustmatchers_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-mustmatchers_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.13/3.2.9/scalatest-mustmatchers_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.13/3.2.9/scalatest-mustmatchers_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_matchers_core_2_13"],
+)
+# Rule org_scalatest_scalatest_mustmatchers_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7342:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7300:11
+jvm_import(
+  name = "org_scalatest_scalatest_funsuite_2_13",
+  tags = ["maven_coordinates=org.scalatest:scalatest-funsuite_2.13:3.2.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-funsuite_2.13/3.2.9/scalatest-funsuite_2.13-3.2.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-funsuite_2.13/3.2.9/scalatest-funsuite_2.13-3.2.9-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect", "@maven//:org_scalatest_scalatest_core_2_13"],
+)
+# Rule org_scalatest_scalatest_funsuite_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7300:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5831:11
+jvm_import(
+  name = "org_codehaus_mojo_animal_sniffer_annotations",
+  tags = ["maven_coordinates=org.codehaus.mojo:animal-sniffer-annotations:1.19"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.19/animal-sniffer-annotations-1.19.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.19/animal-sniffer-annotations-1.19-sources.jar",
+  deps = [],
+)
+# Rule org_codehaus_mojo_animal_sniffer_annotations instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5831:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6183:11
+jvm_import(
+  name = "org_hamcrest_hamcrest_library",
+  tags = ["maven_coordinates=org.hamcrest:hamcrest-library:1.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3-sources.jar",
+  deps = ["@maven//:org_hamcrest_hamcrest_core"],
+)
+# Rule org_hamcrest_hamcrest_library instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6183:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5478:11
+jvm_import(
+  name = "org_apache_commons_commons_exec",
+  tags = ["maven_coordinates=org.apache.commons:commons-exec:1.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-exec/1.3/commons-exec-1.3-sources.jar",
+  deps = [],
+)
+# Rule org_apache_commons_commons_exec instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5478:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3935:11
+jvm_import(
+  name = "io_gatling_gatling_charts",
+  tags = ["maven_coordinates=io.gatling:gatling-charts:3.5.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-charts/3.5.1/gatling-charts-3.5.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/gatling/gatling-charts/3.5.1/gatling-charts-3.5.1-sources.jar",
+  deps = ["@maven//:com_tdunning_t_digest", "@maven//:io_gatling_gatling_core", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_gatling_gatling_charts instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3935:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3355:11
+jvm_import(
+  name = "com_typesafe_akka_akka_protobuf_v3_2_13",
+  tags = ["maven_coordinates=com.typesafe.akka:akka-protobuf-v3_2.13:2.6.18"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.13/2.6.18/akka-protobuf-v3_2.13-2.6.18.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.13/2.6.18/akka-protobuf-v3_2.13-2.6.18-sources.jar",
+  deps = [],
+)
+# Rule com_typesafe_akka_akka_protobuf_v3_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3355:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4722:11
+jvm_import(
+  name = "io_netty_netty_tcnative_classes",
+  tags = ["maven_coordinates=io.netty:netty-tcnative-classes:2.0.46.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-tcnative-classes/2.0.46.Final/netty-tcnative-classes-2.0.46.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-tcnative-classes/2.0.46.Final/netty-tcnative-classes-2.0.46.Final-sources.jar",
+  deps = [],
+)
+# Rule io_netty_netty_tcnative_classes instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4722:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3726:11
+jvm_import(
+  name = "io_circe_circe_jawn_2_13",
+  tags = ["maven_coordinates=io.circe:circe-jawn_2.13:0.13.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-jawn_2.13/0.13.0/circe-jawn_2.13-0.13.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/circe/circe-jawn_2.13/0.13.0/circe-jawn_2.13-0.13.0-sources.jar",
+  deps = ["@maven//:io_circe_circe_core_2_13", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_typelevel_jawn_parser_2_13"],
+)
+# Rule io_circe_circe_jawn_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3726:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6202:11
+jvm_import(
+  name = "org_hdrhistogram_HdrHistogram",
+  tags = ["maven_coordinates=org.hdrhistogram:HdrHistogram:2.1.12"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/hdrhistogram/HdrHistogram/2.1.12/HdrHistogram-2.1.12.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/hdrhistogram/HdrHistogram/2.1.12/HdrHistogram-2.1.12-sources.jar",
+  deps = [],
+)
+# Rule org_hdrhistogram_HdrHistogram instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6202:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5867:11
+jvm_import(
+  name = "org_eclipse_jetty_websocket_websocket_client",
+  tags = ["maven_coordinates=org.eclipse.jetty.websocket:websocket-client:9.4.27.v20200227"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-client/9.4.27.v20200227/websocket-client-9.4.27.v20200227.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-client/9.4.27.v20200227/websocket-client-9.4.27.v20200227-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_client", "@maven//:org_eclipse_jetty_jetty_io", "@maven//:org_eclipse_jetty_jetty_xml", "@maven//:org_eclipse_jetty_websocket_websocket_common", "@maven//:org_eclipse_jetty_jetty_util"],
+)
+# Rule org_eclipse_jetty_websocket_websocket_client instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5867:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3646:11
+jvm_import(
+  name = "io_burt_jmespath_core",
+  tags = ["maven_coordinates=io.burt:jmespath-core:0.5.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/burt/jmespath-core/0.5.0/jmespath-core-0.5.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/burt/jmespath-core/0.5.0/jmespath-core-0.5.0-sources.jar",
+  deps = [],
+)
+# Rule io_burt_jmespath_core instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3646:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4482:11
+jvm_import(
+  name = "io_netty_netty_codec_dns",
+  tags = ["maven_coordinates=io.netty:netty-codec-dns:4.1.58.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec-dns/4.1.58.Final/netty-codec-dns-4.1.58.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec-dns/4.1.58.Final/netty-codec-dns-4.1.58.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_codec", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_transport"],
+)
+# Rule io_netty_netty_codec_dns instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4482:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5890:11
+jvm_import(
+  name = "org_eclipse_jetty_websocket_websocket_common",
+  tags = ["maven_coordinates=org.eclipse.jetty.websocket:websocket-common:9.4.27.v20200227"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-common/9.4.27.v20200227/websocket-common-9.4.27.v20200227.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-common/9.4.27.v20200227/websocket-common-9.4.27.v20200227-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_io", "@maven//:org_eclipse_jetty_jetty_util", "@maven//:org_eclipse_jetty_websocket_websocket_api"],
+)
+# Rule org_eclipse_jetty_websocket_websocket_common instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5890:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7766:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_firefox_driver",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-firefox-driver:3.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-firefox-driver/3.12.0/selenium-firefox-driver-3.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-firefox-driver/3.12.0/selenium-firefox-driver-3.12.0-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:commons_logging_commons_logging", "@maven//:org_seleniumhq_selenium_selenium_remote_driver", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:commons_codec_commons_codec", "@maven//:org_apache_httpcomponents_httpcore", "@maven//:org_apache_httpcomponents_httpclient", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:com_google_code_gson_gson", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_firefox_driver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7766:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7917:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_safari_driver",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-safari-driver:3.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/3.12.0/selenium-safari-driver-3.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/3.12.0/selenium-safari-driver-3.12.0-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:commons_logging_commons_logging", "@maven//:org_seleniumhq_selenium_selenium_remote_driver", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:commons_codec_commons_codec", "@maven//:org_apache_httpcomponents_httpcore", "@maven//:org_apache_httpcomponents_httpclient", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:com_google_code_gson_gson", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_safari_driver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7917:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5429:11
+jvm_import(
+  name = "net_sourceforge_htmlunit_htmlunit",
+  tags = ["maven_coordinates=net.sourceforge.htmlunit:htmlunit:2.39.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/sourceforge/htmlunit/htmlunit/2.39.0/htmlunit-2.39.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/sourceforge/htmlunit/htmlunit/2.39.0/htmlunit-2.39.0-sources.jar",
+  deps = ["@maven//:net_sourceforge_htmlunit_htmlunit_cssparser", "@maven//:net_sourceforge_htmlunit_htmlunit_core_js", "@maven//:org_apache_httpcomponents_httpmime", "@maven//:commons_logging_commons_logging", "@maven//:xalan_xalan", "@maven//:commons_io_commons_io", "@maven//:commons_net_commons_net", "@maven//:org_eclipse_jetty_websocket_websocket_client", "@maven//:net_sourceforge_htmlunit_neko_htmlunit", "@maven//:org_apache_commons_commons_text", "@maven//:org_brotli_dec", "@maven//:org_apache_commons_commons_lang3"],
+)
+# Rule net_sourceforge_htmlunit_htmlunit instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5429:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5994:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_io",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-io:9.4.27.v20200227"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.4.27.v20200227/jetty-io-9.4.27.v20200227.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.4.27.v20200227/jetty-io-9.4.27.v20200227-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_util"],
+)
+# Rule org_eclipse_jetty_jetty_io instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5994:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4551:11
+jvm_import(
+  name = "io_netty_netty_codec_socks",
+  tags = ["maven_coordinates=io.netty:netty-codec-socks:4.1.72.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.72.Final/netty-codec-socks-4.1.72.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.72.Final/netty-codec-socks-4.1.72.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_codec", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_transport"],
+)
+# Rule io_netty_netty_codec_socks instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4551:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8346:11
+jvm_import(
+  name = "org_typelevel_jawn_parser_2_13",
+  tags = ["maven_coordinates=org.typelevel:jawn-parser_2.13:1.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/jawn-parser_2.13/1.0.0/jawn-parser_2.13-1.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/typelevel/jawn-parser_2.13/1.0.0/jawn-parser_2.13-1.0.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_typelevel_jawn_parser_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8346:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6053:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_servlet",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-servlet:9.4.18.v20190429"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlet/9.4.18.v20190429/jetty-servlet-9.4.18.v20190429.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlet/9.4.18.v20190429/jetty-servlet-9.4.18.v20190429-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_security"],
+)
+# Rule org_eclipse_jetty_jetty_servlet instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6053:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5171:11
+jvm_import(
+  name = "javax_jms_javax_jms_api",
+  tags = ["maven_coordinates=javax.jms:javax.jms-api:2.0.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/javax/jms/javax.jms-api/2.0.1/javax.jms-api-2.0.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/javax/jms/javax.jms-api/2.0.1/javax.jms-api-2.0.1-sources.jar",
+  deps = [],
+)
+# Rule javax_jms_javax_jms_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5171:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3027:11
+jvm_import(
+  name = "com_tdunning_t_digest",
+  tags = ["maven_coordinates=com.tdunning:t-digest:3.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/tdunning/t-digest/3.1/t-digest-3.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/tdunning/t-digest/3.1/t-digest-3.1-sources.jar",
+  deps = [],
+)
+# Rule com_tdunning_t_digest instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3027:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7991:11
+jvm_import(
+  name = "org_simpleflatmapper_sfm_util",
+  tags = ["maven_coordinates=org.simpleflatmapper:sfm-util:8.2.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/simpleflatmapper/sfm-util/8.2.3/sfm-util-8.2.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/simpleflatmapper/sfm-util/8.2.3/sfm-util-8.2.3-sources.jar",
+  deps = [],
+)
+# Rule org_simpleflatmapper_sfm_util instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7991:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7706:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_chrome_driver",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-chrome-driver:3.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-chrome-driver/3.12.0/selenium-chrome-driver-3.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-chrome-driver/3.12.0/selenium-chrome-driver-3.12.0-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:commons_logging_commons_logging", "@maven//:org_seleniumhq_selenium_selenium_remote_driver", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:commons_codec_commons_codec", "@maven//:org_apache_httpcomponents_httpcore", "@maven//:org_apache_httpcomponents_httpclient", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:com_google_code_gson_gson", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_chrome_driver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7706:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5189:11
+jvm_import(
+  name = "javax_servlet_javax_servlet_api",
+  tags = ["maven_coordinates=javax.servlet:javax.servlet-api:3.1.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0-sources.jar",
+  deps = [],
+)
+# Rule javax_servlet_javax_servlet_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5189:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8442:11
+jvm_import(
+  name = "org_unbescape_unbescape",
+  tags = ["maven_coordinates=org.unbescape:unbescape:1.1.6.RELEASE"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/unbescape/unbescape/1.1.6.RELEASE/unbescape-1.1.6.RELEASE.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/unbescape/unbescape/1.1.6.RELEASE/unbescape-1.1.6.RELEASE-sources.jar",
+  deps = [],
+)
+# Rule org_unbescape_unbescape instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8442:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7863:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_opera_driver",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-opera-driver:3.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-opera-driver/3.12.0/selenium-opera-driver-3.12.0-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:commons_logging_commons_logging", "@maven//:org_seleniumhq_selenium_selenium_remote_driver", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:commons_codec_commons_codec", "@maven//:org_apache_httpcomponents_httpcore", "@maven//:org_apache_httpcomponents_httpclient", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:com_google_code_gson_gson", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_opera_driver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7863:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5569:11
+jvm_import(
+  name = "org_apache_httpcomponents_httpclient",
+  tags = ["maven_coordinates=org.apache.httpcomponents:httpclient:4.5.12"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.12/httpclient-4.5.12.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.12/httpclient-4.5.12-sources.jar",
+  deps = ["@maven//:commons_codec_commons_codec", "@maven//:commons_logging_commons_logging", "@maven//:org_apache_httpcomponents_httpcore"],
+)
+# Rule org_apache_httpcomponents_httpclient instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5569:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7736:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_edge_driver",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-edge-driver:3.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-edge-driver/3.12.0/selenium-edge-driver-3.12.0-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:commons_logging_commons_logging", "@maven//:org_seleniumhq_selenium_selenium_remote_driver", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:commons_codec_commons_codec", "@maven//:org_apache_httpcomponents_httpcore", "@maven//:org_apache_httpcomponents_httpclient", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:com_google_code_gson_gson", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_edge_driver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7736:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5590:11
+jvm_import(
+  name = "org_apache_httpcomponents_httpcore",
+  tags = ["maven_coordinates=org.apache.httpcomponents:httpcore:4.4.13"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13-sources.jar",
+  deps = [],
+)
+# Rule org_apache_httpcomponents_httpcore instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5590:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4761:11
+jvm_import(
+  name = "io_netty_netty_transport_native_unix_common",
+  tags = ["maven_coordinates=io.netty:netty-transport-native-unix-common:4.1.58.Final"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.58.Final/netty-transport-native-unix-common-4.1.58.Final.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.58.Final/netty-transport-native-unix-common-4.1.58.Final-sources.jar",
+  deps = ["@maven//:io_netty_netty_buffer", "@maven//:io_netty_netty_common", "@maven//:io_netty_netty_transport"],
+)
+# Rule io_netty_netty_transport_native_unix_common instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:4761:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5317:11
+jvm_import(
+  name = "net_debasishg_redisclient_2_13",
+  tags = ["maven_coordinates=net.debasishg:redisclient_2.13:3.30"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/debasishg/redisclient_2.13/3.30/redisclient_2.13-3.30.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/debasishg/redisclient_2.13/3.30/redisclient_2.13-3.30-sources.jar",
+  deps = ["@maven//:org_apache_commons_commons_pool2", "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_slf4j_slf4j_api"],
+)
+# Rule net_debasishg_redisclient_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5317:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7947:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_support",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-support:3.141.59"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.141.59/selenium-support-3.141.59.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.141.59/selenium-support-3.141.59-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:org_seleniumhq_selenium_selenium_remote_driver", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_support instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7947:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3573:11
+jvm_import(
+  name = "commons_logging_commons_logging",
+  tags = ["maven_coordinates=commons-logging:commons-logging:1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar",
+  deps = [],
+)
+# Rule commons_logging_commons_logging instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3573:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6110:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_xml",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-xml:9.4.27.v20200227"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-xml/9.4.27.v20200227/jetty-xml-9.4.27.v20200227.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-xml/9.4.27.v20200227/jetty-xml-9.4.27.v20200227-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_util"],
+)
+# Rule org_eclipse_jetty_jetty_xml instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6110:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7648:11
+jvm_import(
+  name = "org_scodec_scodec_bits_2_13",
+  tags = ["maven_coordinates=org.scodec:scodec-bits_2.13:1.1.27"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scodec/scodec-bits_2.13/1.1.27/scodec-bits_2.13-1.1.27.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scodec/scodec-bits_2.13/1.1.27/scodec-bits_2.13-1.1.27-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scodec_scodec_bits_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7648:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7796:11
+jvm_import(
+  name = "org_seleniumhq_selenium_selenium_ie_driver",
+  tags = ["maven_coordinates=org.seleniumhq.selenium:selenium-ie-driver:3.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-ie-driver/3.12.0/selenium-ie-driver-3.12.0-sources.jar",
+  deps = ["@maven//:com_squareup_okio_okio", "@maven//:commons_logging_commons_logging", "@maven//:org_seleniumhq_selenium_selenium_remote_driver", "@maven//:org_seleniumhq_selenium_selenium_api", "@maven//:commons_codec_commons_codec", "@maven//:org_apache_httpcomponents_httpcore", "@maven//:org_apache_httpcomponents_httpclient", "@maven//:net_bytebuddy_byte_buddy", "@maven//:com_squareup_okhttp3_okhttp", "@maven//:com_google_code_gson_gson", "@maven//:com_google_guava_guava", "@maven//:org_apache_commons_commons_exec"],
+)
+# Rule org_seleniumhq_selenium_selenium_ie_driver instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7796:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5849:11
+jvm_import(
+  name = "org_eclipse_jetty_websocket_websocket_api",
+  tags = ["maven_coordinates=org.eclipse.jetty.websocket:websocket-api:9.4.27.v20200227"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-api/9.4.27.v20200227/websocket-api-9.4.27.v20200227.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-api/9.4.27.v20200227/websocket-api-9.4.27.v20200227-sources.jar",
+  deps = [],
+)
+# Rule org_eclipse_jetty_websocket_websocket_api instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5849:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7584:11
+jvm_import(
+  name = "org_scalaz_scalaz_effect_2_13",
+  tags = ["maven_coordinates=org.scalaz:scalaz-effect_2.13:7.2.33"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-effect_2.13/7.2.33/scalaz-effect_2.13-7.2.33.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scalaz/scalaz-effect_2.13/7.2.33/scalaz-effect_2.13-7.2.33-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library", "@maven//:org_scalaz_scalaz_core_2_13"],
+)
+# Rule org_scalaz_scalaz_effect_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:7584:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6331:11
+jvm_import(
+  name = "org_jodd_jodd_util",
+  tags = ["maven_coordinates=org.jodd:jodd-util:6.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/jodd/jodd-util/6.0.0/jodd-util-6.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/jodd/jodd-util/6.0.0/jodd-util-6.0.0-sources.jar",
+  deps = [],
+)
+# Rule org_jodd_jodd_util instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6331:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2116:11
+jvm_import(
+  name = "com_eatthepath_fast_uuid",
+  tags = ["maven_coordinates=com.eatthepath:fast-uuid:0.1"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/eatthepath/fast-uuid/0.1/fast-uuid-0.1.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/eatthepath/fast-uuid/0.1/fast-uuid-0.1-sources.jar",
+  deps = [],
+)
+# Rule com_eatthepath_fast_uuid instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2116:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5974:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_http",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-http:9.4.27.v20200227"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.27.v20200227/jetty-http-9.4.27.v20200227.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/9.4.27.v20200227/jetty-http-9.4.27.v20200227-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_io", "@maven//:org_eclipse_jetty_jetty_util"],
+)
+# Rule org_eclipse_jetty_jetty_http instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5974:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2190:11
+jvm_import(
+  name = "com_fasterxml_jackson_module_jackson_module_paranamer",
+  tags = ["maven_coordinates=com.fasterxml.jackson.module:jackson-module-paranamer:2.9.9"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/2.9.9/jackson-module-paranamer-2.9.9.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/2.9.9/jackson-module-paranamer-2.9.9-sources.jar",
+  deps = ["@maven//:com_fasterxml_jackson_core_jackson_databind", "@maven//:com_thoughtworks_paranamer_paranamer"],
+)
+# Rule com_fasterxml_jackson_module_jackson_module_paranamer instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:2190:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5134:11
+jvm_import(
+  name = "io_suzaku_boopickle_2_13",
+  tags = ["maven_coordinates=io.suzaku:boopickle_2.13:1.3.3"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/io/suzaku/boopickle_2.13/1.3.3/boopickle_2.13-1.3.3.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/io/suzaku/boopickle_2.13/1.3.3/boopickle_2.13-1.3.3-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule io_suzaku_boopickle_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5134:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6987:11
+jvm_import(
+  name = "org_scala_lang_modules_scala_swing_2_13",
+  tags = ["maven_coordinates=org.scala-lang.modules:scala-swing_2.13:3.0.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-swing_2.13/3.0.0/scala-swing_2.13-3.0.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-swing_2.13/3.0.0/scala-swing_2.13-3.0.0-sources.jar",
+  deps = ["@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"],
+)
+# Rule org_scala_lang_modules_scala_swing_2_13 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6987:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5954:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_client",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-client:9.4.27.v20200227"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/9.4.27.v20200227/jetty-client-9.4.27.v20200227.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/9.4.27.v20200227/jetty-client-9.4.27.v20200227-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_http", "@maven//:org_eclipse_jetty_jetty_io"],
+)
+# Rule org_eclipse_jetty_jetty_client instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5954:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5740:11
+jvm_import(
+  name = "org_brotli_dec",
+  tags = ["maven_coordinates=org.brotli:dec:0.1.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/brotli/dec/0.1.2/dec-0.1.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/brotli/dec/0.1.2/dec-0.1.2-sources.jar",
+  deps = [],
+)
+# Rule org_brotli_dec instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5740:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8552:11
+jvm_import(
+  name = "xalan_xalan",
+  tags = ["maven_coordinates=xalan:xalan:2.7.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/xalan/xalan/2.7.2/xalan-2.7.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/xalan/xalan/2.7.2/xalan-2.7.2-sources.jar",
+  deps = ["@maven//:xalan_serializer"],
+)
+# Rule xalan_xalan instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8552:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5393:11
+jvm_import(
+  name = "net_sourceforge_htmlunit_htmlunit_core_js",
+  tags = ["maven_coordinates=net.sourceforge.htmlunit:htmlunit-core-js:2.39.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/sourceforge/htmlunit/htmlunit-core-js/2.39.0/htmlunit-core-js-2.39.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/sourceforge/htmlunit/htmlunit-core-js/2.39.0/htmlunit-core-js-2.39.0-sources.jar",
+  deps = [],
+)
+# Rule net_sourceforge_htmlunit_htmlunit_core_js instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5393:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5532:11
+jvm_import(
+  name = "org_apache_commons_commons_pool2",
+  tags = ["maven_coordinates=org.apache.commons:commons-pool2:2.8.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-pool2/2.8.0/commons-pool2-2.8.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apache/commons/commons-pool2/2.8.0/commons-pool2-2.8.0-sources.jar",
+  deps = [],
+)
+# Rule org_apache_commons_commons_pool2 instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5532:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3591:11
+jvm_import(
+  name = "commons_net_commons_net",
+  tags = ["maven_coordinates=commons-net:commons-net:3.6"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/commons-net/commons-net/3.6/commons-net-3.6.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/commons-net/commons-net/3.6/commons-net-3.6-sources.jar",
+  deps = [],
+)
+# Rule commons_net_commons_net instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3591:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6013:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_security",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-security:9.4.18.v20190429"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-security/9.4.18.v20190429/jetty-security-9.4.18.v20190429.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-security/9.4.18.v20190429/jetty-security-9.4.18.v20190429-sources.jar",
+  deps = ["@maven//:org_eclipse_jetty_jetty_server"],
+)
+# Rule org_eclipse_jetty_jetty_security instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6013:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3172:11
+jvm_import(
+  name = "com_thoughtworks_paranamer_paranamer",
+  tags = ["maven_coordinates=com.thoughtworks.paranamer:paranamer:2.8"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8-sources.jar",
+  deps = [],
+)
+# Rule com_thoughtworks_paranamer_paranamer instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:3172:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5459:11
+jvm_import(
+  name = "net_sourceforge_htmlunit_neko_htmlunit",
+  tags = ["maven_coordinates=net.sourceforge.htmlunit:neko-htmlunit:2.39.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/sourceforge/htmlunit/neko-htmlunit/2.39.0/neko-htmlunit-2.39.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/sourceforge/htmlunit/neko-htmlunit/2.39.0/neko-htmlunit-2.39.0-sources.jar",
+  deps = ["@maven//:xerces_xercesImpl"],
+)
+# Rule net_sourceforge_htmlunit_neko_htmlunit instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5459:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6072:11
+jvm_import(
+  name = "org_eclipse_jetty_jetty_util",
+  tags = ["maven_coordinates=org.eclipse.jetty:jetty-util:9.4.27.v20200227"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.27.v20200227/jetty-util-9.4.27.v20200227.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.27.v20200227/jetty-util-9.4.27.v20200227-sources.jar",
+  deps = [],
+)
+# Rule org_eclipse_jetty_jetty_util instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:6072:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5411:11
+jvm_import(
+  name = "net_sourceforge_htmlunit_htmlunit_cssparser",
+  tags = ["maven_coordinates=net.sourceforge.htmlunit:htmlunit-cssparser:1.5.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/net/sourceforge/htmlunit/htmlunit-cssparser/1.5.0/htmlunit-cssparser-1.5.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/net/sourceforge/htmlunit/htmlunit-cssparser/1.5.0/htmlunit-cssparser-1.5.0-sources.jar",
+  deps = [],
+)
+# Rule net_sourceforge_htmlunit_htmlunit_cssparser instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5411:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5608:11
+jvm_import(
+  name = "org_apache_httpcomponents_httpmime",
+  tags = ["maven_coordinates=org.apache.httpcomponents:httpmime:4.5.12"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpmime/4.5.12/httpmime-4.5.12.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/org/apache/httpcomponents/httpmime/4.5.12/httpmime-4.5.12-sources.jar",
+  deps = ["@maven//:org_apache_httpcomponents_httpclient"],
+)
+# Rule org_apache_httpcomponents_httpmime instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:5608:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8534:11
+jvm_import(
+  name = "xalan_serializer",
+  tags = ["maven_coordinates=xalan:serializer:2.7.2"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/xalan/serializer/2.7.2/serializer-2.7.2.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/xalan/serializer/2.7.2/serializer-2.7.2-sources.jar",
+  deps = [],
+)
+# Rule xalan_serializer instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8534:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8571:11
+jvm_import(
+  name = "xerces_xercesImpl",
+  tags = ["maven_coordinates=xerces:xercesImpl:2.12.0"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/xerces/xercesImpl/2.12.0/xercesImpl-2.12.0.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/xerces/xercesImpl/2.12.0/xercesImpl-2.12.0-sources.jar",
+  deps = ["@maven//:xml_apis_xml_apis"],
+)
+# Rule xerces_xercesImpl instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8571:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>
+
+# /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8590:11
+jvm_import(
+  name = "xml_apis_xml_apis",
+  tags = ["maven_coordinates=xml-apis:xml-apis:1.4.01"],
+  jars = ["@maven//:v1/https/repo1.maven.org/maven2/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01.jar"],
+  srcjar = "@maven//:v1/https/repo1.maven.org/maven2/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01-sources.jar",
+  deps = [],
+)
+# Rule xml_apis_xml_apis instantiated at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/maven/BUILD:8590:11 in <toplevel>
+# Rule jvm_import defined at (most recent call last):
+#   /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/rules_jvm_external/private/rules/jvm_import.bzl:68:18 in <toplevel>

--- a/src/test/resources/battery/bazel/maven-install-complex/bdio/tests_integration_ArtifactExclusionsTest_Default_Detect_Version_bazel_maven_install_complex_bazel_bom.jsonld
+++ b/src/test/resources/battery/bazel/maven-install-complex/bdio/tests_integration_ArtifactExclusionsTest_Default_Detect_Version_bazel_maven_install_complex_bazel_bom.jsonld
@@ -1,0 +1,8124 @@
+[
+  {
+    "specVersion": "1.1.0",
+    "spdx:name": "tests_integration_ArtifactExclusionsTest/Default Detect Version/bazel-maven-install-complex bazel/bom",
+    "creationInfo": {
+      "spdx:creator": [
+        "Tool: Detect-7.13.0-SNAPSHOT",
+        "Tool: IntegrationBdio-22.1.9"
+      ],
+      "spdx:created": "2022-03-11T20:23:36.720302Z"
+    },
+    "@id": "uuid:4f723080-d96c-4f56-ace5-49279421d63b",
+    "@type": "BillOfMaterials",
+    "relationship": []
+  },
+  {
+    "name": "tests_integration_ArtifactExclusionsTest",
+    "revision": "Default Detect Version",
+    "@id": "http:detect/bazel-maven-install-complex",
+    "@type": "Project",
+    "externalIdentifier": {
+      "externalSystemTypeId": "detect",
+      "externalId": "bazel-maven-install-complex",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "detect",
+          "separator": "/"
+        },
+        "pieces": [
+          "bazel-maven-install-complex",
+          null
+        ]
+      }
+    },
+    "relationship": [
+      {
+        "related": "http:maven/org.awaitility/awaitility/3.1.6",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.playframework.anorm/anorm-tokenizer_2.13/2.6.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/cats-kernel_2.13/2.6.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-common/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/co.fs2/fs2-core_2.13/2.5.6",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.opentelemetry/opentelemetry-sdk-common/1.1.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-resolver/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/simulacrum-scalafix-annotations_2.13/0.5.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.code.gson/gson/2.8.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scala-lang.modules/scala-swing_2.13/3.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-support/3.141.59",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-opera-driver/3.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.hamcrest/hamcrest-core/1.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.opentelemetry/opentelemetry-api-metrics/1.1.0-alpha",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-slf4j_2.13/2.6.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apiguardian/apiguardian-api/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.thesamet.scalapb/compilerplugin_2.13/0.11.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.slf4j/slf4j-api/1.7.26",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/commons-codec/commons-codec/1.14",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-stream-testkit_2.13/2.6.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.thesamet.scalapb/lenses_2.13/0.11.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/ru.vyarus/generics-resolver/3.0.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-ie-driver/3.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalaz/scalaz-scalacheck-binding_2.13/7.2.33-scalacheck-1.15",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.circe/circe-generic_2.13/0.13.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/commons-logging/commons-logging/1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-parsing_2.13/10.2.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.suzaku/boopickle_2.13/1.3.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.unbescape/unbescape/1.1.6.RELEASE",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/xml-apis/xml-apis/1.4.01",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.burt/jmespath-jackson/0.5.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.grpc/grpc-services/1.44.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling.highcharts/gatling-charts-highcharts/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/spire-macros_2.13/0.17.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-refspec_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty.websocket/websocket-common/9.4.27.v20200227",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.logstash.logback/logstash-logback-encoder/6.6",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.parboiled/parboiled_2.13/2.1.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.grpc/grpc-protobuf-lite/1.44.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-java/3.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-jms/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-app/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-commons-shared-unstable/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.tdunning/t-digest/3.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.yaml/snakeyaml/1.26",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.junit.jupiter/junit-jupiter-engine/5.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.prometheus/simpleclient_httpserver/0.8.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.pebbletemplates/pebble/3.1.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-chrome-driver/3.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.jodd/jodd-lagarto/6.0.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-api/3.141.59",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.sparkjava/spark-core/2.9.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.opentelemetry/opentelemetry-sdk/1.1.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-diagrams_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.jline/jline/3.7.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-flatspec_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-actor-testkit-typed_2.13/2.6.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.storm-enroute/scalameter-core_2.13/0.19",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scala-lang.modules/scala-collection-compat_2.13/2.6.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.beust/jcommander/1.12",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.mockito/mockito-core/3.6.28",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-actor_2.13/2.6.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/fansi_2.13/0.3.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-shouldmatchers_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-buffer/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-transport-native-unix-common/4.1.58.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.thesamet.scalapb/protoc-bridge_2.13/0.9.5",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/xalan/serializer/2.7.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.h2database/h2/2.1.210",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.grpc/grpc-core/1.44.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.prometheus/simpleclient/0.8.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.github.ben-manes.caffeine/caffeine/2.8.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scala-sbt/test-interface/1.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.rabbitmq/amqp-client/5.5.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalaz/scalaz-effect_2.13/7.2.33",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalaz/scalaz-core_2.13/7.2.33",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.circe/circe-numbers_2.13/0.13.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.github.pureconfig/pureconfig-core_2.13/0.14.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.opentelemetry/opentelemetry-context/1.1.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.simpleflatmapper/lightning-csv/8.2.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/commons-net/commons-net/3.6",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-propspec_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalacheck/scalacheck_2.13/1.15.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-handler/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/htmlunit-driver/2.39.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatestplus/scalacheck-1-15_2.13/3.2.9.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/scalatags_2.13/0.9.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.squareup.okio/okio/1.14.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalameta/junit-interface/0.7.26",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.fasterxml.jackson.module/jackson-module-paranamer/2.9.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-client/9.4.27.v20200227",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/cats-kernel-laws_2.13/2.6.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.checkerframework/checker-qual/3.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-recorder/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-codec-socks/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.reflections/reflections/0.9.12",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-http-client/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/upickle-core_2.13/1.2.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.chuusai/shapeless_2.13/2.3.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.storm-enroute/scalameter_2.13/0.19",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatestplus/selenium-3-141_2.13/3.2.9.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.junit.platform/junit-platform-engine/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.prometheus/simpleclient_common/0.8.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.bytebuddy/byte-buddy/1.10.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.opentelemetry/opentelemetry-semconv/1.1.0-alpha",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.circe/circe-parser_2.13/0.13.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.objenesis/objenesis/3.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.simpleflatmapper/sfm-util/8.2.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.perfmark/perfmark-api/0.23.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apache.commons/commons-pool2/2.8.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.dropwizard.metrics/metrics-jvm/4.1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.sangria-graphql/sangria-streaming-api_2.13/1.0.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.junit.platform/junit-platform-suite-api/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-graphite/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.dropwizard.metrics/metrics-jmx/4.1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.hamcrest/hamcrest-library/1.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-charts/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.checkerframework/checker/2.5.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.tpolecat/doobie-postgres_2.13/0.13.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-compatible/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-security/9.4.18.v20190429",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty.websocket/websocket-servlet/9.4.18.v20190429",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-codec-http2/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-tcnative-classes/2.0.46.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.sourceforge.htmlunit/htmlunit-core-js/2.39.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty.websocket/websocket-server/9.4.18.v20190429",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-webapp/9.4.18.v20190429",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apache.commons/commons-math3/3.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/kind-projector_2.13.8/0.13.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.grpc/grpc-stub/1.44.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-netty-util/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-edge-driver/3.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/discipline-core_2.13/1.1.5",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.codehaus.mojo/animal-sniffer-annotations/1.19",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.guava/failureaccess/1.0.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatestplus/testng-6-7_2.13/3.2.9.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/ch.qos.logback/logback-core/1.2.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.javassist/javassist/3.26.0-GA",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-http-core_2.13/10.2.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-codec-dns/4.1.58.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/ch.qos.logback/logback-classic/1.2.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apache.commons/commons-text/1.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.squareup/javapoet/1.11.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.tpolecat/doobie-hikari_2.13/0.13.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.testng/testng/6.7",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.squareup.okhttp3/okhttp/3.11.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.sourceforge.htmlunit/htmlunit/2.39.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.code.findbugs/jsr305/3.0.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalaz/scalaz-concurrent_2.13/7.2.33",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe/ssl-config-core_2.13/0.4.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/fastparse_2.13/2.3.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.thesamet.scalapb/protoc-gen_2.13/0.9.5",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.bytebuddy/byte-buddy-agent/1.10.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.j2objc/j2objc-annotations/1.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.prometheus/simpleclient_dropwizard/0.8.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.spray/spray-json_2.13/1.3.5",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-funsuite_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.sourceforge.htmlunit/neko-htmlunit/2.39.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.junit.platform/junit-platform-runner/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.bouncycastle/bcpkix-jdk15on/1.70",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-http-spray-json_2.13/10.2.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.softwaremill.quicklens/quicklens_2.13/1.6.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/dev.dirs/directories/26",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.xerial/sqlite-jdbc/3.36.0.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.guava/guava/31.0.1-jre",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/eu.rekawek.toxiproxy/toxiproxy-java/2.1.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/paiges-core_2.13/0.3.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.circe/circe-core_2.13/0.13.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/pprint_2.13/0.7.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/ujson_2.13/1.2.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.opentelemetry/opentelemetry-api/1.1.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-commons/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.bouncycastle/bcutil-jdk15on/1.70",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.bouncycastle/bcprov-jdk15on/1.70",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scala-lang.modules/scala-xml_2.13/1.3.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/cats-laws_2.13/2.6.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-handler-proxy/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.protobuf/protobuf-java-util/3.19.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-codec/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.jodd/jodd-util/6.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.mockito/mockito-scala_2.13/1.16.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/javax.jms/javax.jms-api/2.0.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.grpc/grpc-protobuf/1.44.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-actor-typed_2.13/2.6.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.android/annotations/4.1.1.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.scala-logging/scala-logging_2.13/3.9.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/joda-time/joda-time/2.10.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-featurespec_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-http_2.13/10.2.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.junit.platform/junit-platform-commons/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-wordspec_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-firefox-driver/3.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.fasterxml.jackson.core/jackson-databind/2.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.grpc/grpc-context/1.44.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.brotli/dec/0.1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.hdrhistogram/HdrHistogram/2.1.12",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.grpc/grpc-netty/1.44.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apache.commons/commons-lang3/3.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.flywaydb/flyway-core/8.4.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-safari-driver/3.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.reactivestreams/reactive-streams-tck/1.0.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.dropwizard.metrics/metrics-core/4.1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.auth0/jwks-rsa/0.11.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty.websocket/websocket-api/9.4.27.v20200227",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.codehaus.janino/commons-compiler/3.1.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-core_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.errorprone/error_prone_annotations/2.9.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.tpolecat/doobie-free_2.13/0.13.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/cats-free_2.13/2.6.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-funspec_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.sf.saxon/Saxon-HE/10.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/cats-core_2.13/2.6.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-testkit_2.13/2.6.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.github.pureconfig/pureconfig-macros_2.13/0.14.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-http/9.4.27.v20200227",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/co.fs2/fs2-io_2.13/2.5.6",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.fasterxml.jackson.core/jackson-annotations/2.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.joda/joda-convert/2.2.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/jawn-parser_2.13/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalameta/munit_2.13/0.7.26",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.burt/jmespath-core/0.5.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.wartremover/wartremover_2.13.8/2.4.16",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.circe/circe-jawn_2.13/0.13.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.debasishg/redisclient_2.13/3.30",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-resolver-dns/4.1.58.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.protobuf/protobuf-java/3.19.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.github.pureconfig/pureconfig-generic-base_2.13/0.14.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.google.api.grpc/proto-google-common-protos/2.0.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.sangria-graphql/sangria-marshalling-api_2.13/1.0.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.github.pureconfig/pureconfig-generic_2.13/0.14.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-server/9.4.18.v20190429",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/xerces/xercesImpl/2.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.junit.jupiter/junit-jupiter-api/5.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.reactivestreams/reactive-streams-examples/1.0.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/javax.annotation/javax.annotation-api/1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-http/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apache.httpcomponents/httpclient/4.5.12",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.ow2.asm/asm/5.0.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-util/9.4.27.v20200227",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.beanshell/bsh/2.0b4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/commons-io/commons-io/2.5",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.9.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apache.commons/commons-exec/1.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalactic/scalactic_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.codehaus.janino/janino/3.1.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.reactivex.rxjava2/rxjava/2.2.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.sangria-graphql/macro-visit_2.13/0.1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/sourcecode_2.13/0.2.7",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-servlet/9.4.18.v20190429",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.junit.platform/junit-platform-launcher/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-xml/9.4.27.v20200227",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.postgresql/postgresql/42.2.25",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.sangria-graphql/sangria_2.13/2.0.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalaz/scalaz-iteratee_2.13/7.2.33",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/sjsonnet_2.13/0.3.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-codec-http/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.dropwizard.metrics/metrics-graphite/4.1.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-http-testkit_2.13/10.2.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-jsonpath/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-core/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.zaxxer/HikariCP/3.2.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.tukaani/xz/1.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/os-lib_2.13/0.7.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/xalan/xalan/2.7.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apache.httpcomponents/httpcore/4.4.13",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.circe/circe-yaml_2.13/0.13.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-tcnative-boringssl-static/2.0.46.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-transport-native-epoll/4.1.58.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.github.paoloboni/spray-json-derived-codecs_2.13/2.3.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.typelevel/cats-effect_2.13/2.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.tpolecat/doobie-core_2.13/0.13.4",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-freespec_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe/config/1.4.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.auth0/java-jwt/3.10.3",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-mustmatchers_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.tpolecat/typename_2.13/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.opentelemetry/opentelemetry-sdk-trace/1.1.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.opentest4j/opentest4j/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.github.scopt/scopt_2.13/4.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.reactivestreams/reactive-streams/1.0.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scalatest/scalatest-matchers-core_2.13/3.2.9",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-redis/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty/jetty-io/9.4.27.v20200227",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/net.sourceforge.htmlunit/htmlunit-cssparser/1.5.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.netty/netty-transport/4.1.72.Final",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/junit/junit/4.12",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.eclipse.jetty.websocket/websocket-client/9.4.27.v20200227",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.playframework.anorm/anorm_2.13/2.6.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/javax.servlet/javax.servlet-api/3.1.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.typesafe.akka/akka-stream_2.13/2.6.18",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.seleniumhq.selenium/selenium-remote-driver/3.141.59",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.eatthepath/fast-uuid/0.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.fasterxml.jackson.core/jackson-core/2.12.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scala-lang.modules/scala-java8-compat_2.13/1.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.apache.httpcomponents/httpmime/4.5.12",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.grpc/grpc-api/1.44.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.lihaoyi/geny_2.13/0.6.2",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-jdbc/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.thesamet.scalapb/scalapb-runtime-grpc_2.13/0.11.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.gatling/gatling-commons-shared/3.5.1",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.oracle.database.jdbc/ojdbc8/19.8.0.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/io.opentelemetry/opentelemetry-sdk-testing/1.1.0",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/com.thoughtworks.paranamer/paranamer/2.8",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.scodec/scodec-bits_2.13/1.1.27",
+        "relationshipType": "DYNAMIC_LINK"
+      },
+      {
+        "related": "http:maven/org.pcollections/pcollections/2.1.3",
+        "relationshipType": "DYNAMIC_LINK"
+      }
+    ]
+  },
+  {
+    "name": "awaitility",
+    "revision": "3.1.6",
+    "@id": "http:maven/org.awaitility/awaitility/3.1.6",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.awaitility:awaitility:3.1.6",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "awaitility",
+          "3.1.6"
+        ],
+        "prefix": "org.awaitility"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "anorm-tokenizer_2.13",
+    "revision": "2.6.8",
+    "@id": "http:maven/org.playframework.anorm/anorm-tokenizer_2.13/2.6.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.playframework.anorm:anorm-tokenizer_2.13:2.6.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "anorm-tokenizer_2.13",
+          "2.6.8"
+        ],
+        "prefix": "org.playframework.anorm"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "cats-kernel_2.13",
+    "revision": "2.6.1",
+    "@id": "http:maven/org.typelevel/cats-kernel_2.13/2.6.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:cats-kernel_2.13:2.6.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "cats-kernel_2.13",
+          "2.6.1"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-common",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-common/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-common:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-common",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "fs2-core_2.13",
+    "revision": "2.5.6",
+    "@id": "http:maven/co.fs2/fs2-core_2.13/2.5.6",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "co.fs2:fs2-core_2.13:2.5.6",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "fs2-core_2.13",
+          "2.5.6"
+        ],
+        "prefix": "co.fs2"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentelemetry-sdk-common",
+    "revision": "1.1.0",
+    "@id": "http:maven/io.opentelemetry/opentelemetry-sdk-common/1.1.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.opentelemetry:opentelemetry-sdk-common:1.1.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentelemetry-sdk-common",
+          "1.1.0"
+        ],
+        "prefix": "io.opentelemetry"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-resolver",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-resolver/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-resolver:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-resolver",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "simulacrum-scalafix-annotations_2.13",
+    "revision": "0.5.4",
+    "@id": "http:maven/org.typelevel/simulacrum-scalafix-annotations_2.13/0.5.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:simulacrum-scalafix-annotations_2.13:0.5.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "simulacrum-scalafix-annotations_2.13",
+          "0.5.4"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gson",
+    "revision": "2.8.2",
+    "@id": "http:maven/com.google.code.gson/gson/2.8.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.code.gson:gson:2.8.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gson",
+          "2.8.2"
+        ],
+        "prefix": "com.google.code.gson"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scala-swing_2.13",
+    "revision": "3.0.0",
+    "@id": "http:maven/org.scala-lang.modules/scala-swing_2.13/3.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scala-lang.modules:scala-swing_2.13:3.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scala-swing_2.13",
+          "3.0.0"
+        ],
+        "prefix": "org.scala-lang.modules"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-support",
+    "revision": "3.141.59",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-support/3.141.59",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-support:3.141.59",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-support",
+          "3.141.59"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-opera-driver",
+    "revision": "3.12.0",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-opera-driver/3.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-opera-driver:3.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-opera-driver",
+          "3.12.0"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "hamcrest-core",
+    "revision": "1.3",
+    "@id": "http:maven/org.hamcrest/hamcrest-core/1.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.hamcrest:hamcrest-core:1.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "hamcrest-core",
+          "1.3"
+        ],
+        "prefix": "org.hamcrest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentelemetry-api-metrics",
+    "revision": "1.1.0-alpha",
+    "@id": "http:maven/io.opentelemetry/opentelemetry-api-metrics/1.1.0-alpha",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.opentelemetry:opentelemetry-api-metrics:1.1.0-alpha",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentelemetry-api-metrics",
+          "1.1.0-alpha"
+        ],
+        "prefix": "io.opentelemetry"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-slf4j_2.13",
+    "revision": "2.6.18",
+    "@id": "http:maven/com.typesafe.akka/akka-slf4j_2.13/2.6.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-slf4j_2.13:2.6.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-slf4j_2.13",
+          "2.6.18"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "apiguardian-api",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.apiguardian/apiguardian-api/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apiguardian:apiguardian-api:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "apiguardian-api",
+          "1.0.0"
+        ],
+        "prefix": "org.apiguardian"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "compilerplugin_2.13",
+    "revision": "0.11.8",
+    "@id": "http:maven/com.thesamet.scalapb/compilerplugin_2.13/0.11.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.thesamet.scalapb:compilerplugin_2.13:0.11.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "compilerplugin_2.13",
+          "0.11.8"
+        ],
+        "prefix": "com.thesamet.scalapb"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "slf4j-api",
+    "revision": "1.7.26",
+    "@id": "http:maven/org.slf4j/slf4j-api/1.7.26",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.slf4j:slf4j-api:1.7.26",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "slf4j-api",
+          "1.7.26"
+        ],
+        "prefix": "org.slf4j"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-codec",
+    "revision": "1.14",
+    "@id": "http:maven/commons-codec/commons-codec/1.14",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "commons-codec:commons-codec:1.14",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-codec",
+          "1.14"
+        ],
+        "prefix": "commons-codec"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-stream-testkit_2.13",
+    "revision": "2.6.18",
+    "@id": "http:maven/com.typesafe.akka/akka-stream-testkit_2.13/2.6.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-stream-testkit_2.13:2.6.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-stream-testkit_2.13",
+          "2.6.18"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "lenses_2.13",
+    "revision": "0.11.8",
+    "@id": "http:maven/com.thesamet.scalapb/lenses_2.13/0.11.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.thesamet.scalapb:lenses_2.13:0.11.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "lenses_2.13",
+          "0.11.8"
+        ],
+        "prefix": "com.thesamet.scalapb"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "generics-resolver",
+    "revision": "3.0.3",
+    "@id": "http:maven/ru.vyarus/generics-resolver/3.0.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "ru.vyarus:generics-resolver:3.0.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "generics-resolver",
+          "3.0.3"
+        ],
+        "prefix": "ru.vyarus"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-ie-driver",
+    "revision": "3.12.0",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-ie-driver/3.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-ie-driver:3.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-ie-driver",
+          "3.12.0"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalaz-scalacheck-binding_2.13",
+    "revision": "7.2.33-scalacheck-1.15",
+    "@id": "http:maven/org.scalaz/scalaz-scalacheck-binding_2.13/7.2.33-scalacheck-1.15",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalaz:scalaz-scalacheck-binding_2.13:7.2.33-scalacheck-1.15",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalaz-scalacheck-binding_2.13",
+          "7.2.33-scalacheck-1.15"
+        ],
+        "prefix": "org.scalaz"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "circe-generic_2.13",
+    "revision": "0.13.0",
+    "@id": "http:maven/io.circe/circe-generic_2.13/0.13.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.circe:circe-generic_2.13:0.13.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "circe-generic_2.13",
+          "0.13.0"
+        ],
+        "prefix": "io.circe"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-logging",
+    "revision": "1.2",
+    "@id": "http:maven/commons-logging/commons-logging/1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "commons-logging:commons-logging:1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-logging",
+          "1.2"
+        ],
+        "prefix": "commons-logging"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-parsing_2.13",
+    "revision": "10.2.8",
+    "@id": "http:maven/com.typesafe.akka/akka-parsing_2.13/10.2.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-parsing_2.13:10.2.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-parsing_2.13",
+          "10.2.8"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "boopickle_2.13",
+    "revision": "1.3.3",
+    "@id": "http:maven/io.suzaku/boopickle_2.13/1.3.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.suzaku:boopickle_2.13:1.3.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "boopickle_2.13",
+          "1.3.3"
+        ],
+        "prefix": "io.suzaku"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "unbescape",
+    "revision": "1.1.6.RELEASE",
+    "@id": "http:maven/org.unbescape/unbescape/1.1.6.RELEASE",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.unbescape:unbescape:1.1.6.RELEASE",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "unbescape",
+          "1.1.6.RELEASE"
+        ],
+        "prefix": "org.unbescape"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "xml-apis",
+    "revision": "1.4.01",
+    "@id": "http:maven/xml-apis/xml-apis/1.4.01",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "xml-apis:xml-apis:1.4.01",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "xml-apis",
+          "1.4.01"
+        ],
+        "prefix": "xml-apis"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jmespath-jackson",
+    "revision": "0.5.0",
+    "@id": "http:maven/io.burt/jmespath-jackson/0.5.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.burt:jmespath-jackson:0.5.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jmespath-jackson",
+          "0.5.0"
+        ],
+        "prefix": "io.burt"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "grpc-services",
+    "revision": "1.44.0",
+    "@id": "http:maven/io.grpc/grpc-services/1.44.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.grpc:grpc-services:1.44.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "grpc-services",
+          "1.44.0"
+        ],
+        "prefix": "io.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-charts-highcharts",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling.highcharts/gatling-charts-highcharts/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling.highcharts:gatling-charts-highcharts:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-charts-highcharts",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling.highcharts"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "spire-macros_2.13",
+    "revision": "0.17.0",
+    "@id": "http:maven/org.typelevel/spire-macros_2.13/0.17.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:spire-macros_2.13:0.17.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "spire-macros_2.13",
+          "0.17.0"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-refspec_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-refspec_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-refspec_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-refspec_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "listenablefuture",
+    "revision": "9999.0-empty-to-avoid-conflict-with-guava",
+    "@id": "http:maven/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "listenablefuture",
+          "9999.0-empty-to-avoid-conflict-with-guava"
+        ],
+        "prefix": "com.google.guava"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "websocket-common",
+    "revision": "9.4.27.v20200227",
+    "@id": "http:maven/org.eclipse.jetty.websocket/websocket-common/9.4.27.v20200227",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty.websocket:websocket-common:9.4.27.v20200227",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "websocket-common",
+          "9.4.27.v20200227"
+        ],
+        "prefix": "org.eclipse.jetty.websocket"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "logstash-logback-encoder",
+    "revision": "6.6",
+    "@id": "http:maven/net.logstash.logback/logstash-logback-encoder/6.6",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.logstash.logback:logstash-logback-encoder:6.6",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "logstash-logback-encoder",
+          "6.6"
+        ],
+        "prefix": "net.logstash.logback"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "parboiled_2.13",
+    "revision": "2.1.8",
+    "@id": "http:maven/org.parboiled/parboiled_2.13/2.1.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.parboiled:parboiled_2.13:2.1.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "parboiled_2.13",
+          "2.1.8"
+        ],
+        "prefix": "org.parboiled"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "grpc-protobuf-lite",
+    "revision": "1.44.0",
+    "@id": "http:maven/io.grpc/grpc-protobuf-lite/1.44.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.grpc:grpc-protobuf-lite:1.44.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "grpc-protobuf-lite",
+          "1.44.0"
+        ],
+        "prefix": "io.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-java",
+    "revision": "3.12.0",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-java/3.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-java:3.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-java",
+          "3.12.0"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-jms",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-jms/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-jms:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-jms",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-app",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-app/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-app:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-app",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-commons-shared-unstable",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-commons-shared-unstable/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-commons-shared-unstable:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-commons-shared-unstable",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "t-digest",
+    "revision": "3.1",
+    "@id": "http:maven/com.tdunning/t-digest/3.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.tdunning:t-digest:3.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "t-digest",
+          "3.1"
+        ],
+        "prefix": "com.tdunning"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "snakeyaml",
+    "revision": "1.26",
+    "@id": "http:maven/org.yaml/snakeyaml/1.26",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.yaml:snakeyaml:1.26",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "snakeyaml",
+          "1.26"
+        ],
+        "prefix": "org.yaml"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit-jupiter-engine",
+    "revision": "5.0.0",
+    "@id": "http:maven/org.junit.jupiter/junit-jupiter-engine/5.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.junit.jupiter:junit-jupiter-engine:5.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit-jupiter-engine",
+          "5.0.0"
+        ],
+        "prefix": "org.junit.jupiter"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "simpleclient_httpserver",
+    "revision": "0.8.1",
+    "@id": "http:maven/io.prometheus/simpleclient_httpserver/0.8.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.prometheus:simpleclient_httpserver:0.8.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "simpleclient_httpserver",
+          "0.8.1"
+        ],
+        "prefix": "io.prometheus"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "pebble",
+    "revision": "3.1.4",
+    "@id": "http:maven/io.pebbletemplates/pebble/3.1.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.pebbletemplates:pebble:3.1.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "pebble",
+          "3.1.4"
+        ],
+        "prefix": "io.pebbletemplates"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-chrome-driver",
+    "revision": "3.12.0",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-chrome-driver/3.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-chrome-driver:3.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-chrome-driver",
+          "3.12.0"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jodd-lagarto",
+    "revision": "6.0.3",
+    "@id": "http:maven/org.jodd/jodd-lagarto/6.0.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.jodd:jodd-lagarto:6.0.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jodd-lagarto",
+          "6.0.3"
+        ],
+        "prefix": "org.jodd"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-api",
+    "revision": "3.141.59",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-api/3.141.59",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-api:3.141.59",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-api",
+          "3.141.59"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "spark-core",
+    "revision": "2.9.1",
+    "@id": "http:maven/com.sparkjava/spark-core/2.9.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.sparkjava:spark-core:2.9.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "spark-core",
+          "2.9.1"
+        ],
+        "prefix": "com.sparkjava"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentelemetry-sdk",
+    "revision": "1.1.0",
+    "@id": "http:maven/io.opentelemetry/opentelemetry-sdk/1.1.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.opentelemetry:opentelemetry-sdk:1.1.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentelemetry-sdk",
+          "1.1.0"
+        ],
+        "prefix": "io.opentelemetry"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-diagrams_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-diagrams_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-diagrams_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-diagrams_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jline",
+    "revision": "3.7.1",
+    "@id": "http:maven/org.jline/jline/3.7.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.jline:jline:3.7.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jline",
+          "3.7.1"
+        ],
+        "prefix": "org.jline"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-flatspec_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-flatspec_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-flatspec_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-flatspec_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-actor-testkit-typed_2.13",
+    "revision": "2.6.18",
+    "@id": "http:maven/com.typesafe.akka/akka-actor-testkit-typed_2.13/2.6.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-actor-testkit-typed_2.13:2.6.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-actor-testkit-typed_2.13",
+          "2.6.18"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalameter-core_2.13",
+    "revision": "0.19",
+    "@id": "http:maven/com.storm-enroute/scalameter-core_2.13/0.19",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.storm-enroute:scalameter-core_2.13:0.19",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalameter-core_2.13",
+          "0.19"
+        ],
+        "prefix": "com.storm-enroute"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scala-collection-compat_2.13",
+    "revision": "2.6.0",
+    "@id": "http:maven/org.scala-lang.modules/scala-collection-compat_2.13/2.6.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scala-lang.modules:scala-collection-compat_2.13:2.6.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scala-collection-compat_2.13",
+          "2.6.0"
+        ],
+        "prefix": "org.scala-lang.modules"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jcommander",
+    "revision": "1.12",
+    "@id": "http:maven/com.beust/jcommander/1.12",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.beust:jcommander:1.12",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jcommander",
+          "1.12"
+        ],
+        "prefix": "com.beust"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "mockito-core",
+    "revision": "3.6.28",
+    "@id": "http:maven/org.mockito/mockito-core/3.6.28",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.mockito:mockito-core:3.6.28",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "mockito-core",
+          "3.6.28"
+        ],
+        "prefix": "org.mockito"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-actor_2.13",
+    "revision": "2.6.18",
+    "@id": "http:maven/com.typesafe.akka/akka-actor_2.13/2.6.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-actor_2.13:2.6.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-actor_2.13",
+          "2.6.18"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "fansi_2.13",
+    "revision": "0.3.0",
+    "@id": "http:maven/com.lihaoyi/fansi_2.13/0.3.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:fansi_2.13:0.3.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "fansi_2.13",
+          "0.3.0"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-shouldmatchers_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-shouldmatchers_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-shouldmatchers_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-shouldmatchers_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-buffer",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-buffer/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-buffer:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-buffer",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-transport-native-unix-common",
+    "revision": "4.1.58.Final",
+    "@id": "http:maven/io.netty/netty-transport-native-unix-common/4.1.58.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-transport-native-unix-common:4.1.58.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-transport-native-unix-common",
+          "4.1.58.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "protoc-bridge_2.13",
+    "revision": "0.9.5",
+    "@id": "http:maven/com.thesamet.scalapb/protoc-bridge_2.13/0.9.5",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.5",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "protoc-bridge_2.13",
+          "0.9.5"
+        ],
+        "prefix": "com.thesamet.scalapb"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "serializer",
+    "revision": "2.7.2",
+    "@id": "http:maven/xalan/serializer/2.7.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "xalan:serializer:2.7.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "serializer",
+          "2.7.2"
+        ],
+        "prefix": "xalan"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "h2",
+    "revision": "2.1.210",
+    "@id": "http:maven/com.h2database/h2/2.1.210",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.h2database:h2:2.1.210",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "h2",
+          "2.1.210"
+        ],
+        "prefix": "com.h2database"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "grpc-core",
+    "revision": "1.44.0",
+    "@id": "http:maven/io.grpc/grpc-core/1.44.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.grpc:grpc-core:1.44.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "grpc-core",
+          "1.44.0"
+        ],
+        "prefix": "io.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "simpleclient",
+    "revision": "0.8.1",
+    "@id": "http:maven/io.prometheus/simpleclient/0.8.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.prometheus:simpleclient:0.8.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "simpleclient",
+          "0.8.1"
+        ],
+        "prefix": "io.prometheus"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "caffeine",
+    "revision": "2.8.0",
+    "@id": "http:maven/com.github.ben-manes.caffeine/caffeine/2.8.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.github.ben-manes.caffeine:caffeine:2.8.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "caffeine",
+          "2.8.0"
+        ],
+        "prefix": "com.github.ben-manes.caffeine"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "test-interface",
+    "revision": "1.0",
+    "@id": "http:maven/org.scala-sbt/test-interface/1.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scala-sbt:test-interface:1.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "test-interface",
+          "1.0"
+        ],
+        "prefix": "org.scala-sbt"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "amqp-client",
+    "revision": "5.5.3",
+    "@id": "http:maven/com.rabbitmq/amqp-client/5.5.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.rabbitmq:amqp-client:5.5.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "amqp-client",
+          "5.5.3"
+        ],
+        "prefix": "com.rabbitmq"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalaz-effect_2.13",
+    "revision": "7.2.33",
+    "@id": "http:maven/org.scalaz/scalaz-effect_2.13/7.2.33",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalaz:scalaz-effect_2.13:7.2.33",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalaz-effect_2.13",
+          "7.2.33"
+        ],
+        "prefix": "org.scalaz"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalaz-core_2.13",
+    "revision": "7.2.33",
+    "@id": "http:maven/org.scalaz/scalaz-core_2.13/7.2.33",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalaz:scalaz-core_2.13:7.2.33",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalaz-core_2.13",
+          "7.2.33"
+        ],
+        "prefix": "org.scalaz"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "circe-numbers_2.13",
+    "revision": "0.13.0",
+    "@id": "http:maven/io.circe/circe-numbers_2.13/0.13.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.circe:circe-numbers_2.13:0.13.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "circe-numbers_2.13",
+          "0.13.0"
+        ],
+        "prefix": "io.circe"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "pureconfig-core_2.13",
+    "revision": "0.14.0",
+    "@id": "http:maven/com.github.pureconfig/pureconfig-core_2.13/0.14.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.github.pureconfig:pureconfig-core_2.13:0.14.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "pureconfig-core_2.13",
+          "0.14.0"
+        ],
+        "prefix": "com.github.pureconfig"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentelemetry-context",
+    "revision": "1.1.0",
+    "@id": "http:maven/io.opentelemetry/opentelemetry-context/1.1.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.opentelemetry:opentelemetry-context:1.1.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentelemetry-context",
+          "1.1.0"
+        ],
+        "prefix": "io.opentelemetry"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "lightning-csv",
+    "revision": "8.2.3",
+    "@id": "http:maven/org.simpleflatmapper/lightning-csv/8.2.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.simpleflatmapper:lightning-csv:8.2.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "lightning-csv",
+          "8.2.3"
+        ],
+        "prefix": "org.simpleflatmapper"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-net",
+    "revision": "3.6",
+    "@id": "http:maven/commons-net/commons-net/3.6",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "commons-net:commons-net:3.6",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-net",
+          "3.6"
+        ],
+        "prefix": "commons-net"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-propspec_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-propspec_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-propspec_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-propspec_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalacheck_2.13",
+    "revision": "1.15.4",
+    "@id": "http:maven/org.scalacheck/scalacheck_2.13/1.15.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalacheck:scalacheck_2.13:1.15.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalacheck_2.13",
+          "1.15.4"
+        ],
+        "prefix": "org.scalacheck"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-handler",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-handler/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-handler:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-handler",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "htmlunit-driver",
+    "revision": "2.39.0",
+    "@id": "http:maven/org.seleniumhq.selenium/htmlunit-driver/2.39.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:htmlunit-driver:2.39.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "htmlunit-driver",
+          "2.39.0"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalacheck-1-15_2.13",
+    "revision": "3.2.9.0",
+    "@id": "http:maven/org.scalatestplus/scalacheck-1-15_2.13/3.2.9.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatestplus:scalacheck-1-15_2.13:3.2.9.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalacheck-1-15_2.13",
+          "3.2.9.0"
+        ],
+        "prefix": "org.scalatestplus"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatags_2.13",
+    "revision": "0.9.1",
+    "@id": "http:maven/com.lihaoyi/scalatags_2.13/0.9.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:scalatags_2.13:0.9.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatags_2.13",
+          "0.9.1"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "okio",
+    "revision": "1.14.0",
+    "@id": "http:maven/com.squareup.okio/okio/1.14.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.squareup.okio:okio:1.14.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "okio",
+          "1.14.0"
+        ],
+        "prefix": "com.squareup.okio"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit-interface",
+    "revision": "0.7.26",
+    "@id": "http:maven/org.scalameta/junit-interface/0.7.26",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalameta:junit-interface:0.7.26",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit-interface",
+          "0.7.26"
+        ],
+        "prefix": "org.scalameta"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jackson-module-paranamer",
+    "revision": "2.9.9",
+    "@id": "http:maven/com.fasterxml.jackson.module/jackson-module-paranamer/2.9.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.fasterxml.jackson.module:jackson-module-paranamer:2.9.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jackson-module-paranamer",
+          "2.9.9"
+        ],
+        "prefix": "com.fasterxml.jackson.module"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-client",
+    "revision": "9.4.27.v20200227",
+    "@id": "http:maven/org.eclipse.jetty/jetty-client/9.4.27.v20200227",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-client:9.4.27.v20200227",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-client",
+          "9.4.27.v20200227"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "cats-kernel-laws_2.13",
+    "revision": "2.6.1",
+    "@id": "http:maven/org.typelevel/cats-kernel-laws_2.13/2.6.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:cats-kernel-laws_2.13:2.6.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "cats-kernel-laws_2.13",
+          "2.6.1"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "checker-qual",
+    "revision": "3.12.0",
+    "@id": "http:maven/org.checkerframework/checker-qual/3.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.checkerframework:checker-qual:3.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "checker-qual",
+          "3.12.0"
+        ],
+        "prefix": "org.checkerframework"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-recorder",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-recorder/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-recorder:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-recorder",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-codec-socks",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-codec-socks/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-codec-socks:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-codec-socks",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "reflections",
+    "revision": "0.9.12",
+    "@id": "http:maven/org.reflections/reflections/0.9.12",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.reflections:reflections:0.9.12",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "reflections",
+          "0.9.12"
+        ],
+        "prefix": "org.reflections"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-http-client",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-http-client/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-http-client:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-http-client",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "upickle-core_2.13",
+    "revision": "1.2.0",
+    "@id": "http:maven/com.lihaoyi/upickle-core_2.13/1.2.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:upickle-core_2.13:1.2.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "upickle-core_2.13",
+          "1.2.0"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "shapeless_2.13",
+    "revision": "2.3.3",
+    "@id": "http:maven/com.chuusai/shapeless_2.13/2.3.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.chuusai:shapeless_2.13:2.3.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "shapeless_2.13",
+          "2.3.3"
+        ],
+        "prefix": "com.chuusai"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalameter_2.13",
+    "revision": "0.19",
+    "@id": "http:maven/com.storm-enroute/scalameter_2.13/0.19",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.storm-enroute:scalameter_2.13:0.19",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalameter_2.13",
+          "0.19"
+        ],
+        "prefix": "com.storm-enroute"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-3-141_2.13",
+    "revision": "3.2.9.0",
+    "@id": "http:maven/org.scalatestplus/selenium-3-141_2.13/3.2.9.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatestplus:selenium-3-141_2.13:3.2.9.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-3-141_2.13",
+          "3.2.9.0"
+        ],
+        "prefix": "org.scalatestplus"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit-platform-engine",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.junit.platform/junit-platform-engine/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.junit.platform:junit-platform-engine:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit-platform-engine",
+          "1.0.0"
+        ],
+        "prefix": "org.junit.platform"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "simpleclient_common",
+    "revision": "0.8.1",
+    "@id": "http:maven/io.prometheus/simpleclient_common/0.8.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.prometheus:simpleclient_common:0.8.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "simpleclient_common",
+          "0.8.1"
+        ],
+        "prefix": "io.prometheus"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "byte-buddy",
+    "revision": "1.10.18",
+    "@id": "http:maven/net.bytebuddy/byte-buddy/1.10.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.bytebuddy:byte-buddy:1.10.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "byte-buddy",
+          "1.10.18"
+        ],
+        "prefix": "net.bytebuddy"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentelemetry-semconv",
+    "revision": "1.1.0-alpha",
+    "@id": "http:maven/io.opentelemetry/opentelemetry-semconv/1.1.0-alpha",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.opentelemetry:opentelemetry-semconv:1.1.0-alpha",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentelemetry-semconv",
+          "1.1.0-alpha"
+        ],
+        "prefix": "io.opentelemetry"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "circe-parser_2.13",
+    "revision": "0.13.0",
+    "@id": "http:maven/io.circe/circe-parser_2.13/0.13.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.circe:circe-parser_2.13:0.13.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "circe-parser_2.13",
+          "0.13.0"
+        ],
+        "prefix": "io.circe"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "objenesis",
+    "revision": "3.1",
+    "@id": "http:maven/org.objenesis/objenesis/3.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.objenesis:objenesis:3.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "objenesis",
+          "3.1"
+        ],
+        "prefix": "org.objenesis"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "sfm-util",
+    "revision": "8.2.3",
+    "@id": "http:maven/org.simpleflatmapper/sfm-util/8.2.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.simpleflatmapper:sfm-util:8.2.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "sfm-util",
+          "8.2.3"
+        ],
+        "prefix": "org.simpleflatmapper"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "perfmark-api",
+    "revision": "0.23.0",
+    "@id": "http:maven/io.perfmark/perfmark-api/0.23.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.perfmark:perfmark-api:0.23.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "perfmark-api",
+          "0.23.0"
+        ],
+        "prefix": "io.perfmark"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-pool2",
+    "revision": "2.8.0",
+    "@id": "http:maven/org.apache.commons/commons-pool2/2.8.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apache.commons:commons-pool2:2.8.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-pool2",
+          "2.8.0"
+        ],
+        "prefix": "org.apache.commons"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "metrics-jvm",
+    "revision": "4.1.2",
+    "@id": "http:maven/io.dropwizard.metrics/metrics-jvm/4.1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.dropwizard.metrics:metrics-jvm:4.1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "metrics-jvm",
+          "4.1.2"
+        ],
+        "prefix": "io.dropwizard.metrics"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "sangria-streaming-api_2.13",
+    "revision": "1.0.1",
+    "@id": "http:maven/org.sangria-graphql/sangria-streaming-api_2.13/1.0.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.sangria-graphql:sangria-streaming-api_2.13:1.0.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "sangria-streaming-api_2.13",
+          "1.0.1"
+        ],
+        "prefix": "org.sangria-graphql"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit-platform-suite-api",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.junit.platform/junit-platform-suite-api/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.junit.platform:junit-platform-suite-api:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit-platform-suite-api",
+          "1.0.0"
+        ],
+        "prefix": "org.junit.platform"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-graphite",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-graphite/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-graphite:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-graphite",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "metrics-jmx",
+    "revision": "4.1.2",
+    "@id": "http:maven/io.dropwizard.metrics/metrics-jmx/4.1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.dropwizard.metrics:metrics-jmx:4.1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "metrics-jmx",
+          "4.1.2"
+        ],
+        "prefix": "io.dropwizard.metrics"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "hamcrest-library",
+    "revision": "1.3",
+    "@id": "http:maven/org.hamcrest/hamcrest-library/1.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.hamcrest:hamcrest-library:1.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "hamcrest-library",
+          "1.3"
+        ],
+        "prefix": "org.hamcrest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-charts",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-charts/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-charts:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-charts",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "checker",
+    "revision": "2.5.4",
+    "@id": "http:maven/org.checkerframework/checker/2.5.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.checkerframework:checker:2.5.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "checker",
+          "2.5.4"
+        ],
+        "prefix": "org.checkerframework"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "doobie-postgres_2.13",
+    "revision": "0.13.4",
+    "@id": "http:maven/org.tpolecat/doobie-postgres_2.13/0.13.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.tpolecat:doobie-postgres_2.13:0.13.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "doobie-postgres_2.13",
+          "0.13.4"
+        ],
+        "prefix": "org.tpolecat"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-protobuf-v3_2.13",
+    "revision": "2.6.18",
+    "@id": "http:maven/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-protobuf-v3_2.13:2.6.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-protobuf-v3_2.13",
+          "2.6.18"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-compatible",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-compatible/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-compatible:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-compatible",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-security",
+    "revision": "9.4.18.v20190429",
+    "@id": "http:maven/org.eclipse.jetty/jetty-security/9.4.18.v20190429",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-security:9.4.18.v20190429",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-security",
+          "9.4.18.v20190429"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "websocket-servlet",
+    "revision": "9.4.18.v20190429",
+    "@id": "http:maven/org.eclipse.jetty.websocket/websocket-servlet/9.4.18.v20190429",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty.websocket:websocket-servlet:9.4.18.v20190429",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "websocket-servlet",
+          "9.4.18.v20190429"
+        ],
+        "prefix": "org.eclipse.jetty.websocket"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-codec-http2",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-codec-http2/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-codec-http2:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-codec-http2",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-tcnative-classes",
+    "revision": "2.0.46.Final",
+    "@id": "http:maven/io.netty/netty-tcnative-classes/2.0.46.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-tcnative-classes:2.0.46.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-tcnative-classes",
+          "2.0.46.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "htmlunit-core-js",
+    "revision": "2.39.0",
+    "@id": "http:maven/net.sourceforge.htmlunit/htmlunit-core-js/2.39.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.sourceforge.htmlunit:htmlunit-core-js:2.39.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "htmlunit-core-js",
+          "2.39.0"
+        ],
+        "prefix": "net.sourceforge.htmlunit"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "websocket-server",
+    "revision": "9.4.18.v20190429",
+    "@id": "http:maven/org.eclipse.jetty.websocket/websocket-server/9.4.18.v20190429",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty.websocket:websocket-server:9.4.18.v20190429",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "websocket-server",
+          "9.4.18.v20190429"
+        ],
+        "prefix": "org.eclipse.jetty.websocket"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-webapp",
+    "revision": "9.4.18.v20190429",
+    "@id": "http:maven/org.eclipse.jetty/jetty-webapp/9.4.18.v20190429",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-webapp:9.4.18.v20190429",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-webapp",
+          "9.4.18.v20190429"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-math3",
+    "revision": "3.2",
+    "@id": "http:maven/org.apache.commons/commons-math3/3.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apache.commons:commons-math3:3.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-math3",
+          "3.2"
+        ],
+        "prefix": "org.apache.commons"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "kind-projector_2.13.8",
+    "revision": "0.13.2",
+    "@id": "http:maven/org.typelevel/kind-projector_2.13.8/0.13.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:kind-projector_2.13.8:0.13.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "kind-projector_2.13.8",
+          "0.13.2"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "grpc-stub",
+    "revision": "1.44.0",
+    "@id": "http:maven/io.grpc/grpc-stub/1.44.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.grpc:grpc-stub:1.44.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "grpc-stub",
+          "1.44.0"
+        ],
+        "prefix": "io.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-netty-util",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-netty-util/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-netty-util:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-netty-util",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-edge-driver",
+    "revision": "3.12.0",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-edge-driver/3.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-edge-driver:3.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-edge-driver",
+          "3.12.0"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "discipline-core_2.13",
+    "revision": "1.1.5",
+    "@id": "http:maven/org.typelevel/discipline-core_2.13/1.1.5",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:discipline-core_2.13:1.1.5",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "discipline-core_2.13",
+          "1.1.5"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "animal-sniffer-annotations",
+    "revision": "1.19",
+    "@id": "http:maven/org.codehaus.mojo/animal-sniffer-annotations/1.19",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.codehaus.mojo:animal-sniffer-annotations:1.19",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "animal-sniffer-annotations",
+          "1.19"
+        ],
+        "prefix": "org.codehaus.mojo"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "failureaccess",
+    "revision": "1.0.1",
+    "@id": "http:maven/com.google.guava/failureaccess/1.0.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.guava:failureaccess:1.0.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "failureaccess",
+          "1.0.1"
+        ],
+        "prefix": "com.google.guava"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "testng-6-7_2.13",
+    "revision": "3.2.9.0",
+    "@id": "http:maven/org.scalatestplus/testng-6-7_2.13/3.2.9.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatestplus:testng-6-7_2.13:3.2.9.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "testng-6-7_2.13",
+          "3.2.9.0"
+        ],
+        "prefix": "org.scalatestplus"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "logback-core",
+    "revision": "1.2.8",
+    "@id": "http:maven/ch.qos.logback/logback-core/1.2.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "ch.qos.logback:logback-core:1.2.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "logback-core",
+          "1.2.8"
+        ],
+        "prefix": "ch.qos.logback"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "javassist",
+    "revision": "3.26.0-GA",
+    "@id": "http:maven/org.javassist/javassist/3.26.0-GA",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.javassist:javassist:3.26.0-GA",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "javassist",
+          "3.26.0-GA"
+        ],
+        "prefix": "org.javassist"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-http-core_2.13",
+    "revision": "10.2.8",
+    "@id": "http:maven/com.typesafe.akka/akka-http-core_2.13/10.2.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-http-core_2.13:10.2.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-http-core_2.13",
+          "10.2.8"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-codec-dns",
+    "revision": "4.1.58.Final",
+    "@id": "http:maven/io.netty/netty-codec-dns/4.1.58.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-codec-dns:4.1.58.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-codec-dns",
+          "4.1.58.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "logback-classic",
+    "revision": "1.2.8",
+    "@id": "http:maven/ch.qos.logback/logback-classic/1.2.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "ch.qos.logback:logback-classic:1.2.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "logback-classic",
+          "1.2.8"
+        ],
+        "prefix": "ch.qos.logback"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-text",
+    "revision": "1.4",
+    "@id": "http:maven/org.apache.commons/commons-text/1.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apache.commons:commons-text:1.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-text",
+          "1.4"
+        ],
+        "prefix": "org.apache.commons"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "javapoet",
+    "revision": "1.11.1",
+    "@id": "http:maven/com.squareup/javapoet/1.11.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.squareup:javapoet:1.11.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "javapoet",
+          "1.11.1"
+        ],
+        "prefix": "com.squareup"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "doobie-hikari_2.13",
+    "revision": "0.13.4",
+    "@id": "http:maven/org.tpolecat/doobie-hikari_2.13/0.13.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.tpolecat:doobie-hikari_2.13:0.13.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "doobie-hikari_2.13",
+          "0.13.4"
+        ],
+        "prefix": "org.tpolecat"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "testng",
+    "revision": "6.7",
+    "@id": "http:maven/org.testng/testng/6.7",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.testng:testng:6.7",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "testng",
+          "6.7"
+        ],
+        "prefix": "org.testng"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "okhttp",
+    "revision": "3.11.0",
+    "@id": "http:maven/com.squareup.okhttp3/okhttp/3.11.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.squareup.okhttp3:okhttp:3.11.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "okhttp",
+          "3.11.0"
+        ],
+        "prefix": "com.squareup.okhttp3"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "htmlunit",
+    "revision": "2.39.0",
+    "@id": "http:maven/net.sourceforge.htmlunit/htmlunit/2.39.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.sourceforge.htmlunit:htmlunit:2.39.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "htmlunit",
+          "2.39.0"
+        ],
+        "prefix": "net.sourceforge.htmlunit"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jsr305",
+    "revision": "3.0.2",
+    "@id": "http:maven/com.google.code.findbugs/jsr305/3.0.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.code.findbugs:jsr305:3.0.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jsr305",
+          "3.0.2"
+        ],
+        "prefix": "com.google.code.findbugs"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalaz-concurrent_2.13",
+    "revision": "7.2.33",
+    "@id": "http:maven/org.scalaz/scalaz-concurrent_2.13/7.2.33",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalaz:scalaz-concurrent_2.13:7.2.33",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalaz-concurrent_2.13",
+          "7.2.33"
+        ],
+        "prefix": "org.scalaz"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "ssl-config-core_2.13",
+    "revision": "0.4.2",
+    "@id": "http:maven/com.typesafe/ssl-config-core_2.13/0.4.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe:ssl-config-core_2.13:0.4.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "ssl-config-core_2.13",
+          "0.4.2"
+        ],
+        "prefix": "com.typesafe"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "fastparse_2.13",
+    "revision": "2.3.0",
+    "@id": "http:maven/com.lihaoyi/fastparse_2.13/2.3.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:fastparse_2.13:2.3.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "fastparse_2.13",
+          "2.3.0"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "protoc-gen_2.13",
+    "revision": "0.9.5",
+    "@id": "http:maven/com.thesamet.scalapb/protoc-gen_2.13/0.9.5",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.thesamet.scalapb:protoc-gen_2.13:0.9.5",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "protoc-gen_2.13",
+          "0.9.5"
+        ],
+        "prefix": "com.thesamet.scalapb"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "byte-buddy-agent",
+    "revision": "1.10.18",
+    "@id": "http:maven/net.bytebuddy/byte-buddy-agent/1.10.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.bytebuddy:byte-buddy-agent:1.10.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "byte-buddy-agent",
+          "1.10.18"
+        ],
+        "prefix": "net.bytebuddy"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "j2objc-annotations",
+    "revision": "1.3",
+    "@id": "http:maven/com.google.j2objc/j2objc-annotations/1.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.j2objc:j2objc-annotations:1.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "j2objc-annotations",
+          "1.3"
+        ],
+        "prefix": "com.google.j2objc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "simpleclient_dropwizard",
+    "revision": "0.8.1",
+    "@id": "http:maven/io.prometheus/simpleclient_dropwizard/0.8.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.prometheus:simpleclient_dropwizard:0.8.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "simpleclient_dropwizard",
+          "0.8.1"
+        ],
+        "prefix": "io.prometheus"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "spray-json_2.13",
+    "revision": "1.3.5",
+    "@id": "http:maven/io.spray/spray-json_2.13/1.3.5",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.spray:spray-json_2.13:1.3.5",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "spray-json_2.13",
+          "1.3.5"
+        ],
+        "prefix": "io.spray"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-funsuite_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-funsuite_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-funsuite_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-funsuite_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "neko-htmlunit",
+    "revision": "2.39.0",
+    "@id": "http:maven/net.sourceforge.htmlunit/neko-htmlunit/2.39.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.sourceforge.htmlunit:neko-htmlunit:2.39.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "neko-htmlunit",
+          "2.39.0"
+        ],
+        "prefix": "net.sourceforge.htmlunit"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit-platform-runner",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.junit.platform/junit-platform-runner/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.junit.platform:junit-platform-runner:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit-platform-runner",
+          "1.0.0"
+        ],
+        "prefix": "org.junit.platform"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "bcpkix-jdk15on",
+    "revision": "1.70",
+    "@id": "http:maven/org.bouncycastle/bcpkix-jdk15on/1.70",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.bouncycastle:bcpkix-jdk15on:1.70",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "bcpkix-jdk15on",
+          "1.70"
+        ],
+        "prefix": "org.bouncycastle"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-http-spray-json_2.13",
+    "revision": "10.2.8",
+    "@id": "http:maven/com.typesafe.akka/akka-http-spray-json_2.13/10.2.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-http-spray-json_2.13:10.2.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-http-spray-json_2.13",
+          "10.2.8"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "quicklens_2.13",
+    "revision": "1.6.1",
+    "@id": "http:maven/com.softwaremill.quicklens/quicklens_2.13/1.6.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.softwaremill.quicklens:quicklens_2.13:1.6.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "quicklens_2.13",
+          "1.6.1"
+        ],
+        "prefix": "com.softwaremill.quicklens"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "directories",
+    "revision": "26",
+    "@id": "http:maven/dev.dirs/directories/26",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "dev.dirs:directories:26",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "directories",
+          "26"
+        ],
+        "prefix": "dev.dirs"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "sqlite-jdbc",
+    "revision": "3.36.0.1",
+    "@id": "http:maven/org.xerial/sqlite-jdbc/3.36.0.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.xerial:sqlite-jdbc:3.36.0.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "sqlite-jdbc",
+          "3.36.0.1"
+        ],
+        "prefix": "org.xerial"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "guava",
+    "revision": "31.0.1-jre",
+    "@id": "http:maven/com.google.guava/guava/31.0.1-jre",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.guava:guava:31.0.1-jre",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "guava",
+          "31.0.1-jre"
+        ],
+        "prefix": "com.google.guava"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "toxiproxy-java",
+    "revision": "2.1.3",
+    "@id": "http:maven/eu.rekawek.toxiproxy/toxiproxy-java/2.1.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "eu.rekawek.toxiproxy:toxiproxy-java:2.1.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "toxiproxy-java",
+          "2.1.3"
+        ],
+        "prefix": "eu.rekawek.toxiproxy"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "paiges-core_2.13",
+    "revision": "0.3.2",
+    "@id": "http:maven/org.typelevel/paiges-core_2.13/0.3.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:paiges-core_2.13:0.3.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "paiges-core_2.13",
+          "0.3.2"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "circe-core_2.13",
+    "revision": "0.13.0",
+    "@id": "http:maven/io.circe/circe-core_2.13/0.13.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.circe:circe-core_2.13:0.13.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "circe-core_2.13",
+          "0.13.0"
+        ],
+        "prefix": "io.circe"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "pprint_2.13",
+    "revision": "0.7.1",
+    "@id": "http:maven/com.lihaoyi/pprint_2.13/0.7.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:pprint_2.13:0.7.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "pprint_2.13",
+          "0.7.1"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "ujson_2.13",
+    "revision": "1.2.0",
+    "@id": "http:maven/com.lihaoyi/ujson_2.13/1.2.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:ujson_2.13:1.2.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "ujson_2.13",
+          "1.2.0"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentelemetry-api",
+    "revision": "1.1.0",
+    "@id": "http:maven/io.opentelemetry/opentelemetry-api/1.1.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.opentelemetry:opentelemetry-api:1.1.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentelemetry-api",
+          "1.1.0"
+        ],
+        "prefix": "io.opentelemetry"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-commons",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-commons/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-commons:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-commons",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "bcutil-jdk15on",
+    "revision": "1.70",
+    "@id": "http:maven/org.bouncycastle/bcutil-jdk15on/1.70",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.bouncycastle:bcutil-jdk15on:1.70",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "bcutil-jdk15on",
+          "1.70"
+        ],
+        "prefix": "org.bouncycastle"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "bcprov-jdk15on",
+    "revision": "1.70",
+    "@id": "http:maven/org.bouncycastle/bcprov-jdk15on/1.70",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.bouncycastle:bcprov-jdk15on:1.70",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "bcprov-jdk15on",
+          "1.70"
+        ],
+        "prefix": "org.bouncycastle"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scala-xml_2.13",
+    "revision": "1.3.0",
+    "@id": "http:maven/org.scala-lang.modules/scala-xml_2.13/1.3.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scala-lang.modules:scala-xml_2.13:1.3.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scala-xml_2.13",
+          "1.3.0"
+        ],
+        "prefix": "org.scala-lang.modules"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "cats-laws_2.13",
+    "revision": "2.6.1",
+    "@id": "http:maven/org.typelevel/cats-laws_2.13/2.6.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:cats-laws_2.13:2.6.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "cats-laws_2.13",
+          "2.6.1"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-handler-proxy",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-handler-proxy/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-handler-proxy:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-handler-proxy",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "protobuf-java-util",
+    "revision": "3.19.2",
+    "@id": "http:maven/com.google.protobuf/protobuf-java-util/3.19.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.protobuf:protobuf-java-util:3.19.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "protobuf-java-util",
+          "3.19.2"
+        ],
+        "prefix": "com.google.protobuf"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-codec",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-codec/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-codec:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-codec",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jodd-util",
+    "revision": "6.0.0",
+    "@id": "http:maven/org.jodd/jodd-util/6.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.jodd:jodd-util:6.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jodd-util",
+          "6.0.0"
+        ],
+        "prefix": "org.jodd"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "mockito-scala_2.13",
+    "revision": "1.16.3",
+    "@id": "http:maven/org.mockito/mockito-scala_2.13/1.16.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.mockito:mockito-scala_2.13:1.16.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "mockito-scala_2.13",
+          "1.16.3"
+        ],
+        "prefix": "org.mockito"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "javax.jms-api",
+    "revision": "2.0.1",
+    "@id": "http:maven/javax.jms/javax.jms-api/2.0.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "javax.jms:javax.jms-api:2.0.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "javax.jms-api",
+          "2.0.1"
+        ],
+        "prefix": "javax.jms"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "grpc-protobuf",
+    "revision": "1.44.0",
+    "@id": "http:maven/io.grpc/grpc-protobuf/1.44.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.grpc:grpc-protobuf:1.44.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "grpc-protobuf",
+          "1.44.0"
+        ],
+        "prefix": "io.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-actor-typed_2.13",
+    "revision": "2.6.18",
+    "@id": "http:maven/com.typesafe.akka/akka-actor-typed_2.13/2.6.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-actor-typed_2.13:2.6.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-actor-typed_2.13",
+          "2.6.18"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "annotations",
+    "revision": "4.1.1.4",
+    "@id": "http:maven/com.google.android/annotations/4.1.1.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.android:annotations:4.1.1.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "annotations",
+          "4.1.1.4"
+        ],
+        "prefix": "com.google.android"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scala-logging_2.13",
+    "revision": "3.9.2",
+    "@id": "http:maven/com.typesafe.scala-logging/scala-logging_2.13/3.9.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.scala-logging:scala-logging_2.13:3.9.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scala-logging_2.13",
+          "3.9.2"
+        ],
+        "prefix": "com.typesafe.scala-logging"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "joda-time",
+    "revision": "2.10.8",
+    "@id": "http:maven/joda-time/joda-time/2.10.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "joda-time:joda-time:2.10.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "joda-time",
+          "2.10.8"
+        ],
+        "prefix": "joda-time"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-featurespec_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-featurespec_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-featurespec_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-featurespec_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-http_2.13",
+    "revision": "10.2.8",
+    "@id": "http:maven/com.typesafe.akka/akka-http_2.13/10.2.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-http_2.13:10.2.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-http_2.13",
+          "10.2.8"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit-platform-commons",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.junit.platform/junit-platform-commons/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.junit.platform:junit-platform-commons:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit-platform-commons",
+          "1.0.0"
+        ],
+        "prefix": "org.junit.platform"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-wordspec_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-wordspec_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-wordspec_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-wordspec_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-firefox-driver",
+    "revision": "3.12.0",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-firefox-driver/3.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-firefox-driver:3.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-firefox-driver",
+          "3.12.0"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jackson-databind",
+    "revision": "2.12.0",
+    "@id": "http:maven/com.fasterxml.jackson.core/jackson-databind/2.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.fasterxml.jackson.core:jackson-databind:2.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jackson-databind",
+          "2.12.0"
+        ],
+        "prefix": "com.fasterxml.jackson.core"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "grpc-context",
+    "revision": "1.44.0",
+    "@id": "http:maven/io.grpc/grpc-context/1.44.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.grpc:grpc-context:1.44.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "grpc-context",
+          "1.44.0"
+        ],
+        "prefix": "io.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "dec",
+    "revision": "0.1.2",
+    "@id": "http:maven/org.brotli/dec/0.1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.brotli:dec:0.1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "dec",
+          "0.1.2"
+        ],
+        "prefix": "org.brotli"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "HdrHistogram",
+    "revision": "2.1.12",
+    "@id": "http:maven/org.hdrhistogram/HdrHistogram/2.1.12",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.hdrhistogram:HdrHistogram:2.1.12",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "HdrHistogram",
+          "2.1.12"
+        ],
+        "prefix": "org.hdrhistogram"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "grpc-netty",
+    "revision": "1.44.0",
+    "@id": "http:maven/io.grpc/grpc-netty/1.44.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.grpc:grpc-netty:1.44.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "grpc-netty",
+          "1.44.0"
+        ],
+        "prefix": "io.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-lang3",
+    "revision": "3.9",
+    "@id": "http:maven/org.apache.commons/commons-lang3/3.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apache.commons:commons-lang3:3.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-lang3",
+          "3.9"
+        ],
+        "prefix": "org.apache.commons"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "flyway-core",
+    "revision": "8.4.1",
+    "@id": "http:maven/org.flywaydb/flyway-core/8.4.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.flywaydb:flyway-core:8.4.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "flyway-core",
+          "8.4.1"
+        ],
+        "prefix": "org.flywaydb"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-safari-driver",
+    "revision": "3.12.0",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-safari-driver/3.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-safari-driver:3.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-safari-driver",
+          "3.12.0"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "reactive-streams-tck",
+    "revision": "1.0.2",
+    "@id": "http:maven/org.reactivestreams/reactive-streams-tck/1.0.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.reactivestreams:reactive-streams-tck:1.0.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "reactive-streams-tck",
+          "1.0.2"
+        ],
+        "prefix": "org.reactivestreams"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "metrics-core",
+    "revision": "4.1.2",
+    "@id": "http:maven/io.dropwizard.metrics/metrics-core/4.1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.dropwizard.metrics:metrics-core:4.1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "metrics-core",
+          "4.1.2"
+        ],
+        "prefix": "io.dropwizard.metrics"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jwks-rsa",
+    "revision": "0.11.0",
+    "@id": "http:maven/com.auth0/jwks-rsa/0.11.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.auth0:jwks-rsa:0.11.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jwks-rsa",
+          "0.11.0"
+        ],
+        "prefix": "com.auth0"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scala-parser-combinators_2.13",
+    "revision": "1.1.2",
+    "@id": "http:maven/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scala-lang.modules:scala-parser-combinators_2.13:1.1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scala-parser-combinators_2.13",
+          "1.1.2"
+        ],
+        "prefix": "org.scala-lang.modules"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "websocket-api",
+    "revision": "9.4.27.v20200227",
+    "@id": "http:maven/org.eclipse.jetty.websocket/websocket-api/9.4.27.v20200227",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty.websocket:websocket-api:9.4.27.v20200227",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "websocket-api",
+          "9.4.27.v20200227"
+        ],
+        "prefix": "org.eclipse.jetty.websocket"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-compiler",
+    "revision": "3.1.4",
+    "@id": "http:maven/org.codehaus.janino/commons-compiler/3.1.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.codehaus.janino:commons-compiler:3.1.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-compiler",
+          "3.1.4"
+        ],
+        "prefix": "org.codehaus.janino"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-core_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-core_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-core_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-core_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "error_prone_annotations",
+    "revision": "2.9.0",
+    "@id": "http:maven/com.google.errorprone/error_prone_annotations/2.9.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.errorprone:error_prone_annotations:2.9.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "error_prone_annotations",
+          "2.9.0"
+        ],
+        "prefix": "com.google.errorprone"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "doobie-free_2.13",
+    "revision": "0.13.4",
+    "@id": "http:maven/org.tpolecat/doobie-free_2.13/0.13.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.tpolecat:doobie-free_2.13:0.13.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "doobie-free_2.13",
+          "0.13.4"
+        ],
+        "prefix": "org.tpolecat"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "cats-free_2.13",
+    "revision": "2.6.1",
+    "@id": "http:maven/org.typelevel/cats-free_2.13/2.6.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:cats-free_2.13:2.6.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "cats-free_2.13",
+          "2.6.1"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-funspec_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-funspec_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-funspec_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-funspec_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "Saxon-HE",
+    "revision": "10.3",
+    "@id": "http:maven/net.sf.saxon/Saxon-HE/10.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.sf.saxon:Saxon-HE:10.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "Saxon-HE",
+          "10.3"
+        ],
+        "prefix": "net.sf.saxon"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "cats-core_2.13",
+    "revision": "2.6.1",
+    "@id": "http:maven/org.typelevel/cats-core_2.13/2.6.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:cats-core_2.13:2.6.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "cats-core_2.13",
+          "2.6.1"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-testkit_2.13",
+    "revision": "2.6.18",
+    "@id": "http:maven/com.typesafe.akka/akka-testkit_2.13/2.6.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-testkit_2.13:2.6.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-testkit_2.13",
+          "2.6.18"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "pureconfig-macros_2.13",
+    "revision": "0.14.0",
+    "@id": "http:maven/com.github.pureconfig/pureconfig-macros_2.13/0.14.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.github.pureconfig:pureconfig-macros_2.13:0.14.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "pureconfig-macros_2.13",
+          "0.14.0"
+        ],
+        "prefix": "com.github.pureconfig"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-http",
+    "revision": "9.4.27.v20200227",
+    "@id": "http:maven/org.eclipse.jetty/jetty-http/9.4.27.v20200227",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-http:9.4.27.v20200227",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-http",
+          "9.4.27.v20200227"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "fs2-io_2.13",
+    "revision": "2.5.6",
+    "@id": "http:maven/co.fs2/fs2-io_2.13/2.5.6",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "co.fs2:fs2-io_2.13:2.5.6",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "fs2-io_2.13",
+          "2.5.6"
+        ],
+        "prefix": "co.fs2"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jackson-annotations",
+    "revision": "2.12.0",
+    "@id": "http:maven/com.fasterxml.jackson.core/jackson-annotations/2.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.fasterxml.jackson.core:jackson-annotations:2.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jackson-annotations",
+          "2.12.0"
+        ],
+        "prefix": "com.fasterxml.jackson.core"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "joda-convert",
+    "revision": "2.2.1",
+    "@id": "http:maven/org.joda/joda-convert/2.2.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.joda:joda-convert:2.2.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "joda-convert",
+          "2.2.1"
+        ],
+        "prefix": "org.joda"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jawn-parser_2.13",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.typelevel/jawn-parser_2.13/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:jawn-parser_2.13:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jawn-parser_2.13",
+          "1.0.0"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "munit_2.13",
+    "revision": "0.7.26",
+    "@id": "http:maven/org.scalameta/munit_2.13/0.7.26",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalameta:munit_2.13:0.7.26",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "munit_2.13",
+          "0.7.26"
+        ],
+        "prefix": "org.scalameta"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jmespath-core",
+    "revision": "0.5.0",
+    "@id": "http:maven/io.burt/jmespath-core/0.5.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.burt:jmespath-core:0.5.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jmespath-core",
+          "0.5.0"
+        ],
+        "prefix": "io.burt"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "wartremover_2.13.8",
+    "revision": "2.4.16",
+    "@id": "http:maven/org.wartremover/wartremover_2.13.8/2.4.16",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.wartremover:wartremover_2.13.8:2.4.16",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "wartremover_2.13.8",
+          "2.4.16"
+        ],
+        "prefix": "org.wartremover"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "circe-jawn_2.13",
+    "revision": "0.13.0",
+    "@id": "http:maven/io.circe/circe-jawn_2.13/0.13.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.circe:circe-jawn_2.13:0.13.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "circe-jawn_2.13",
+          "0.13.0"
+        ],
+        "prefix": "io.circe"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalapb-runtime_2.13",
+    "revision": "0.11.8",
+    "@id": "http:maven/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.thesamet.scalapb:scalapb-runtime_2.13:0.11.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalapb-runtime_2.13",
+          "0.11.8"
+        ],
+        "prefix": "com.thesamet.scalapb"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "redisclient_2.13",
+    "revision": "3.30",
+    "@id": "http:maven/net.debasishg/redisclient_2.13/3.30",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.debasishg:redisclient_2.13:3.30",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "redisclient_2.13",
+          "3.30"
+        ],
+        "prefix": "net.debasishg"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-resolver-dns",
+    "revision": "4.1.58.Final",
+    "@id": "http:maven/io.netty/netty-resolver-dns/4.1.58.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-resolver-dns:4.1.58.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-resolver-dns",
+          "4.1.58.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "protobuf-java",
+    "revision": "3.19.3",
+    "@id": "http:maven/com.google.protobuf/protobuf-java/3.19.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.protobuf:protobuf-java:3.19.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "protobuf-java",
+          "3.19.3"
+        ],
+        "prefix": "com.google.protobuf"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "pureconfig-generic-base_2.13",
+    "revision": "0.14.0",
+    "@id": "http:maven/com.github.pureconfig/pureconfig-generic-base_2.13/0.14.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.github.pureconfig:pureconfig-generic-base_2.13:0.14.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "pureconfig-generic-base_2.13",
+          "0.14.0"
+        ],
+        "prefix": "com.github.pureconfig"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "proto-google-common-protos",
+    "revision": "2.0.1",
+    "@id": "http:maven/com.google.api.grpc/proto-google-common-protos/2.0.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.google.api.grpc:proto-google-common-protos:2.0.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "proto-google-common-protos",
+          "2.0.1"
+        ],
+        "prefix": "com.google.api.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "sangria-marshalling-api_2.13",
+    "revision": "1.0.4",
+    "@id": "http:maven/org.sangria-graphql/sangria-marshalling-api_2.13/1.0.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.sangria-graphql:sangria-marshalling-api_2.13:1.0.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "sangria-marshalling-api_2.13",
+          "1.0.4"
+        ],
+        "prefix": "org.sangria-graphql"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "pureconfig-generic_2.13",
+    "revision": "0.14.0",
+    "@id": "http:maven/com.github.pureconfig/pureconfig-generic_2.13/0.14.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.github.pureconfig:pureconfig-generic_2.13:0.14.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "pureconfig-generic_2.13",
+          "0.14.0"
+        ],
+        "prefix": "com.github.pureconfig"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-server",
+    "revision": "9.4.18.v20190429",
+    "@id": "http:maven/org.eclipse.jetty/jetty-server/9.4.18.v20190429",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-server:9.4.18.v20190429",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-server",
+          "9.4.18.v20190429"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "xercesImpl",
+    "revision": "2.12.0",
+    "@id": "http:maven/xerces/xercesImpl/2.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "xerces:xercesImpl:2.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "xercesImpl",
+          "2.12.0"
+        ],
+        "prefix": "xerces"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit-jupiter-api",
+    "revision": "5.0.0",
+    "@id": "http:maven/org.junit.jupiter/junit-jupiter-api/5.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.junit.jupiter:junit-jupiter-api:5.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit-jupiter-api",
+          "5.0.0"
+        ],
+        "prefix": "org.junit.jupiter"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "reactive-streams-examples",
+    "revision": "1.0.2",
+    "@id": "http:maven/org.reactivestreams/reactive-streams-examples/1.0.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.reactivestreams:reactive-streams-examples:1.0.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "reactive-streams-examples",
+          "1.0.2"
+        ],
+        "prefix": "org.reactivestreams"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "javax.annotation-api",
+    "revision": "1.2",
+    "@id": "http:maven/javax.annotation/javax.annotation-api/1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "javax.annotation:javax.annotation-api:1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "javax.annotation-api",
+          "1.2"
+        ],
+        "prefix": "javax.annotation"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scala-parallel-collections_2.13",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scala-lang.modules:scala-parallel-collections_2.13:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scala-parallel-collections_2.13",
+          "1.0.0"
+        ],
+        "prefix": "org.scala-lang.modules"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-http",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-http/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-http:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-http",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "httpclient",
+    "revision": "4.5.12",
+    "@id": "http:maven/org.apache.httpcomponents/httpclient/4.5.12",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apache.httpcomponents:httpclient:4.5.12",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "httpclient",
+          "4.5.12"
+        ],
+        "prefix": "org.apache.httpcomponents"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "asm",
+    "revision": "5.0.4",
+    "@id": "http:maven/org.ow2.asm/asm/5.0.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.ow2.asm:asm:5.0.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "asm",
+          "5.0.4"
+        ],
+        "prefix": "org.ow2.asm"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-util",
+    "revision": "9.4.27.v20200227",
+    "@id": "http:maven/org.eclipse.jetty/jetty-util/9.4.27.v20200227",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-util:9.4.27.v20200227",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-util",
+          "9.4.27.v20200227"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "bsh",
+    "revision": "2.0b4",
+    "@id": "http:maven/org.beanshell/bsh/2.0b4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.beanshell:bsh:2.0b4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "bsh",
+          "2.0b4"
+        ],
+        "prefix": "org.beanshell"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-io",
+    "revision": "2.5",
+    "@id": "http:maven/commons-io/commons-io/2.5",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "commons-io:commons-io:2.5",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-io",
+          "2.5"
+        ],
+        "prefix": "commons-io"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jackson-module-scala_2.13",
+    "revision": "2.9.9",
+    "@id": "http:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.9.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.fasterxml.jackson.module:jackson-module-scala_2.13:2.9.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jackson-module-scala_2.13",
+          "2.9.9"
+        ],
+        "prefix": "com.fasterxml.jackson.module"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "commons-exec",
+    "revision": "1.3",
+    "@id": "http:maven/org.apache.commons/commons-exec/1.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apache.commons:commons-exec:1.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "commons-exec",
+          "1.3"
+        ],
+        "prefix": "org.apache.commons"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalactic_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalactic/scalactic_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalactic:scalactic_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalactic_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalactic"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "janino",
+    "revision": "3.1.4",
+    "@id": "http:maven/org.codehaus.janino/janino/3.1.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.codehaus.janino:janino:3.1.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "janino",
+          "3.1.4"
+        ],
+        "prefix": "org.codehaus.janino"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "rxjava",
+    "revision": "2.2.1",
+    "@id": "http:maven/io.reactivex.rxjava2/rxjava/2.2.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.reactivex.rxjava2:rxjava:2.2.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "rxjava",
+          "2.2.1"
+        ],
+        "prefix": "io.reactivex.rxjava2"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "macro-visit_2.13",
+    "revision": "0.1.2",
+    "@id": "http:maven/org.sangria-graphql/macro-visit_2.13/0.1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.sangria-graphql:macro-visit_2.13:0.1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "macro-visit_2.13",
+          "0.1.2"
+        ],
+        "prefix": "org.sangria-graphql"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "sourcecode_2.13",
+    "revision": "0.2.7",
+    "@id": "http:maven/com.lihaoyi/sourcecode_2.13/0.2.7",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:sourcecode_2.13:0.2.7",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "sourcecode_2.13",
+          "0.2.7"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-servlet",
+    "revision": "9.4.18.v20190429",
+    "@id": "http:maven/org.eclipse.jetty/jetty-servlet/9.4.18.v20190429",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-servlet:9.4.18.v20190429",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-servlet",
+          "9.4.18.v20190429"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit-platform-launcher",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.junit.platform/junit-platform-launcher/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.junit.platform:junit-platform-launcher:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit-platform-launcher",
+          "1.0.0"
+        ],
+        "prefix": "org.junit.platform"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-xml",
+    "revision": "9.4.27.v20200227",
+    "@id": "http:maven/org.eclipse.jetty/jetty-xml/9.4.27.v20200227",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-xml:9.4.27.v20200227",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-xml",
+          "9.4.27.v20200227"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "postgresql",
+    "revision": "42.2.25",
+    "@id": "http:maven/org.postgresql/postgresql/42.2.25",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.postgresql:postgresql:42.2.25",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "postgresql",
+          "42.2.25"
+        ],
+        "prefix": "org.postgresql"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "sangria_2.13",
+    "revision": "2.0.1",
+    "@id": "http:maven/org.sangria-graphql/sangria_2.13/2.0.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.sangria-graphql:sangria_2.13:2.0.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "sangria_2.13",
+          "2.0.1"
+        ],
+        "prefix": "org.sangria-graphql"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalaz-iteratee_2.13",
+    "revision": "7.2.33",
+    "@id": "http:maven/org.scalaz/scalaz-iteratee_2.13/7.2.33",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalaz:scalaz-iteratee_2.13:7.2.33",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalaz-iteratee_2.13",
+          "7.2.33"
+        ],
+        "prefix": "org.scalaz"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "sjsonnet_2.13",
+    "revision": "0.3.0",
+    "@id": "http:maven/com.lihaoyi/sjsonnet_2.13/0.3.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:sjsonnet_2.13:0.3.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "sjsonnet_2.13",
+          "0.3.0"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-codec-http",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-codec-http/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-codec-http:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-codec-http",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "metrics-graphite",
+    "revision": "4.1.2",
+    "@id": "http:maven/io.dropwizard.metrics/metrics-graphite/4.1.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.dropwizard.metrics:metrics-graphite:4.1.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "metrics-graphite",
+          "4.1.2"
+        ],
+        "prefix": "io.dropwizard.metrics"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-http-testkit_2.13",
+    "revision": "10.2.8",
+    "@id": "http:maven/com.typesafe.akka/akka-http-testkit_2.13/10.2.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-http-testkit_2.13:10.2.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-http-testkit_2.13",
+          "10.2.8"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-jsonpath",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-jsonpath/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-jsonpath:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-jsonpath",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-core",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-core/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-core:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-core",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "HikariCP",
+    "revision": "3.2.0",
+    "@id": "http:maven/com.zaxxer/HikariCP/3.2.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.zaxxer:HikariCP:3.2.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "HikariCP",
+          "3.2.0"
+        ],
+        "prefix": "com.zaxxer"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "xz",
+    "revision": "1.8",
+    "@id": "http:maven/org.tukaani/xz/1.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.tukaani:xz:1.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "xz",
+          "1.8"
+        ],
+        "prefix": "org.tukaani"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "os-lib_2.13",
+    "revision": "0.7.1",
+    "@id": "http:maven/com.lihaoyi/os-lib_2.13/0.7.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:os-lib_2.13:0.7.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "os-lib_2.13",
+          "0.7.1"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "xalan",
+    "revision": "2.7.2",
+    "@id": "http:maven/xalan/xalan/2.7.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "xalan:xalan:2.7.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "xalan",
+          "2.7.2"
+        ],
+        "prefix": "xalan"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "httpcore",
+    "revision": "4.4.13",
+    "@id": "http:maven/org.apache.httpcomponents/httpcore/4.4.13",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apache.httpcomponents:httpcore:4.4.13",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "httpcore",
+          "4.4.13"
+        ],
+        "prefix": "org.apache.httpcomponents"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "circe-yaml_2.13",
+    "revision": "0.13.0",
+    "@id": "http:maven/io.circe/circe-yaml_2.13/0.13.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.circe:circe-yaml_2.13:0.13.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "circe-yaml_2.13",
+          "0.13.0"
+        ],
+        "prefix": "io.circe"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-tcnative-boringssl-static",
+    "revision": "2.0.46.Final",
+    "@id": "http:maven/io.netty/netty-tcnative-boringssl-static/2.0.46.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-tcnative-boringssl-static:2.0.46.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-tcnative-boringssl-static",
+          "2.0.46.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-transport-native-epoll",
+    "revision": "4.1.58.Final",
+    "@id": "http:maven/io.netty/netty-transport-native-epoll/4.1.58.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-transport-native-epoll:4.1.58.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-transport-native-epoll",
+          "4.1.58.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "spray-json-derived-codecs_2.13",
+    "revision": "2.3.4",
+    "@id": "http:maven/io.github.paoloboni/spray-json-derived-codecs_2.13/2.3.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.github.paoloboni:spray-json-derived-codecs_2.13:2.3.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "spray-json-derived-codecs_2.13",
+          "2.3.4"
+        ],
+        "prefix": "io.github.paoloboni"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "cats-effect_2.13",
+    "revision": "2.5.1",
+    "@id": "http:maven/org.typelevel/cats-effect_2.13/2.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.typelevel:cats-effect_2.13:2.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "cats-effect_2.13",
+          "2.5.1"
+        ],
+        "prefix": "org.typelevel"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "doobie-core_2.13",
+    "revision": "0.13.4",
+    "@id": "http:maven/org.tpolecat/doobie-core_2.13/0.13.4",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.tpolecat:doobie-core_2.13:0.13.4",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "doobie-core_2.13",
+          "0.13.4"
+        ],
+        "prefix": "org.tpolecat"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-freespec_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-freespec_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-freespec_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-freespec_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "config",
+    "revision": "1.4.1",
+    "@id": "http:maven/com.typesafe/config/1.4.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe:config:1.4.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "config",
+          "1.4.1"
+        ],
+        "prefix": "com.typesafe"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "java-jwt",
+    "revision": "3.10.3",
+    "@id": "http:maven/com.auth0/java-jwt/3.10.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.auth0:java-jwt:3.10.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "java-jwt",
+          "3.10.3"
+        ],
+        "prefix": "com.auth0"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-mustmatchers_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-mustmatchers_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-mustmatchers_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-mustmatchers_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "typename_2.13",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.tpolecat/typename_2.13/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.tpolecat:typename_2.13:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "typename_2.13",
+          "1.0.0"
+        ],
+        "prefix": "org.tpolecat"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentelemetry-sdk-trace",
+    "revision": "1.1.0",
+    "@id": "http:maven/io.opentelemetry/opentelemetry-sdk-trace/1.1.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.opentelemetry:opentelemetry-sdk-trace:1.1.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentelemetry-sdk-trace",
+          "1.1.0"
+        ],
+        "prefix": "io.opentelemetry"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentest4j",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.opentest4j/opentest4j/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.opentest4j:opentest4j:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentest4j",
+          "1.0.0"
+        ],
+        "prefix": "org.opentest4j"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scopt_2.13",
+    "revision": "4.0.0",
+    "@id": "http:maven/com.github.scopt/scopt_2.13/4.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.github.scopt:scopt_2.13:4.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scopt_2.13",
+          "4.0.0"
+        ],
+        "prefix": "com.github.scopt"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "reactive-streams",
+    "revision": "1.0.2",
+    "@id": "http:maven/org.reactivestreams/reactive-streams/1.0.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.reactivestreams:reactive-streams:1.0.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "reactive-streams",
+          "1.0.2"
+        ],
+        "prefix": "org.reactivestreams"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalatest-matchers-core_2.13",
+    "revision": "3.2.9",
+    "@id": "http:maven/org.scalatest/scalatest-matchers-core_2.13/3.2.9",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scalatest:scalatest-matchers-core_2.13:3.2.9",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalatest-matchers-core_2.13",
+          "3.2.9"
+        ],
+        "prefix": "org.scalatest"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-redis",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-redis/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-redis:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-redis",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jetty-io",
+    "revision": "9.4.27.v20200227",
+    "@id": "http:maven/org.eclipse.jetty/jetty-io/9.4.27.v20200227",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty:jetty-io:9.4.27.v20200227",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jetty-io",
+          "9.4.27.v20200227"
+        ],
+        "prefix": "org.eclipse.jetty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "htmlunit-cssparser",
+    "revision": "1.5.0",
+    "@id": "http:maven/net.sourceforge.htmlunit/htmlunit-cssparser/1.5.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "net.sourceforge.htmlunit:htmlunit-cssparser:1.5.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "htmlunit-cssparser",
+          "1.5.0"
+        ],
+        "prefix": "net.sourceforge.htmlunit"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "netty-transport",
+    "revision": "4.1.72.Final",
+    "@id": "http:maven/io.netty/netty-transport/4.1.72.Final",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.netty:netty-transport:4.1.72.Final",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "netty-transport",
+          "4.1.72.Final"
+        ],
+        "prefix": "io.netty"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "junit",
+    "revision": "4.12",
+    "@id": "http:maven/junit/junit/4.12",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "junit:junit:4.12",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "junit",
+          "4.12"
+        ],
+        "prefix": "junit"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "websocket-client",
+    "revision": "9.4.27.v20200227",
+    "@id": "http:maven/org.eclipse.jetty.websocket/websocket-client/9.4.27.v20200227",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.eclipse.jetty.websocket:websocket-client:9.4.27.v20200227",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "websocket-client",
+          "9.4.27.v20200227"
+        ],
+        "prefix": "org.eclipse.jetty.websocket"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "anorm_2.13",
+    "revision": "2.6.8",
+    "@id": "http:maven/org.playframework.anorm/anorm_2.13/2.6.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.playframework.anorm:anorm_2.13:2.6.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "anorm_2.13",
+          "2.6.8"
+        ],
+        "prefix": "org.playframework.anorm"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "javax.servlet-api",
+    "revision": "3.1.0",
+    "@id": "http:maven/javax.servlet/javax.servlet-api/3.1.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "javax.servlet:javax.servlet-api:3.1.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "javax.servlet-api",
+          "3.1.0"
+        ],
+        "prefix": "javax.servlet"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "akka-stream_2.13",
+    "revision": "2.6.18",
+    "@id": "http:maven/com.typesafe.akka/akka-stream_2.13/2.6.18",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.typesafe.akka:akka-stream_2.13:2.6.18",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "akka-stream_2.13",
+          "2.6.18"
+        ],
+        "prefix": "com.typesafe.akka"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "selenium-remote-driver",
+    "revision": "3.141.59",
+    "@id": "http:maven/org.seleniumhq.selenium/selenium-remote-driver/3.141.59",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.seleniumhq.selenium:selenium-remote-driver:3.141.59",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "selenium-remote-driver",
+          "3.141.59"
+        ],
+        "prefix": "org.seleniumhq.selenium"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "fast-uuid",
+    "revision": "0.1",
+    "@id": "http:maven/com.eatthepath/fast-uuid/0.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.eatthepath:fast-uuid:0.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "fast-uuid",
+          "0.1"
+        ],
+        "prefix": "com.eatthepath"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "jackson-core",
+    "revision": "2.12.0",
+    "@id": "http:maven/com.fasterxml.jackson.core/jackson-core/2.12.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.fasterxml.jackson.core:jackson-core:2.12.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "jackson-core",
+          "2.12.0"
+        ],
+        "prefix": "com.fasterxml.jackson.core"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scala-java8-compat_2.13",
+    "revision": "1.0.0",
+    "@id": "http:maven/org.scala-lang.modules/scala-java8-compat_2.13/1.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scala-lang.modules:scala-java8-compat_2.13:1.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scala-java8-compat_2.13",
+          "1.0.0"
+        ],
+        "prefix": "org.scala-lang.modules"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "httpmime",
+    "revision": "4.5.12",
+    "@id": "http:maven/org.apache.httpcomponents/httpmime/4.5.12",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.apache.httpcomponents:httpmime:4.5.12",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "httpmime",
+          "4.5.12"
+        ],
+        "prefix": "org.apache.httpcomponents"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "grpc-api",
+    "revision": "1.44.0",
+    "@id": "http:maven/io.grpc/grpc-api/1.44.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.grpc:grpc-api:1.44.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "grpc-api",
+          "1.44.0"
+        ],
+        "prefix": "io.grpc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "geny_2.13",
+    "revision": "0.6.2",
+    "@id": "http:maven/com.lihaoyi/geny_2.13/0.6.2",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.lihaoyi:geny_2.13:0.6.2",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "geny_2.13",
+          "0.6.2"
+        ],
+        "prefix": "com.lihaoyi"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-jdbc",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-jdbc/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-jdbc:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-jdbc",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scalapb-runtime-grpc_2.13",
+    "revision": "0.11.8",
+    "@id": "http:maven/com.thesamet.scalapb/scalapb-runtime-grpc_2.13/0.11.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.thesamet.scalapb:scalapb-runtime-grpc_2.13:0.11.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scalapb-runtime-grpc_2.13",
+          "0.11.8"
+        ],
+        "prefix": "com.thesamet.scalapb"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "gatling-commons-shared",
+    "revision": "3.5.1",
+    "@id": "http:maven/io.gatling/gatling-commons-shared/3.5.1",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.gatling:gatling-commons-shared:3.5.1",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "gatling-commons-shared",
+          "3.5.1"
+        ],
+        "prefix": "io.gatling"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "ojdbc8",
+    "revision": "19.8.0.0",
+    "@id": "http:maven/com.oracle.database.jdbc/ojdbc8/19.8.0.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.oracle.database.jdbc:ojdbc8:19.8.0.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "ojdbc8",
+          "19.8.0.0"
+        ],
+        "prefix": "com.oracle.database.jdbc"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "opentelemetry-sdk-testing",
+    "revision": "1.1.0",
+    "@id": "http:maven/io.opentelemetry/opentelemetry-sdk-testing/1.1.0",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "io.opentelemetry:opentelemetry-sdk-testing:1.1.0",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "opentelemetry-sdk-testing",
+          "1.1.0"
+        ],
+        "prefix": "io.opentelemetry"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "paranamer",
+    "revision": "2.8",
+    "@id": "http:maven/com.thoughtworks.paranamer/paranamer/2.8",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "com.thoughtworks.paranamer:paranamer:2.8",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "paranamer",
+          "2.8"
+        ],
+        "prefix": "com.thoughtworks.paranamer"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "scodec-bits_2.13",
+    "revision": "1.1.27",
+    "@id": "http:maven/org.scodec/scodec-bits_2.13/1.1.27",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.scodec:scodec-bits_2.13:1.1.27",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "scodec-bits_2.13",
+          "1.1.27"
+        ],
+        "prefix": "org.scodec"
+      }
+    },
+    "relationship": []
+  },
+  {
+    "name": "pcollections",
+    "revision": "2.1.3",
+    "@id": "http:maven/org.pcollections/pcollections/2.1.3",
+    "@type": "Component",
+    "externalIdentifier": {
+      "externalSystemTypeId": "maven",
+      "externalId": "org.pcollections:pcollections:2.1.3",
+      "externalIdMetaData": {
+        "forge": {
+          "name": "maven",
+          "separator": ":"
+        },
+        "pieces": [
+          "pcollections",
+          "2.1.3"
+        ],
+        "prefix": "org.pcollections"
+      }
+    },
+    "relationship": []
+  }
+]


### PR DESCRIPTION
Fix for Bazel maven_install dependencies with maven_coordinates values that consist of > 3 parts. Whether the value has 3, 4, or 5 parts, the three we need (GAV) are first, second, and last.

The release note commit is: https://github.com/blackducksoftware/synopsys-detect/pull/549/commits/eacea3e57e579211a163c95eb0f4733e3df623c4 