### PR TITLE
Sb improve docker msg for invalid tar

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/BazelExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/BazelExtractor.java
@@ -73,18 +73,14 @@ public class BazelExtractor {
         this.bazelProjectNameGenerator = bazelProjectNameGenerator;
     }
 
-    public Extraction extract(ExecutableTarget bazelExe, File workspaceDir, File workspaceFile) {
-        try {
-            toolVersionLogger.log(workspaceDir, bazelExe, "version");
-            BazelCommandExecutor bazelCommandExecutor = new BazelCommandExecutor(executableRunner, workspaceDir, bazelExe);
-            Pipelines pipelines = new Pipelines(bazelCommandExecutor, bazelVariableSubstitutor, externalIdFactory, haskellCabalLibraryJsonProtoParser);
-            Set<WorkspaceRule> workspaceRulesFromFile = parseWorkspaceRulesFromFile(workspaceFile);
-            Set<WorkspaceRule> workspaceRulesToQuery = workspaceRuleChooser.choose(workspaceRulesFromFile, workspaceRulesFromDeprecatedProperty, workspaceRulesFromProperty);
-            CodeLocation codeLocation = generateCodelocation(pipelines, workspaceRulesToQuery);
-            return buildResults(codeLocation, bazelProjectNameGenerator.generateFromBazelTarget(bazelTarget));
-        } catch (Exception e) {
-            return new Extraction.Builder().exception(e).build();
-        }
+    public Extraction extract(ExecutableTarget bazelExe, File workspaceDir, File workspaceFile) throws ExecutableFailedException, DetectableException {
+        toolVersionLogger.log(workspaceDir, bazelExe, "version");
+        BazelCommandExecutor bazelCommandExecutor = new BazelCommandExecutor(executableRunner, workspaceDir, bazelExe);
+        Pipelines pipelines = new Pipelines(bazelCommandExecutor, bazelVariableSubstitutor, externalIdFactory, haskellCabalLibraryJsonProtoParser);
+        Set<WorkspaceRule> workspaceRulesFromFile = parseWorkspaceRulesFromFile(workspaceFile);
+        Set<WorkspaceRule> workspaceRulesToQuery = workspaceRuleChooser.choose(workspaceRulesFromFile, workspaceRulesFromDeprecatedProperty, workspaceRulesFromProperty);
+        CodeLocation codeLocation = generateCodelocation(pipelines, workspaceRulesToQuery);
+        return buildResults(codeLocation, bazelProjectNameGenerator.generateFromBazelTarget(bazelTarget));
     }
 
     private Set<WorkspaceRule> parseWorkspaceRulesFromFile(File workspaceFile) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/BazelExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/bazel/BazelExtractor.java
@@ -73,17 +73,21 @@ public class BazelExtractor {
         this.bazelProjectNameGenerator = bazelProjectNameGenerator;
     }
 
-    public Extraction extract(ExecutableTarget bazelExe, File workspaceDir, File workspaceFile) throws DetectableException, ExecutableFailedException {
-        toolVersionLogger.log(workspaceDir, bazelExe, "version");
-        BazelCommandExecutor bazelCommandExecutor = new BazelCommandExecutor(executableRunner, workspaceDir, bazelExe);
-        Pipelines pipelines = new Pipelines(bazelCommandExecutor, bazelVariableSubstitutor, externalIdFactory, haskellCabalLibraryJsonProtoParser);
-        Set<WorkspaceRule> workspaceRulesFromFile = parseWorkspaceRulesFromFile(workspaceFile);
-        Set<WorkspaceRule> workspaceRulesToQuery = workspaceRuleChooser.choose(workspaceRulesFromFile, workspaceRulesFromDeprecatedProperty, workspaceRulesFromProperty);
-        CodeLocation codeLocation = generateCodelocation(pipelines, workspaceRulesToQuery);
-        return buildResults(codeLocation, bazelProjectNameGenerator.generateFromBazelTarget(bazelTarget));
+    public Extraction extract(ExecutableTarget bazelExe, File workspaceDir, File workspaceFile) {
+        try {
+            toolVersionLogger.log(workspaceDir, bazelExe, "version");
+            BazelCommandExecutor bazelCommandExecutor = new BazelCommandExecutor(executableRunner, workspaceDir, bazelExe);
+            Pipelines pipelines = new Pipelines(bazelCommandExecutor, bazelVariableSubstitutor, externalIdFactory, haskellCabalLibraryJsonProtoParser);
+            Set<WorkspaceRule> workspaceRulesFromFile = parseWorkspaceRulesFromFile(workspaceFile);
+            Set<WorkspaceRule> workspaceRulesToQuery = workspaceRuleChooser.choose(workspaceRulesFromFile, workspaceRulesFromDeprecatedProperty, workspaceRulesFromProperty);
+            CodeLocation codeLocation = generateCodelocation(pipelines, workspaceRulesToQuery);
+            return buildResults(codeLocation, bazelProjectNameGenerator.generateFromBazelTarget(bazelTarget));
+        } catch (Exception e) {
+            return new Extraction.Builder().exception(e).build();
+        }
     }
 
-    private Set<WorkspaceRule> parseWorkspaceRulesFromFile(final File workspaceFile) {
+    private Set<WorkspaceRule> parseWorkspaceRulesFromFile(File workspaceFile) {
         List<String> workspaceFileLines;
         try {
             workspaceFileLines = FileUtils.readLines(workspaceFile, StandardCharsets.UTF_8);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerDetectable.java
@@ -1,5 +1,7 @@
 package com.synopsys.integration.detectable.detectables.docker;
 
+import java.io.IOException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +21,7 @@ import com.synopsys.integration.detectable.detectable.result.PassedDetectableRes
 import com.synopsys.integration.detectable.detectable.result.PropertyInsufficientDetectableResult;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
+import com.synopsys.integration.executable.ExecutableRunnerException;
 
 //TODO: Violates Detectable contract. Take folder -> give project data. This does not take a folder.
 @DetectableInfo(language = "N/A", forge = "Derived from the Linux distribution", requirementsMarkdown = "Access to a Docker Engine. See <a href='https://blackducksoftware.github.io/blackduck-docker-inspector/latest/overview/'>Docker Inspector documentation</a> for details.")
@@ -92,7 +95,7 @@ public class DockerDetectable extends Detectable {
     }
 
     @Override
-    public Extraction extract(ExtractionEnvironment extractionEnvironment) {
+    public Extraction extract(ExtractionEnvironment extractionEnvironment) throws IOException, ExecutableRunnerException {
         String image = dockerDetectableOptions.getSuppliedDockerImage().orElse("");
         String imageId = dockerDetectableOptions.getSuppliedDockerImageId().orElse("");
         String tar = dockerDetectableOptions.getSuppliedDockerTar().orElse("");

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerExtractor.java
@@ -90,33 +90,29 @@ public class DockerExtractor {
         String tar,
         DockerInspectorInfo dockerInspectorInfo,
         DockerProperties dockerProperties
-    ) {
-        try {
-            String imageArgument = null;
-            String imagePiece = null;
-            ImageIdentifierType imageIdentifierType = ImageIdentifierType.IMAGE_NAME;
-            if (StringUtils.isNotBlank(tar)) {
-                File dockerTarFile = new File(tar);
-                imageArgument = String.format("--docker.tar=%s", dockerTarFile.getCanonicalPath());
-                imagePiece = dockerTarFile.getName();
-                imageIdentifierType = ImageIdentifierType.TAR;
-            } else if (StringUtils.isNotBlank(image)) {
-                imagePiece = image;
-                imageArgument = String.format("--docker.image=%s", image);
-                imageIdentifierType = ImageIdentifierType.IMAGE_NAME;
-            } else if (StringUtils.isNotBlank(imageId)) {
-                imagePiece = imageId;
-                imageArgument = String.format("--docker.image.id=%s", imageId);
-                imageIdentifierType = ImageIdentifierType.IMAGE_ID;
-            }
+    ) throws IOException, ExecutableRunnerException {
+        String imageArgument = null;
+        String imagePiece = null;
+        ImageIdentifierType imageIdentifierType = ImageIdentifierType.IMAGE_NAME;
+        if (StringUtils.isNotBlank(tar)) {
+            File dockerTarFile = new File(tar);
+            imageArgument = String.format("--docker.tar=%s", dockerTarFile.getCanonicalPath());
+            imagePiece = dockerTarFile.getName();
+            imageIdentifierType = ImageIdentifierType.TAR;
+        } else if (StringUtils.isNotBlank(image)) {
+            imagePiece = image;
+            imageArgument = String.format("--docker.image=%s", image);
+            imageIdentifierType = ImageIdentifierType.IMAGE_NAME;
+        } else if (StringUtils.isNotBlank(imageId)) {
+            imagePiece = imageId;
+            imageArgument = String.format("--docker.image.id=%s", imageId);
+            imageIdentifierType = ImageIdentifierType.IMAGE_ID;
+        }
 
-            if (StringUtils.isBlank(imageArgument) || StringUtils.isBlank(imagePiece)) {
-                return new Extraction.Builder().failure("No docker image found.").build();
-            } else {
-                return executeDocker(outputDirectory, imageIdentifierType, imageArgument, imagePiece, tar, directory, javaExe, dockerExe, dockerInspectorInfo, dockerProperties);
-            }
-        } catch (Exception e) {
-            return new Extraction.Builder().exception(e).build();
+        if (StringUtils.isBlank(imageArgument) || StringUtils.isBlank(imagePiece)) {
+            return new Extraction.Builder().failure("No docker image found.").build();
+        } else {
+            return executeDocker(outputDirectory, imageIdentifierType, imageArgument, imagePiece, tar, directory, javaExe, dockerExe, dockerInspectorInfo, dockerProperties);
         }
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/DockerExtractor.java
@@ -31,7 +31,7 @@ import com.synopsys.integration.detectable.ExecutableTarget;
 import com.synopsys.integration.detectable.ExecutableUtils;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectable.executable.DetectableExecutableRunner;
-import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+import com.synopsys.integration.detectable.detectables.docker.model.DockerInspectorResults;
 import com.synopsys.integration.detectable.detectables.docker.parser.DockerInspectorResultsFileParser;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionMetadata;
@@ -43,8 +43,6 @@ import com.synopsys.integration.executable.ExecutableRunnerException;
 public class DockerExtractor {
     public static final ExtractionMetadata<File> DOCKER_TAR_META_DATA = new ExtractionMetadata<>("dockerTar", File.class);
     public static final ExtractionMetadata<String> DOCKER_IMAGE_NAME_META_DATA = new ExtractionMetadata<>("dockerImage", String.class);
-    // TODO remove this
-    public static final ExtractionMetadata<String> DOCKER_IMAGE_ID_META_DATA = new ExtractionMetadata<>("dockerImageId", String.class);
     public static final ExtractionMetadata<File> SQUASHED_IMAGE_META_DATA = new ExtractionMetadata<>("squashedImage", File.class);
     public static final ExtractionMetadata<File> CONTAINER_FILESYSTEM_META_DATA = new ExtractionMetadata<>("containerFilesystem", File.class);
 
@@ -187,13 +185,13 @@ public class DockerExtractor {
         }
 
         Extraction.Builder extractionBuilder = findCodeLocations(outputDirectory, directory);
-        Optional<DockerImageInfo> dockerResults = Optional.empty();
+        Optional<DockerInspectorResults> dockerResults = Optional.empty();
         File producedResultFile = fileFinder.findFile(outputDirectory, RESULTS_FILENAME_PATTERN);
         if (producedResultFile != null) {
             String resultsFileContents = FileUtils.readFileToString(producedResultFile, StandardCharsets.UTF_8);
             dockerResults = dockerInspectorResultsFileParser.parse(resultsFileContents);
         }
-        String imageIdentifier = imageIdentifierGenerator.deriveImageIdentifier(imageIdentifierType, suppliedImagePiece, dockerResults.orElse(null));
+        String imageIdentifier = imageIdentifierGenerator.generate(imageIdentifierType, suppliedImagePiece, dockerResults.orElse(null));
         // The value of DOCKER_IMAGE_NAME_META_DATA is built into the codelocation name, so changing how its value is derived is likely to
         // change how codelocation names are generated. Currently either an image repo, repo:tag, or tarfile path gets written there.
         // It's tempting to always store the image repo:tag in that field, but that would change code location naming with consequences for users.

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/ImageIdentifierGenerator.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/ImageIdentifierGenerator.java
@@ -3,11 +3,11 @@ package com.synopsys.integration.detectable.detectables.docker;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
-import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+import com.synopsys.integration.detectable.detectables.docker.model.DockerInspectorResults;
 
 public class ImageIdentifierGenerator {
 
-    public String deriveImageIdentifier(ImageIdentifierType imageIdentifierType, String suppliedImagePiece, @Nullable DockerImageInfo dockerResults) {
+    public String generate(ImageIdentifierType imageIdentifierType, String suppliedImagePiece, @Nullable DockerInspectorResults dockerResults) {
         if (imageIdentifierType.equals(ImageIdentifierType.IMAGE_ID) && (dockerResults != null) &&
             StringUtils.isNotBlank(dockerResults.getImageRepo()) && StringUtils.isNotBlank(dockerResults.getImageTag())) {
             return dockerResults.getImageRepo() + ":" + dockerResults.getImageTag();

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/ImageIdentifierGenerator.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/ImageIdentifierGenerator.java
@@ -8,8 +8,11 @@ import com.synopsys.integration.detectable.detectables.docker.model.DockerInspec
 public class ImageIdentifierGenerator {
 
     public String generate(ImageIdentifierType imageIdentifierType, String suppliedImagePiece, @Nullable DockerInspectorResults dockerResults) {
-        if (imageIdentifierType.equals(ImageIdentifierType.IMAGE_ID) && (dockerResults != null) &&
-            StringUtils.isNotBlank(dockerResults.getImageRepo()) && StringUtils.isNotBlank(dockerResults.getImageTag())) {
+        if (imageIdentifierType.equals(ImageIdentifierType.IMAGE_ID)
+            && (dockerResults != null)
+            && StringUtils.isNotBlank(dockerResults.getImageRepo())
+            && StringUtils.isNotBlank(dockerResults.getImageTag())
+        ) {
             return dockerResults.getImageRepo() + ":" + dockerResults.getImageTag();
         }
         return suppliedImagePiece;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/ImageIdentifierGenerator.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/ImageIdentifierGenerator.java
@@ -1,0 +1,17 @@
+package com.synopsys.integration.detectable.detectables.docker;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+
+public class ImageIdentifierGenerator {
+
+    public String deriveImageIdentifier(ImageIdentifierType imageIdentifierType, String suppliedImagePiece, @Nullable DockerImageInfo dockerResults) {
+        if (imageIdentifierType.equals(ImageIdentifierType.IMAGE_ID) && (dockerResults != null) &&
+            StringUtils.isNotBlank(dockerResults.getImageRepo()) && StringUtils.isNotBlank(dockerResults.getImageTag())) {
+            return dockerResults.getImageRepo() + ":" + dockerResults.getImageTag();
+        }
+        return suppliedImagePiece;
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/model/DockerImageInfo.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/model/DockerImageInfo.java
@@ -1,12 +1,15 @@
 package com.synopsys.integration.detectable.detectables.docker.model;
 
+// TODO rename this class to DockerInspectorResults
 public class DockerImageInfo {
     private final String imageRepo;
     private final String imageTag;
+    private final String message;
 
-    public DockerImageInfo(String imageRepo, String imageTag) {
+    public DockerImageInfo(String imageRepo, String imageTag, String message) {
         this.imageRepo = imageRepo;
         this.imageTag = imageTag;
+        this.message = message;
     }
 
     public String getImageRepo() {
@@ -15,5 +18,9 @@ public class DockerImageInfo {
 
     public String getImageTag() {
         return imageTag;
+    }
+
+    public String getMessage() {
+        return message;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/model/DockerInspectorResults.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/model/DockerInspectorResults.java
@@ -1,12 +1,11 @@
 package com.synopsys.integration.detectable.detectables.docker.model;
 
-// TODO rename this class to DockerInspectorResults
-public class DockerImageInfo {
+public class DockerInspectorResults {
     private final String imageRepo;
     private final String imageTag;
     private final String message;
 
-    public DockerImageInfo(String imageRepo, String imageTag, String message) {
+    public DockerInspectorResults(String imageRepo, String imageTag, String message) {
         this.imageRepo = imageRepo;
         this.imageTag = imageTag;
         this.message = message;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/parser/DockerInspectorResultsFileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/parser/DockerInspectorResultsFileParser.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
-import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+import com.synopsys.integration.detectable.detectables.docker.model.DockerInspectorResults;
 
 public class DockerInspectorResultsFileParser {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -17,9 +17,9 @@ public class DockerInspectorResultsFileParser {
         this.gson = gson;
     }
 
-    public Optional<DockerImageInfo> parse(String resultsFileContents) {
+    public Optional<DockerInspectorResults> parse(String resultsFileContents) {
         try {
-            DockerImageInfo results = gson.fromJson(resultsFileContents, DockerImageInfo.class);
+            DockerInspectorResults results = gson.fromJson(resultsFileContents, DockerInspectorResults.class);
             return Optional.of(results);
         } catch (JsonSyntaxException e) {
             logger.warn("Failed to parse results file from run of Docker Inspector; results file contents: {}", resultsFileContents);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/parser/DockerInspectorResultsFileParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/docker/parser/DockerInspectorResultsFileParser.java
@@ -1,0 +1,29 @@
+package com.synopsys.integration.detectable.detectables.docker.parser;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+
+public class DockerInspectorResultsFileParser {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Gson gson;
+
+    public DockerInspectorResultsFileParser(Gson gson) {
+        this.gson = gson;
+    }
+
+    public Optional<DockerImageInfo> parse(String resultsFileContents) {
+        try {
+            DockerImageInfo results = gson.fromJson(resultsFileContents, DockerImageInfo.class);
+            return Optional.of(results);
+        } catch (JsonSyntaxException e) {
+            logger.warn("Failed to parse results file from run of Docker Inspector; results file contents: {}", resultsFileContents);
+            return Optional.empty();
+        }
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -126,6 +126,8 @@ import com.synopsys.integration.detectable.detectables.docker.DockerDetectable;
 import com.synopsys.integration.detectable.detectables.docker.DockerDetectableOptions;
 import com.synopsys.integration.detectable.detectables.docker.DockerExtractor;
 import com.synopsys.integration.detectable.detectables.docker.DockerInspectorResolver;
+import com.synopsys.integration.detectable.detectables.docker.ImageIdentifierGenerator;
+import com.synopsys.integration.detectable.detectables.docker.parser.DockerInspectorResultsFileParser;
 import com.synopsys.integration.detectable.detectables.git.GitDetectable;
 import com.synopsys.integration.detectable.detectables.git.GitParseDetectable;
 import com.synopsys.integration.detectable.detectables.git.cli.GitCliExtractor;
@@ -1012,7 +1014,15 @@ public class DetectableFactory {
     }
 
     private DockerExtractor dockerExtractor() {
-        return new DockerExtractor(fileFinder, executableRunner, new BdioTransformer(), new ExternalIdFactory(), gson);
+        return new DockerExtractor(
+            fileFinder,
+            executableRunner,
+            new BdioTransformer(),
+            new ExternalIdFactory(),
+            gson,
+            new DockerInspectorResultsFileParser(gson),
+            new ImageIdentifierGenerator()
+        );
     }
 
     private GoGradleLockParser goGradleLockParser() {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerExtractorTest.java
@@ -57,7 +57,7 @@ public class DockerExtractorTest {
 
     @Test
     @DisabledOnOs(WINDOWS)
-    public void testExtractImageReturningContainerFileSystem() throws ExecutableRunnerException {
+    public void testExtractImageReturningContainerFileSystem() throws ExecutableRunnerException, IOException {
 
         final String image = "ubuntu:latest";
         String imageId = null;
@@ -83,7 +83,7 @@ public class DockerExtractorTest {
 
     @Test
     @DisabledOnOs(WINDOWS)
-    public void testExtractImageReturningSquashedImage() throws ExecutableRunnerException {
+    public void testExtractImageReturningSquashedImage() throws ExecutableRunnerException, IOException {
 
         final String image = "ubuntu:latest";
         String imageId = null;
@@ -109,7 +109,7 @@ public class DockerExtractorTest {
 
     @Test
     @DisabledOnOs(WINDOWS)
-    public void testExtractTarReturningContainerFileSystem() throws ExecutableRunnerException {
+    public void testExtractTarReturningContainerFileSystem() throws ExecutableRunnerException, IOException {
 
         String image = null;
         String imageId = null;
@@ -136,7 +136,7 @@ public class DockerExtractorTest {
 
     @Test
     @DisabledOnOs(WINDOWS)
-    public void testExtractTarReturningOriginalTar() throws ExecutableRunnerException {
+    public void testExtractTarReturningOriginalTar() throws ExecutableRunnerException, IOException {
 
         String image = null;
         String imageId = null;
@@ -191,7 +191,7 @@ public class DockerExtractorTest {
         File returnedSquashedImageFile,
         File resultsFile,
         DetectableExecutableRunner executableRunner
-    ) {
+    ) throws IOException, ExecutableRunnerException {
         FileFinder fileFinder = Mockito.mock(FileFinder.class);
         DockerExtractor dockerExtractor = getMockDockerExtractor(executableRunner, fileFinder);
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerExtractorTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import com.synopsys.integration.detectable.detectables.docker.model.DockerInspec
 import com.synopsys.integration.detectable.detectables.docker.parser.DockerInspectorResultsFileParser;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.executable.Executable;
+import com.synopsys.integration.executable.ExecutableOutput;
 import com.synopsys.integration.executable.ExecutableRunnerException;
 
 public class DockerExtractorTest {
@@ -60,7 +62,7 @@ public class DockerExtractorTest {
         final String image = "ubuntu:latest";
         String imageId = null;
         String tar = null;
-        DetectableExecutableRunner executableRunner = Mockito.mock(DetectableExecutableRunner.class);
+        DetectableExecutableRunner executableRunner = getDetectableExecutableRunner();
 
         Extraction extraction = extract(image, imageId, tar, fakeContainerFileSystemFile, null, fakeResultsFile, executableRunner);
 
@@ -86,7 +88,7 @@ public class DockerExtractorTest {
         final String image = "ubuntu:latest";
         String imageId = null;
         String tar = null;
-        DetectableExecutableRunner executableRunner = Mockito.mock(DetectableExecutableRunner.class);
+        DetectableExecutableRunner executableRunner = getDetectableExecutableRunner();
 
         Extraction extraction = extract(image, imageId, tar, fakeContainerFileSystemFile, fakeSquashedImageFile, fakeResultsFile, executableRunner);
 
@@ -112,7 +114,7 @@ public class DockerExtractorTest {
         String image = null;
         String imageId = null;
         String tar = fakeDockerTarFile.getAbsolutePath();
-        DetectableExecutableRunner executableRunner = Mockito.mock(DetectableExecutableRunner.class);
+        DetectableExecutableRunner executableRunner = getDetectableExecutableRunner();
 
         Extraction extraction = extract(image, imageId, tar, fakeContainerFileSystemFile, null, fakeResultsFile, executableRunner);
 
@@ -139,7 +141,7 @@ public class DockerExtractorTest {
         String image = null;
         String imageId = null;
         String tar = fakeDockerTarFile.getAbsolutePath();
-        DetectableExecutableRunner executableRunner = Mockito.mock(DetectableExecutableRunner.class);
+        DetectableExecutableRunner executableRunner = getDetectableExecutableRunner();
 
         Extraction extraction = extract(image, imageId, tar, null, null, fakeResultsFile, executableRunner);
 
@@ -158,6 +160,15 @@ public class DockerExtractorTest {
         assertTrue(command.get(3).endsWith("/application.properties"));
         assertTrue(command.get(4).startsWith("--docker.tar="));
         assertTrue(command.get(4).endsWith("testDockerTarfile.tar"));
+    }
+
+    @NotNull
+    private DetectableExecutableRunner getDetectableExecutableRunner() throws ExecutableRunnerException {
+        DetectableExecutableRunner executableRunner = Mockito.mock(DetectableExecutableRunner.class);
+        ExecutableOutput executableOutput = Mockito.mock(ExecutableOutput.class);
+        Mockito.when(executableOutput.getReturnCode()).thenReturn(0);
+        Mockito.when(executableRunner.execute(Mockito.any(Executable.class))).thenReturn(executableOutput);
+        return executableRunner;
     }
 
     private DockerExtractor getMockDockerExtractor(DetectableExecutableRunner executableRunner, FileFinder fileFinder) {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/DockerExtractorTest.java
@@ -27,7 +27,7 @@ import com.synopsys.integration.detectable.detectables.docker.DockerExtractor;
 import com.synopsys.integration.detectable.detectables.docker.DockerInspectorInfo;
 import com.synopsys.integration.detectable.detectables.docker.DockerProperties;
 import com.synopsys.integration.detectable.detectables.docker.ImageIdentifierGenerator;
-import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+import com.synopsys.integration.detectable.detectables.docker.model.DockerInspectorResults;
 import com.synopsys.integration.detectable.detectables.docker.parser.DockerInspectorResultsFileParser;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.executable.Executable;
@@ -165,7 +165,7 @@ public class DockerExtractorTest {
         ExternalIdFactory externalIdFactory = Mockito.mock(ExternalIdFactory.class);
         Gson gson = new Gson();
         DockerInspectorResultsFileParser dockerInspectorResultsFileParser = Mockito.mock(DockerInspectorResultsFileParser.class);
-        DockerImageInfo dockerInspectorResults = new DockerImageInfo("returnedimage", "returnedtag", "returned message");
+        DockerInspectorResults dockerInspectorResults = new DockerInspectorResults("returnedimage", "returnedtag", "returned message");
         Mockito.when(dockerInspectorResultsFileParser.parse(Mockito.anyString())).thenReturn(Optional.of(dockerInspectorResults));
         ImageIdentifierGenerator imageIdentifierGenerator = new ImageIdentifierGenerator();
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/ImageIdentifierGeneratorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/ImageIdentifierGeneratorTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.detectable.detectables.docker.ImageIdentifierGenerator;
 import com.synopsys.integration.detectable.detectables.docker.ImageIdentifierType;
-import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+import com.synopsys.integration.detectable.detectables.docker.model.DockerInspectorResults;
 
 public class ImageIdentifierGeneratorTest {
     private static ImageIdentifierGenerator generator;
@@ -19,25 +19,25 @@ public class ImageIdentifierGeneratorTest {
 
     @Test
     void testImageName() {
-        DockerImageInfo dockerImageInfo = new DockerImageInfo("returnedrepo", "returnedtag", "success");
-        assertEquals("suppliedrepo:suppliedtag", generator.deriveImageIdentifier(ImageIdentifierType.IMAGE_NAME, "suppliedrepo:suppliedtag", dockerImageInfo));
+        DockerInspectorResults dockerInspectorResults = new DockerInspectorResults("returnedrepo", "returnedtag", "success");
+        assertEquals("suppliedrepo:suppliedtag", generator.generate(ImageIdentifierType.IMAGE_NAME, "suppliedrepo:suppliedtag", dockerInspectorResults));
     }
 
     @Test
     void testImageId() {
-        DockerImageInfo dockerImageInfo = new DockerImageInfo("returnedrepo", "returnedtag", "success");
-        assertEquals("returnedrepo:returnedtag", generator.deriveImageIdentifier(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerImageInfo));
+        DockerInspectorResults dockerInspectorResults = new DockerInspectorResults("returnedrepo", "returnedtag", "success");
+        assertEquals("returnedrepo:returnedtag", generator.generate(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerInspectorResults));
     }
 
     @Test
     void testMissingReturnedRepo() {
-        DockerImageInfo dockerImageInfo = new DockerImageInfo(null, "returnedtag", "success");
-        assertEquals("suppliedrepo:suppliedtag", generator.deriveImageIdentifier(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerImageInfo));
+        DockerInspectorResults dockerInspectorResults = new DockerInspectorResults(null, "returnedtag", "success");
+        assertEquals("suppliedrepo:suppliedtag", generator.generate(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerInspectorResults));
     }
 
     @Test
     void testMissingReturnedTag() {
-        DockerImageInfo dockerImageInfo = new DockerImageInfo("returnedrepo", null, "success");
-        assertEquals("suppliedrepo:suppliedtag", generator.deriveImageIdentifier(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerImageInfo));
+        DockerInspectorResults dockerInspectorResults = new DockerInspectorResults("returnedrepo", null, "success");
+        assertEquals("suppliedrepo:suppliedtag", generator.generate(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerInspectorResults));
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/ImageIdentifierGeneratorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/ImageIdentifierGeneratorTest.java
@@ -9,7 +9,7 @@ import com.synopsys.integration.detectable.detectables.docker.ImageIdentifierGen
 import com.synopsys.integration.detectable.detectables.docker.ImageIdentifierType;
 import com.synopsys.integration.detectable.detectables.docker.model.DockerInspectorResults;
 
-public class ImageIdentifierGeneratorTest {
+class ImageIdentifierGeneratorTest {
     private static ImageIdentifierGenerator generator;
 
     @BeforeAll

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/ImageIdentifierGeneratorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/docker/unit/ImageIdentifierGeneratorTest.java
@@ -1,0 +1,43 @@
+package com.synopsys.integration.detectable.detectables.docker.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detectable.detectables.docker.ImageIdentifierGenerator;
+import com.synopsys.integration.detectable.detectables.docker.ImageIdentifierType;
+import com.synopsys.integration.detectable.detectables.docker.model.DockerImageInfo;
+
+public class ImageIdentifierGeneratorTest {
+    private static ImageIdentifierGenerator generator;
+
+    @BeforeAll
+    static void setup() {
+        generator = new ImageIdentifierGenerator();
+    }
+
+    @Test
+    void testImageName() {
+        DockerImageInfo dockerImageInfo = new DockerImageInfo("returnedrepo", "returnedtag", "success");
+        assertEquals("suppliedrepo:suppliedtag", generator.deriveImageIdentifier(ImageIdentifierType.IMAGE_NAME, "suppliedrepo:suppliedtag", dockerImageInfo));
+    }
+
+    @Test
+    void testImageId() {
+        DockerImageInfo dockerImageInfo = new DockerImageInfo("returnedrepo", "returnedtag", "success");
+        assertEquals("returnedrepo:returnedtag", generator.deriveImageIdentifier(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerImageInfo));
+    }
+
+    @Test
+    void testMissingReturnedRepo() {
+        DockerImageInfo dockerImageInfo = new DockerImageInfo(null, "returnedtag", "success");
+        assertEquals("suppliedrepo:suppliedtag", generator.deriveImageIdentifier(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerImageInfo));
+    }
+
+    @Test
+    void testMissingReturnedTag() {
+        DockerImageInfo dockerImageInfo = new DockerImageInfo("returnedrepo", null, "success");
+        assertEquals("suppliedrepo:suppliedtag", generator.deriveImageIdentifier(ImageIdentifierType.IMAGE_ID, "suppliedrepo:suppliedtag", dockerImageInfo));
+    }
+}

--- a/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,13 +120,7 @@ public class DetectableTool {
 
         if (!extraction.isSuccess()) {
             logger.error("Extraction was not success.");
-            List<String> errorMessages = new LinkedList<>();
-            if (StringUtils.isNotBlank(extraction.getDescription())) {
-                errorMessages.add(extraction.getDescription());
-            }
-            if (extraction.getError() != null && StringUtils.isNotBlank(extraction.getError().getMessage())) {
-                errorMessages.add(extraction.getError().getMessage());
-            }
+            List<String> errorMessages = collectErrorMessages(extraction);
             statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.DETECTABLE_TOOL, "Detectable Tool Issue", errorMessages));
             statusEventPublisher.publishStatusSummary(new Status(name, StatusType.FAILURE));
             exitCodePublisher.publishExitCode(new ExitCodeRequest(ExitCodeType.FAILURE_GENERAL_ERROR, extraction.getDescription()));
@@ -149,5 +144,17 @@ public class DetectableTool {
         logger.debug("Tool finished.");
 
         return DetectableToolResult.success(detectCodeLocations, projectInfo, dockerTargetData);
+    }
+
+    @NotNull
+    private List<String> collectErrorMessages(Extraction extraction) {
+        List<String> errorMessages = new LinkedList<>();
+        if (StringUtils.isNotBlank(extraction.getDescription())) {
+            errorMessages.add(extraction.getDescription());
+        }
+        if (extraction.getError() != null && StringUtils.isNotBlank(extraction.getError().getMessage())) {
+            errorMessages.add(extraction.getError().getMessage());
+        }
+        return errorMessages;
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.detect.tool;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -21,6 +22,8 @@ import com.synopsys.integration.detect.tool.detector.CodeLocationConverter;
 import com.synopsys.integration.detect.tool.detector.extraction.ExtractionEnvironmentProvider;
 import com.synopsys.integration.detect.workflow.codelocation.DetectCodeLocation;
 import com.synopsys.integration.detect.workflow.project.DetectToolProjectInfo;
+import com.synopsys.integration.detect.workflow.status.DetectIssue;
+import com.synopsys.integration.detect.workflow.status.DetectIssueType;
 import com.synopsys.integration.detect.workflow.status.Status;
 import com.synopsys.integration.detect.workflow.status.StatusEventPublisher;
 import com.synopsys.integration.detect.workflow.status.StatusType;
@@ -97,6 +100,7 @@ public class DetectableTool {
 
         if (!extractable.getPassed()) {
             logger.error(String.format("Was not extractable: %s", extractable.toDescription()));
+            statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.DETECTABLE_TOOL, "Detectable Tool Issue", Arrays.asList(extractable.toDescription())));
             statusEventPublisher.publishStatusSummary(new Status(name, StatusType.FAILURE));
             exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_GENERAL_ERROR, extractable.toDescription());
             return DetectableToolResult.failed(extractable);
@@ -114,6 +118,7 @@ public class DetectableTool {
 
         if (!extraction.isSuccess()) {
             logger.error("Extraction was not success.");
+            statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.DETECTABLE_TOOL, "Detectable Tool Issue", Arrays.asList(extraction.getDescription())));
             statusEventPublisher.publishStatusSummary(new Status(name, StatusType.FAILURE));
             exitCodePublisher.publishExitCode(new ExitCodeRequest(ExitCodeType.FAILURE_GENERAL_ERROR, extraction.getDescription()));
             return DetectableToolResult.failed();

--- a/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
@@ -115,7 +115,7 @@ public class DetectableTool {
         if (!extraction.isSuccess()) {
             logger.error("Extraction was not success.");
             statusEventPublisher.publishStatusSummary(new Status(name, StatusType.FAILURE));
-            exitCodePublisher.publishExitCode(new ExitCodeRequest(ExitCodeType.FAILURE_GENERAL_ERROR, extractable.toDescription()));
+            exitCodePublisher.publishExitCode(new ExitCodeRequest(ExitCodeType.FAILURE_GENERAL_ERROR, extraction.getDescription()));
             return DetectableToolResult.failed();
         } else {
             logger.debug("Extraction success.");

--- a/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/DetectableTool.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -118,7 +119,14 @@ public class DetectableTool {
 
         if (!extraction.isSuccess()) {
             logger.error("Extraction was not success.");
-            statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.DETECTABLE_TOOL, "Detectable Tool Issue", Arrays.asList(extraction.getDescription())));
+            List<String> errorMessages = new LinkedList<>();
+            if (StringUtils.isNotBlank(extraction.getDescription())) {
+                errorMessages.add(extraction.getDescription());
+            }
+            if (extraction.getError() != null && StringUtils.isNotBlank(extraction.getError().getMessage())) {
+                errorMessages.add(extraction.getError().getMessage());
+            }
+            statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.DETECTABLE_TOOL, "Detectable Tool Issue", errorMessages));
             statusEventPublisher.publishStatusSummary(new Status(name, StatusType.FAILURE));
             exitCodePublisher.publishExitCode(new ExitCodeRequest(ExitCodeType.FAILURE_GENERAL_ERROR, extraction.getDescription()));
             return DetectableToolResult.failed();

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspectors/ArtifactoryDockerInspectorResolver.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspectors/ArtifactoryDockerInspectorResolver.java
@@ -130,7 +130,7 @@ public class ArtifactoryDockerInspectorResolver implements DockerInspectorResolv
         return airGapInspectorImageTarfiles;
     }
 
-    private DockerInspectorInfo findProvidedJar(@NotNull Path providedJarPath) {
+    private DockerInspectorInfo findProvidedJar(@NotNull Path providedJarPath) throws IntegrationException {
         File providedJar = null;
 
         logger.debug(String.format("Using user-provided docker inspector jar path: %s", providedJarPath));
@@ -138,6 +138,8 @@ public class ArtifactoryDockerInspectorResolver implements DockerInspectorResolv
         if (providedJarCandidate.isFile()) {
             logger.debug(String.format("Found user-specified jar: %s", providedJarCandidate.getAbsolutePath()));
             providedJar = providedJarCandidate;
+        } else {
+            throw new IntegrationException(String.format("Provided Docker Inspector path (%s) does not exist or is not a file", providedJarCandidate.getAbsolutePath()));
         }
 
         return new DockerInspectorInfo(providedJar);

--- a/src/main/java/com/synopsys/integration/detect/workflow/status/DetectIssueType.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/DetectIssueType.java
@@ -6,5 +6,6 @@ public enum DetectIssueType {
     DETECTOR,
     SIGNATURE_SCANNER,
     BINARY_SCAN,
-    IMPACT_ANALYSIS
+    IMPACT_ANALYSIS,
+    DETECTABLE_TOOL
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/status/DetectStatusLogger.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/DetectStatusLogger.java
@@ -63,9 +63,11 @@ public class DetectStatusLogger {
             logger.info("");
 
             Predicate<DetectIssue> detectorsFilter = issue -> issue.getType() == DetectIssueType.DETECTOR;
+            Predicate<DetectIssue> detectableToolsFilter = issue -> issue.getType() == DetectIssueType.DETECTABLE_TOOL;
             Predicate<DetectIssue> exceptionsFilter = issue -> issue.getType() == DetectIssueType.EXCEPTION;
             Predicate<DetectIssue> deprecationsFilter = issue -> issue.getType() == DetectIssueType.DEPRECATION;
             logIssuesInGroup(logger, "DETECTORS:", detectorsFilter, detectIssues);
+            logIssuesInGroup(logger, "DETECTABLE TOOLS:", detectableToolsFilter, detectIssues);
             logIssuesInGroup(logger, "EXCEPTIONS:", exceptionsFilter, detectIssues);
             logIssuesInGroup(logger, "DEPRECATIONS:", deprecationsFilter, detectIssues);
         }

--- a/src/test/resources/workflow/status/expectedStatusLoggerOutput.txt
+++ b/src/test/resources/workflow/status/expectedStatusLoggerOutput.txt
@@ -9,6 +9,15 @@ DETECTORS:
 		Junit Test Issue Set 2 primary message: DETECTOR
 		Junit Test Issue Set 2 secondary message: DETECTOR
 
+DETECTABLE TOOLS:
+	Junit Test Issue Set 1 Detect Issue
+		Junit Test Issue Set 1 primary message: DETECTABLE_TOOL
+		Junit Test Issue Set 1 secondary message: DETECTABLE_TOOL
+
+	Junit Test Issue Set 2 Detect Issue
+		Junit Test Issue Set 2 primary message: DETECTABLE_TOOL
+		Junit Test Issue Set 2 secondary message: DETECTABLE_TOOL
+
 EXCEPTIONS:
 	Junit Test Issue Set 1 Detect Issue
 		Junit Test Issue Set 1 primary message: EXCEPTION


### PR DESCRIPTION
In IDETECT-3020 the user wanted a more helpful error message when they pass a docker image in an unsupported file format. Part of the fix is to modify Docker Inspector to send back a better message. These changes make that error message visible to the Detect user as an issue that appears in both the Issues section of the log, and the Issues section of status.json. (It looks like Detectable Tool errors had been inadvertently left out of issues.) With this change, Detectable Tool (Bazel, Docker) errors are published as issues (as detectable errors are).

I've also modified the Bazel extractor to catch exceptions and build them into the Extraction object it returns. That change plus the DetectableTool change described above addresses IDETECT-3207.