### PR TITLE
Print passthroughs

### DIFF
--- a/configuration/src/main/java/com/synopsys/integration/configuration/config/PropertyConfiguration.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/config/PropertyConfiguration.java
@@ -193,6 +193,14 @@ public class PropertyConfiguration {
         for (Property property : properties) {
             String rawKey = property.getKey();
             getRaw(property).ifPresent(rawValue -> rawMap.put(rawKey, maskValue(rawKey, rawValue, shouldMask)));
+            if (property instanceof PassthroughProperty) {
+                getRaw((PassthroughProperty) property).entrySet()
+                    .forEach(passThrough -> {
+                            String fullPassThroughKey = String.format("%s.%s", rawKey, passThrough.getKey()); //TODO- do we want the "full" name?
+                            rawMap.put(fullPassThroughKey, maskValue(fullPassThroughKey, passThrough.getValue(), shouldMask));
+                        }
+                    );
+            }
         }
         return rawMap;
     }
@@ -247,7 +255,7 @@ public class PropertyConfiguration {
     private void assertPropertyNotNull(Property property, @NotNull String message) {
         Assert.notNull(property, message);
     }
-
+    
     private PropertyResolution resolveFromCache(@NotNull String key) {
         Assert.notNull(key, "Cannot resolve a null key.");
         if (!resolutionCache.containsKey(key)) {

--- a/configuration/src/main/java/com/synopsys/integration/configuration/config/PropertyConfiguration.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/config/PropertyConfiguration.java
@@ -192,14 +192,15 @@ public class PropertyConfiguration {
         Map<String, String> rawMap = new HashMap<>();
         for (Property property : properties) {
             String rawKey = property.getKey();
-            getRaw(property).ifPresent(rawValue -> rawMap.put(rawKey, maskValue(rawKey, rawValue, shouldMask)));
             if (property instanceof PassthroughProperty) {
                 getRaw((PassthroughProperty) property).entrySet()
                     .forEach(passThrough -> {
-                            String fullPassThroughKey = String.format("%s.%s", rawKey, passThrough.getKey()); //TODO- do we want the "full" name?
+                            String fullPassThroughKey = String.format("%s.%s", rawKey, passThrough.getKey());
                             rawMap.put(fullPassThroughKey, maskValue(fullPassThroughKey, passThrough.getValue(), shouldMask));
                         }
                     );
+            } else {
+                getRaw(property).ifPresent(rawValue -> rawMap.put(rawKey, maskValue(rawKey, rawValue, shouldMask)));
             }
         }
         return rawMap;
@@ -255,7 +256,7 @@ public class PropertyConfiguration {
     private void assertPropertyNotNull(Property property, @NotNull String message) {
         Assert.notNull(property, message);
     }
-    
+
     private PropertyResolution resolveFromCache(@NotNull String key) {
         Assert.notNull(key, "Cannot resolve a null key.");
         if (!resolutionCache.containsKey(key)) {

--- a/configuration/src/main/java/com/synopsys/integration/configuration/help/PropertyConfigurationHelpContext.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/help/PropertyConfigurationHelpContext.java
@@ -45,11 +45,7 @@ public class PropertyConfigurationHelpContext {
         this.propertyConfiguration = propertyConfiguration;
     }
 
-    public void printCurrentValues(Consumer<String> logger, SortedMap<String, String> maskedRawPropertyValues, Map<String, String> additionalNotes) {
-        printKnownCurrentValues(logger, maskedRawPropertyValues, additionalNotes);
-    }
-
-    public void printKnownCurrentValues(
+    public void printCurrentValues(
         Consumer<String> logger,
         SortedMap<String, String> maskedRawPropertyValues,
         Map<String, String> additionalNotes

--- a/configuration/src/main/java/com/synopsys/integration/configuration/help/PropertyConfigurationHelpContext.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/help/PropertyConfigurationHelpContext.java
@@ -46,12 +46,11 @@ public class PropertyConfigurationHelpContext {
     }
 
     public void printCurrentValues(Consumer<String> logger, SortedMap<String, String> maskedRawPropertyValues, Map<String, String> additionalNotes) {
-        printKnownCurrentValues(logger, maskedRawPropertyValues.keySet(), maskedRawPropertyValues, additionalNotes);
+        printKnownCurrentValues(logger, maskedRawPropertyValues, additionalNotes);
     }
 
     public void printKnownCurrentValues(
         Consumer<String> logger,
-        Set<String> knownPropertyKeys,
         SortedMap<String, String> maskedRawPropertyValues,
         Map<String, String> additionalNotes
     ) {
@@ -61,7 +60,6 @@ public class PropertyConfigurationHelpContext {
         logger.accept(StringUtils.repeat("-", 60));
 
         maskedRawPropertyValues.entrySet().stream()
-            .filter(rawPropertyValue -> knownPropertyKeys.contains(rawPropertyValue.getKey()))
             .forEach(rawPropertyValue -> {
                 String rawMaskedValue = maskedRawPropertyValues.get(rawPropertyValue.getKey());
                 String sourceName = propertyConfiguration.getPropertySource(rawPropertyValue.getKey()).orElse("unknown");

--- a/configuration/src/test/java/com/synopsys/integration/configuration/config/PropertyConfigurationTest.java
+++ b/configuration/src/test/java/com/synopsys/integration/configuration/config/PropertyConfigurationTest.java
@@ -240,6 +240,23 @@ public class PropertyConfigurationTest {
     }
 
     @Test
+    public void getRawValueMapWithPassthroughs() {
+        Set<Property> properties = new HashSet<>();
+        PassthroughProperty passthrough = new PassthroughProperty("blackduck.passthrough");
+        properties.add(passthrough);
+
+        Map<String, String> propertyMap = Bds.mapOf(
+            Pair.of("blackduck.passthrough.password", "password")
+        );
+
+        PropertyConfiguration configuration = configOf(propertyMap);
+
+        Map<String, String> rawPropertyValues = configuration.getMaskedRawValueMap(properties, rawKey -> rawKey.contains("password"));
+
+        Assertions.assertEquals("********", rawPropertyValues.get("blackduck.passthrough.password"));
+    }
+
+    @Test
     public void getRawFromKeys() {
         NullableAlikeProperty<String> NullableAlikeProperty = new NullableTestProperty("example.key");
         ValuedAlikeProperty<String> valuedProperty = new ValuedTestProperty("property.two.key", "test");

--- a/src/main/java/com/synopsys/integration/detect/configuration/validation/DetectConfigurationBootManager.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/validation/DetectConfigurationBootManager.java
@@ -3,11 +3,9 @@ package com.synopsys.integration.detect.configuration.validation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 
@@ -93,22 +91,8 @@ public class DetectConfigurationBootManager {
         return new DeprecationResult(additionalNotes);
     }
 
-    public void printConfiguration(SortedMap<String, String> maskedRawPropertyValues, Set<String> propertyKeys, Map<String, String> additionalNotes) {
-        Set<String> passThroughKeys = determinePassthroughKeys(maskedRawPropertyValues.keySet());
-        propertyKeys.addAll(passThroughKeys);
-        detectConfigurationReporter.printKnownCurrentValues(logger::info, propertyKeys, maskedRawPropertyValues, additionalNotes);
-    }
-
-    private Set<String> determinePassthroughKeys(Set<String> maskedRawPropertyKeys) {
-        Set<String> passthroughKeys = new HashSet<>();
-        for (String passthroughPrefix : DETECT_PASSTHROUGH_PREFIXES) {
-            for (String maskedRawPropertyKey : maskedRawPropertyKeys) {
-                if (maskedRawPropertyKey.startsWith(passthroughPrefix)) {
-                    passthroughKeys.add(maskedRawPropertyKey);
-                }
-            }
-        }
-        return passthroughKeys;
+    public void printConfiguration(SortedMap<String, String> maskedRawPropertyValues, Map<String, String> additionalNotes) {
+        detectConfigurationReporter.printKnownCurrentValues(logger::info, maskedRawPropertyValues, additionalNotes);
     }
 
     // Check for options that are just plain bad, ie giving a detector type we don't know about.

--- a/src/main/java/com/synopsys/integration/detect/configuration/validation/DetectConfigurationBootManager.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/validation/DetectConfigurationBootManager.java
@@ -24,8 +24,6 @@ import com.synopsys.integration.detect.workflow.status.DetectIssue;
 import com.synopsys.integration.detect.workflow.status.DetectIssueType;
 
 public class DetectConfigurationBootManager {
-    private static final String[] DETECT_PASSTHROUGH_PREFIXES = { DetectProperties.DOCKER_PASSTHROUGH.getKey() };
-
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final EventSystem eventSystem;
     private final PropertyConfigurationHelpContext detectConfigurationReporter;
@@ -92,7 +90,7 @@ public class DetectConfigurationBootManager {
     }
 
     public void printConfiguration(SortedMap<String, String> maskedRawPropertyValues, Map<String, String> additionalNotes) {
-        detectConfigurationReporter.printKnownCurrentValues(logger::info, maskedRawPropertyValues, additionalNotes);
+        detectConfigurationReporter.printCurrentValues(logger::info, maskedRawPropertyValues, additionalNotes);
     }
 
     // Check for options that are just plain bad, ie giving a detector type we don't know about.

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -116,7 +115,6 @@ public class DetectBoot {
         PropertyConfiguration propertyConfiguration = new PropertyConfiguration(propertySources);
 
         SortedMap<String, String> maskedRawPropertyValues = collectMaskedRawPropertyValues(propertyConfiguration);
-        Set<String> propertyKeys = new HashSet<>(DetectProperties.allProperties().getPropertyKeys());
 
         publishCollectedPropertyValues(maskedRawPropertyValues);
 
@@ -124,7 +122,7 @@ public class DetectBoot {
 
         DetectConfigurationBootManager detectConfigurationBootManager = detectBootFactory.createDetectConfigurationBootManager(propertyConfiguration);
         DeprecationResult deprecationResult = detectConfigurationBootManager.createDeprecationNotesAndPublishEvents(propertyConfiguration);
-        detectConfigurationBootManager.printConfiguration(maskedRawPropertyValues, propertyKeys, deprecationResult.getAdditionalNotes());
+        detectConfigurationBootManager.printConfiguration(maskedRawPropertyValues, deprecationResult.getAdditionalNotes());
 
         Optional<DetectUserFriendlyException> possiblePropertyParseError = detectConfigurationBootManager.validateForPropertyParseErrors();
         if (possiblePropertyParseError.isPresent()) {
@@ -148,8 +146,7 @@ public class DetectBoot {
                 diagnosticDecision.isExtended(),
                 propertyConfiguration,
                 directoryManager,
-                maskedRawPropertyValues,
-                propertyKeys
+                maskedRawPropertyValues
             );
         }
 
@@ -214,7 +211,8 @@ public class DetectBoot {
         }
 
         BootSingletons bootSingletons = detectBootFactory
-            .createRunDependencies(productRunData,
+            .createRunDependencies(
+                productRunData,
                 propertyConfiguration,
                 detectableOptionFactory,
                 detectConfigurationFactory,

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBootFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBootFactory.java
@@ -2,7 +2,6 @@ package com.synopsys.integration.detect.lifecycle.boot;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 import java.util.SortedMap;
 
 import org.apache.commons.lang3.SystemUtils;
@@ -139,10 +138,9 @@ public class DetectBootFactory {
         boolean isDiagnosticExtended,
         PropertyConfiguration detectConfiguration,
         DirectoryManager directoryManager,
-        SortedMap<String, String> maskedRawPropertyValues,
-        Set<String> propertyKeys
+        SortedMap<String, String> maskedRawPropertyValues
     ) {
-        return new DiagnosticSystem(isDiagnosticExtended, detectConfiguration, detectRunId, detectInfo, directoryManager, eventSystem, maskedRawPropertyValues, propertyKeys);
+        return new DiagnosticSystem(isDiagnosticExtended, detectConfiguration, detectRunId, detectInfo, directoryManager, eventSystem, maskedRawPropertyValues);
     }
 
     public AirGapCreator createAirGapCreator(

--- a/src/main/java/com/synopsys/integration/detect/workflow/diagnostic/DiagnosticReportHandler.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/diagnostic/DiagnosticReportHandler.java
@@ -3,7 +3,6 @@ package com.synopsys.integration.detect.workflow.diagnostic;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 
 import org.slf4j.Logger;
@@ -150,13 +149,12 @@ public class DiagnosticReportHandler {
     public void configurationsReport(
         DetectInfo detectInfo,
         PropertyConfiguration propertyConfiguration,
-        SortedMap<String, String> maskedRawPropertyValues,
-        Set<String> propertyKeys
+        SortedMap<String, String> maskedRawPropertyValues
     ) {
         try {
             ReportWriter profileWriter = getReportWriter(ReportTypes.CONFIGURATION);
             ConfigurationReporter reporter = new ConfigurationReporter();
-            reporter.writeReport(profileWriter, detectInfo, propertyConfiguration, maskedRawPropertyValues, propertyKeys);
+            reporter.writeReport(profileWriter, detectInfo, propertyConfiguration, maskedRawPropertyValues);
         } catch (Exception e) {
             logger.error("Failed to write profiling report.", e);
         }

--- a/src/main/java/com/synopsys/integration/detect/workflow/diagnostic/DiagnosticSystem.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/diagnostic/DiagnosticSystem.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 
 import org.slf4j.Logger;
@@ -38,8 +37,7 @@ public class DiagnosticSystem {
         DetectInfo detectInfo,
         DirectoryManager directoryManager,
         EventSystem eventSystem,
-        SortedMap<String, String> maskedRawPropertyValues,
-        Set<String> propertyKeys
+        SortedMap<String, String> maskedRawPropertyValues
     ) {
         this.propertyConfiguration = propertyConfiguration;
         this.detectRunId = detectRunId;
@@ -47,10 +45,10 @@ public class DiagnosticSystem {
         this.directoryManager = directoryManager;
         this.eventSystem = eventSystem;
 
-        init(isExtendedMode, maskedRawPropertyValues, propertyKeys);
+        init(isExtendedMode, maskedRawPropertyValues);
     }
 
-    private void init(boolean isExtendedMode, SortedMap<String, String> maskedRawPropertyValues, Set<String> propertyKeys) {
+    private void init(boolean isExtendedMode, SortedMap<String, String> maskedRawPropertyValues) {
         System.out.println();
         System.out.println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
         System.out.println("Diagnostic mode on.");
@@ -77,7 +75,7 @@ public class DiagnosticSystem {
 
         logger.info("Creating configuration diagnostics reports.");
 
-        diagnosticReportHandler.configurationsReport(detectInfo, propertyConfiguration, maskedRawPropertyValues, propertyKeys);
+        diagnosticReportHandler.configurationsReport(detectInfo, propertyConfiguration, maskedRawPropertyValues);
 
         logger.info("Diagnostics system is ready (extended mode: {}).", isExtendedMode);
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/ConfigurationReporter.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/ConfigurationReporter.java
@@ -1,7 +1,6 @@
 package com.synopsys.integration.detect.workflow.report;
 
 import java.util.HashMap;
-import java.util.Set;
 import java.util.SortedMap;
 
 import com.synopsys.integration.configuration.config.PropertyConfiguration;
@@ -14,8 +13,7 @@ public class ConfigurationReporter {
         ReportWriter writer,
         DetectInfo detectInfo,
         PropertyConfiguration propertyConfiguration,
-        SortedMap<String, String> maskedRawPropertyValues,
-        Set<String> propertyKeys
+        SortedMap<String, String> maskedRawPropertyValues
     ) throws IllegalAccessException {
         writer.writeSeparator();
         writer.writeLine("Detect Info");
@@ -26,7 +24,7 @@ public class ConfigurationReporter {
         writer.writeLine("Detect Configuration");
         writer.writeSeparator();
         PropertyConfigurationHelpContext helpContext = new PropertyConfigurationHelpContext(propertyConfiguration);
-        helpContext.printKnownCurrentValues(writer::writeLine, propertyKeys, maskedRawPropertyValues, new HashMap<>());
+        helpContext.printKnownCurrentValues(writer::writeLine, maskedRawPropertyValues, new HashMap<>());
         writer.writeSeparator();
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/ConfigurationReporter.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/ConfigurationReporter.java
@@ -24,7 +24,7 @@ public class ConfigurationReporter {
         writer.writeLine("Detect Configuration");
         writer.writeSeparator();
         PropertyConfigurationHelpContext helpContext = new PropertyConfigurationHelpContext(propertyConfiguration);
-        helpContext.printKnownCurrentValues(writer::writeLine, maskedRawPropertyValues, new HashMap<>());
+        helpContext.printCurrentValues(writer::writeLine, maskedRawPropertyValues, new HashMap<>());
         writer.writeSeparator();
     }
 }


### PR DESCRIPTION
Resolve passthrough properties when collecting property configuration data.
Remove filtering of raw property value map based on known property keys.
