### PR TITLE
Sb target type clarification

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1573,7 +1573,7 @@ public class DetectProperties {
             .setInfo("Detect Target", DetectPropertyFromVersion.VERSION_7_0_0)
             .setHelp(
                 "Informs detect of what is being scanned which allows improved user experience when scanning different types of targets.",
-                "Changes the behaviour of detect to better suite what is being scanned. For example, when IMAGE is selected, detect will not pick a source directory, will automatically disable the DETECTOR tool and run BINARY/SIGNATURE SCAN on the provided image."
+                "Changes the behaviour of detect to better suite what is being scanned. For example, when IMAGE is selected and the DOCKER tool applies and has not been excluded, detect will not pick a source directory, will automatically disable the DETECTOR tool and run BINARY/SIGNATURE SCAN on the provided image."
             )
             .setGroups(DetectGroup.GENERAL, DetectGroup.GLOBAL)
             .setCategory(DetectCategory.Simple)

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -191,9 +191,9 @@ public class DetectBoot {
             RunDecision runDecision = new RunDecision(detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE); //TODO: Move to proper decision home. -jp
             DetectToolFilter detectToolFilter = detectConfigurationFactory.createToolFilter(runDecision, blackDuckDecision);
             oneRequiresTheOther(
-                runDecision.isDockerMode(),
+                detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE,
                 detectToolFilter.shouldInclude(DetectTool.DOCKER),
-                "Detect target type is set to IMAGE, but the DOCKER tool is excluded"
+                "Detect target type is set to IMAGE, but the DOCKER tool was excluded."
             );
 
             logger.debug("Decided what products will be run. Starting product boot.");
@@ -216,7 +216,7 @@ public class DetectBoot {
             oneRequiresTheOther(
                 detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE,
                 detectableOptionFactory.createDockerDetectableOptions().hasDockerImageOrTar(),
-                "Detect target type is set to IMAGE, but no docker image was specified"
+                "Detect target type is set to IMAGE, but no docker image was specified."
             );
         } catch (DetectUserFriendlyException e) {
             return Optional.of(DetectBootResult.exception(e, propertyConfiguration, directoryManager, diagnosticSystem));


### PR DESCRIPTION
Clarified in propery detect.target.type's description that target type IMAGE requires that the docker tool applies and is not excluded.
Added configuration checks for, and failures on:
1. target type is IMAGE but docker tool is excluded.
2. target type is IMAGE but no docker image was provided.