### PR TITLE
feat: Detectors can nest but not below certain types.

### DIFF
--- a/detector/src/main/java/com/synopsys/integration/detector/result/NotNestableBeneathDetectorResult.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/result/NotNestableBeneathDetectorResult.java
@@ -1,0 +1,9 @@
+package com.synopsys.integration.detector.result;
+
+import com.synopsys.integration.detector.base.DetectorType;
+
+public class NotNestableBeneathDetectorResult extends FailedDetectorResult {
+    public NotNestableBeneathDetectorResult(DetectorType theType) {
+        super("Not nestable below a detector of type: " + theType.toString(), NotNestableBeneathDetectorResult.class);
+    }
+}

--- a/detector/src/main/java/com/synopsys/integration/detector/rule/DetectorRule.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/rule/DetectorRule.java
@@ -1,5 +1,7 @@
 package com.synopsys.integration.detector.rule;
 
+import java.util.Set;
+
 import com.synopsys.integration.detectable.Detectable;
 import com.synopsys.integration.detectable.DetectableEnvironment;
 import com.synopsys.integration.detector.base.DetectableCreatable;
@@ -15,6 +17,7 @@ public class DetectorRule<T extends Detectable> {
     private final DetectorType detectorType;
     private final String name;
     private final boolean nestInvisible;
+    private final Set<DetectorType> notNestableBeneath;
 
     public DetectorRule(
         DetectableCreatable detectableCreatable,
@@ -24,7 +27,8 @@ public class DetectorRule<T extends Detectable> {
         boolean selfNestable,
         DetectorType detectorType,
         String name,
-        boolean nestInvisible
+        boolean nestInvisible,
+        Set<DetectorType> notNestableBeneath
     ) {
         this.detectableCreatable = detectableCreatable;
         this.detectableClass = detectableClass;
@@ -34,6 +38,7 @@ public class DetectorRule<T extends Detectable> {
         this.detectorType = detectorType;
         this.name = name;
         this.nestInvisible = nestInvisible;
+        this.notNestableBeneath = notNestableBeneath;
     }
 
     public DetectableCreatable getDetectableCreatable() {
@@ -74,5 +79,9 @@ public class DetectorRule<T extends Detectable> {
 
     public Class<T> getDetectableClass() {
         return detectableClass;
+    }
+
+    public Set<DetectorType> getNotNestableBeneath() {
+        return notNestableBeneath;
     }
 }

--- a/detector/src/main/java/com/synopsys/integration/detector/rule/DetectorRuleBuilder.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/rule/DetectorRuleBuilder.java
@@ -1,5 +1,9 @@
 package com.synopsys.integration.detector.rule;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import com.synopsys.integration.detectable.Detectable;
 import com.synopsys.integration.detector.base.DetectableCreatable;
 import com.synopsys.integration.detector.base.DetectorType;
@@ -11,6 +15,7 @@ public class DetectorRuleBuilder<T extends Detectable> {
     private boolean nestable;
     private boolean selfNestable = false;
     private boolean nestInvisible = false;
+    private final Set<DetectorType> notNestableBeneath = new HashSet<>();
 
     private final String name;
     private final DetectorType detectorType;
@@ -80,8 +85,17 @@ public class DetectorRuleBuilder<T extends Detectable> {
         return isSelfNestable(false);
     }
 
+    public DetectorRuleBuilder notNestableBeneath(DetectorType... detectorType) {
+        notNestableBeneath.addAll(Arrays.asList(detectorType));
+        return this;
+    }
+
+    public DetectorRuleBuilder nestableExceptTo(DetectorType... detectorType) {
+        return nestable().notNestableBeneath(detectorType);
+    }
+
     public DetectorRule build() {
-        DetectorRule rule = new DetectorRule(detectableCreatable, detectableClass, maxDepth, nestable, selfNestable, detectorType, name, nestInvisible);
+        DetectorRule rule = new DetectorRule(detectableCreatable, detectableClass, maxDepth, nestable, selfNestable, detectorType, name, nestInvisible, notNestableBeneath);
         if (detectorRuleSetBuilder != null) {
             detectorRuleSetBuilder.add(rule);
         }

--- a/detector/src/test/java/com/synopsys/integration/detector/evaluation/DetectorRuleSetEvaluatorTest.java
+++ b/detector/src/test/java/com/synopsys/integration/detector/evaluation/DetectorRuleSetEvaluatorTest.java
@@ -6,12 +6,19 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.github.jsonldjava.shaded.com.google.common.collect.Sets;
+import com.synopsys.integration.detectable.detectables.swift.SwiftCliDetectable;
+import com.synopsys.integration.detectable.detectables.xcode.XcodeSwiftDetectable;
+import com.synopsys.integration.detector.base.DetectorType;
 import com.synopsys.integration.detector.result.DetectorResult;
+import com.synopsys.integration.detector.result.NotNestableBeneathDetectorResult;
 import com.synopsys.integration.detector.rule.DetectorRule;
 import com.synopsys.integration.detector.rule.DetectorRuleSet;
+import com.synopsys.integration.detector.rule.DetectorRuleSetBuilder;
 
 public class DetectorRuleSetEvaluatorTest {
 
@@ -35,5 +42,21 @@ public class DetectorRuleSetEvaluatorTest {
         DetectorResult result = evaluator.evaluateSearchable(detectorRuleSet, detectorRule, environment);
 
         assertTrue(result.getPassed());
+    }
+
+    @Test
+    public void nestableExcept() {
+        DetectorRuleSetBuilder ruleSet = new DetectorRuleSetBuilder();
+
+        DetectorRule xcode = ruleSet.addDetector(DetectorType.XCODE, "Xcode", XcodeSwiftDetectable.class, (e) -> null).defaults().build();
+        DetectorRule swift = ruleSet.addDetector(DetectorType.SWIFT, "Swift", SwiftCliDetectable.class, (e) -> null).defaults().nestableExceptTo(DetectorType.XCODE).build();
+
+        //XCODE applied at depth 0, we are now scanning a folder at depth 2.
+        Set<DetectorRule> appliedToParent = Sets.newHashSet();
+        Set<DetectorRule> appliedSoFar = Sets.newHashSet(xcode);
+        SearchEnvironment searchEnvironment = new SearchEnvironment(2, (d) -> true, false, false, appliedToParent, appliedSoFar);
+        DetectorResult result = new DetectorRuleSetEvaluator().evaluateSearchable(ruleSet.build(), swift, searchEnvironment);
+
+        Assertions.assertEquals(NotNestableBeneathDetectorResult.class, result.getClass());
     }
 }


### PR DESCRIPTION
You can specify specific types you can't nest below. The way I would recommend using it would be ".defaults().nestableExcept(DetectorType.XCODE)". I think this works as expected. 