### PR TITLE
style: log build date

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ final def resources = new File("${projectDir}/src/main/resources")
 final def versionFile = new File(resources, "version.txt")
 resources.mkdirs()
 versionFile.delete()
-versionFile << version
+versionFile << "version=" << version << "\n" << "builddate=" << new Date().format('yyyy-MM-dd')
 
 // By default, starting in 2.5.0, spring boot creates an extra "plain" .jar that we don't want
 jar {

--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -170,7 +170,7 @@ public class Application implements ApplicationRunner {
             DetectBootFactory detectBootFactory = new DetectBootFactory(detectRunId, detectInfo, gson, eventSystem, fileFinder);
             DetectBoot detectBoot = new DetectBoot(eventSystem, gson, detectBootFactory, detectArgumentState, propertySources, installedToolManager);
 
-            bootResult = detectBoot.boot(detectInfo.getDetectVersion());
+            bootResult = detectBoot.boot(detectInfo.getDetectVersion(), detectInfo.getBuildDateString());
 
             logger.debug("Detect boot completed.");
         } catch (Exception e) {

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectInfo.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectInfo.java
@@ -5,10 +5,12 @@ import com.synopsys.integration.util.OperatingSystemType;
 public class DetectInfo {
     private final OperatingSystemType currentOs;
     private final String detectVersion;
+    private final String buildDateString;
 
-    public DetectInfo(String detectVersionText, OperatingSystemType currentOs) {
+    public DetectInfo(String detectVersionText, OperatingSystemType currentOs, String buildDateString) {
         this.detectVersion = detectVersionText;
         this.currentOs = currentOs;
+        this.buildDateString = buildDateString;
     }
 
     public String getDetectVersion() {
@@ -19,4 +21,7 @@ public class DetectInfo {
         return currentOs;
     }
 
+    public String getBuildDateString() {
+        return buildDateString;
+    }
 }

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectInfoUtility.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectInfoUtility.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.detect.configuration;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -21,11 +22,13 @@ public class DetectInfoUtility {
     }
 
     public DetectInfo createDetectInfo() {
-        String versionText = findDetectVersionFromResources();
+        List<String> detectVersionFileContents = readDetectVersionFile();
+        String versionText = parseValueromVersionFileContents(detectVersionFileContents, "version");
+        String buildDateText = parseValueromVersionFileContents(detectVersionFileContents, "builddate");
         OperatingSystemType os = findOperatingSystemType();
         logger.debug(String.format("You seem to be running in a %s operating system.", os));
         logger.debug(String.format("You seem to be using %s architecture.", StringUtils.join(findArchitectures(), ", ")));
-        return new DetectInfo(versionText, os);
+        return new DetectInfo(versionText, os, buildDateText);
     }
 
     public List<String> findArchitectures() {
@@ -34,12 +37,21 @@ public class DetectInfoUtility {
             .toList();
     }
 
-    public String findDetectVersionFromResources() {
+    public List<String> readDetectVersionFile() {
         try {
-            return ResourceUtil.getResourceAsString(this.getClass(), "/version.txt", StandardCharsets.UTF_8.toString());
+            String versionFileContents = ResourceUtil.getResourceAsString(this.getClass(), "/version.txt", StandardCharsets.UTF_8.toString());
+            return Arrays.asList(versionFileContents.split("\n"));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public String parseValueromVersionFileContents(List<String> versionFileContents, String variableName) {
+        return versionFileContents.stream()
+            .filter(s -> s.startsWith(variableName + "="))
+            .map(s -> StringUtils.removeStart(s, variableName + "="))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("Error parsing version string from version file"));
     }
 
     public OperatingSystemType findOperatingSystemType() {

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectInfoUtility.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectInfoUtility.java
@@ -23,8 +23,8 @@ public class DetectInfoUtility {
 
     public DetectInfo createDetectInfo() {
         List<String> detectVersionFileContents = readDetectVersionFile();
-        String versionText = parseValueromVersionFileContents(detectVersionFileContents, "version");
-        String buildDateText = parseValueromVersionFileContents(detectVersionFileContents, "builddate");
+        String versionText = parseValueFromVersionFileContents(detectVersionFileContents, "version");
+        String buildDateText = parseValueFromVersionFileContents(detectVersionFileContents, "builddate");
         OperatingSystemType os = findOperatingSystemType();
         logger.debug(String.format("You seem to be running in a %s operating system.", os));
         logger.debug(String.format("You seem to be using %s architecture.", StringUtils.join(findArchitectures(), ", ")));
@@ -46,7 +46,7 @@ public class DetectInfoUtility {
         }
     }
 
-    public String parseValueromVersionFileContents(List<String> versionFileContents, String variableName) {
+    public String parseValueFromVersionFileContents(List<String> versionFileContents, String variableName) {
         return versionFileContents.stream()
             .filter(s -> s.startsWith(variableName + "="))
             .map(s -> StringUtils.removeStart(s, variableName + "="))

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -85,7 +85,7 @@ public class DetectBoot {
         this.installedToolManager = installedToolManager;
     }
 
-    public Optional<DetectBootResult> boot(String detectVersion) throws IOException, IllegalAccessException {
+    public Optional<DetectBootResult> boot(String detectVersion, String detectBuildDate) throws IOException, IllegalAccessException {
         if (detectArgumentState.isHelp() || detectArgumentState.isDeprecatedHelp() || detectArgumentState.isVerboseHelp()) {
             HelpPrinter helpPrinter = new HelpPrinter();
             helpPrinter.printAppropriateHelpMessage(
@@ -131,6 +131,7 @@ public class DetectBoot {
             return Optional.of(DetectBootResult.exception(possiblePropertyParseError.get(), propertyConfiguration));
         }
 
+        logger.info("Detect build date: {}", detectBuildDate);
         logger.debug("Initializing Detect.");
 
         Configuration freemarkerConfiguration = detectBootFactory.createFreemarkerConfiguration();

--- a/src/test/java/com/synopsys/integration/detect/interactive/InteractiveModeDecisionTreeEndToEndTest.java
+++ b/src/test/java/com/synopsys/integration/detect/interactive/InteractiveModeDecisionTreeEndToEndTest.java
@@ -258,7 +258,7 @@ public class InteractiveModeDecisionTreeEndToEndTest {
     }
 
     public void testTraverse(Map<String, String> callToResponse, Map<Property, String> expectedProperties) {
-        DetectInfo detectInfo = new DetectInfo("synopsys_detect", OperatingSystemType.LINUX);
+        DetectInfo detectInfo = new DetectInfo("synopsys_detect", OperatingSystemType.LINUX, "unknown");
         InteractiveModeDecisionTree decisionTree = new InteractiveModeDecisionTree(detectInfo, new BlackDuckConnectivityChecker(), new ArrayList<>(), new Gson());
 
         InteractiveWriter mockWriter = mockWriter(callToResponse);

--- a/src/test/java/com/synopsys/integration/detect/workflow/report/FormattedOutputManagerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/report/FormattedOutputManagerTest.java
@@ -55,7 +55,7 @@ public class FormattedOutputManagerTest {
         );
         eventSystem.publishEvent(Event.DetectorsComplete, detectorToolResult);
 
-        DetectInfo detectInfo = new DetectInfo("", null);
+        DetectInfo detectInfo = new DetectInfo("", null, "");
         FormattedOutput formattedOutput = formattedOutputManager.createFormattedOutput(detectInfo);
         FormattedDetectorOutput detectorOutput = formattedOutput.detectors.get(0);
 


### PR DESCRIPTION
There are more users on Detect 6.9.1 than on 7.12.1. I thought it would be good if users knew how old their version was. This change logs the build date.