### PR TITLE
Sb doc pkg mgr pages link to props

### DIFF
--- a/docs/markdown/packagemgrs/bazel.md
+++ b/docs/markdown/packagemgrs/bazel.md
@@ -1,5 +1,11 @@
 # Bazel support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fbazel.html)
+
+## Overview
+
 [solution_name] provides very limited support for Bazel projects.
 
 [solution_name] supports dependencies specified in *maven_jar*, *maven_install*, and *haskell_cabal_library* workspace rules only.

--- a/docs/markdown/packagemgrs/bazel.md
+++ b/docs/markdown/packagemgrs/bazel.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fbazel.html)
+[Detector properties](../properties/detectors/bazel.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/bitbake.md
+++ b/docs/markdown/packagemgrs/bitbake.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fbitbake.html)
+[Detector properties](../properties/detectors/bitbake.md)
 
 ## Requirements
 

--- a/docs/markdown/packagemgrs/bitbake.md
+++ b/docs/markdown/packagemgrs/bitbake.md
@@ -1,5 +1,9 @@
 # BitBake support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fbitbake.html)
+
 ## Requirements
 
 The BitBake detector will run if it finds a BitBake build environment setup script (which defaults to *oe-init-build-env*, but can be configured

--- a/docs/markdown/packagemgrs/cargo.md
+++ b/docs/markdown/packagemgrs/cargo.md
@@ -1,5 +1,7 @@
 # Cargo support
 
+## Overview
+
 [solution_name] runs the Cargo detector if it finds either of the following files in your project:
 
 * Cargo.toml

--- a/docs/markdown/packagemgrs/carthage.md
+++ b/docs/markdown/packagemgrs/carthage.md
@@ -1,5 +1,7 @@
 # Carthage support
 
+## Overview
+
 [solution_name] runs the Carthage detector if it finds either of the following files in your project:
 
 * Cartfile

--- a/docs/markdown/packagemgrs/clang.md
+++ b/docs/markdown/packagemgrs/clang.md
@@ -1,5 +1,7 @@
 # C/C++ (Clang) support
 
+## Overview
+
 C/C++ (Clang) support is limited to Linux systems that support one of the following
 package manager commands: APK, DPKG, or RPM.
 

--- a/docs/markdown/packagemgrs/conan.md
+++ b/docs/markdown/packagemgrs/conan.md
@@ -1,5 +1,11 @@
 # Conan support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fconan.html)
+
+## Overview
+
 [solution_name] has two detectors for Conan:
 
 * Conan Lockfile detector

--- a/docs/markdown/packagemgrs/conan.md
+++ b/docs/markdown/packagemgrs/conan.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fconan.html)
+[Detector properties](../properties/detectors/conan.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/conda.md
+++ b/docs/markdown/packagemgrs/conda.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fconda.html)
+[Detector properties](../properties/detectors/conda.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/conda.md
+++ b/docs/markdown/packagemgrs/conda.md
@@ -1,5 +1,11 @@
 # Conda Support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fconda.html)
+
+## Overview
+
 The Conda detector discovers dependencies of python projects utilizing the Conda package and environment manager.
 
 [solution_name] runs the Conda detector if an environment.yml file is found in your project.

--- a/docs/markdown/packagemgrs/dart.md
+++ b/docs/markdown/packagemgrs/dart.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fdart.html)
+[Detector properties](../properties/detectors/dart.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/dart.md
+++ b/docs/markdown/packagemgrs/dart.md
@@ -1,5 +1,11 @@
 # Dart Support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fdart.html)
+
+## Overview
+
 [solution_name] has two detectors for Dart:
 
 * Dart Pub Spec Lock detector

--- a/docs/markdown/packagemgrs/docker/intro.md
+++ b/docs/markdown/packagemgrs/docker/intro.md
@@ -1,5 +1,11 @@
 # Docker image support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fdocker.html)
+
+## Overview
+
 On Linux, Mac, and Windows 10 Enterprise, [solution_name] can invoke Docker Inspector to inspect Linux Docker images to discover packages installed by the Linux package manager.
 For simple use cases, add ```--detect.docker.image={repo}:{tag}```, ```--detect.docker.tar={path to an image archive}```,
 ```--detect.docker.image.id={image id}```,

--- a/docs/markdown/packagemgrs/docker/intro.md
+++ b/docs/markdown/packagemgrs/docker/intro.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fdocker.html)
+[Detector properties](../../properties/detectors/docker.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/golang.md
+++ b/docs/markdown/packagemgrs/golang.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fgo.html)
+[Detector properties](../properties/detectors/go.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/golang.md
+++ b/docs/markdown/packagemgrs/golang.md
@@ -1,5 +1,11 @@
 # GoLang support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fgo.html)
+
+## Overview
+
 [solution_name] has four detectors for GoLang:
 
 * Go Mod Cli (GO_MOD) detector (recommended)

--- a/docs/markdown/packagemgrs/gradle.md
+++ b/docs/markdown/packagemgrs/gradle.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fgradle.html)
+[Detector properties](../properties/detectors/gradle.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/gradle.md
+++ b/docs/markdown/packagemgrs/gradle.md
@@ -1,5 +1,11 @@
 # Gradle support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fgradle.html)
+
+## Overview
+
 [solution_name] has two detectors for Gradle:
 
 * Gradle inspector detector

--- a/docs/markdown/packagemgrs/hex.md
+++ b/docs/markdown/packagemgrs/hex.md
@@ -1,5 +1,11 @@
 # Erlang/Hex/Rebar support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fhex.html)
+
+## Overview
+
 The Rebar detector discovers dependencies of Erlang projects that use the Hex package manager.
 
 The Rebar detector runs if [solution_name] finds a *rebar.config* file in your project.

--- a/docs/markdown/packagemgrs/hex.md
+++ b/docs/markdown/packagemgrs/hex.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fhex.html)
+[Detector properties](../properties/detectors/hex.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/ivy.md
+++ b/docs/markdown/packagemgrs/ivy.md
@@ -1,5 +1,7 @@
 # Ivy (Ant) support
 
+## Overview
+
 [solution_name] supports an Ivy detector to extract dependency information for projects that use Ivy, a common dependency manager for Ant projects.
 
 [solution_name] runs the Ivy detector if it finds a ivy.xml file in your project.

--- a/docs/markdown/packagemgrs/lerna.md
+++ b/docs/markdown/packagemgrs/lerna.md
@@ -1,5 +1,11 @@
 # Lerna support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Flerna.html)
+
+## Overview
+
 The Lerna detector will register in the presence of a lerna.json file.
 
 It will then execute a lerna command to retrieve all the packages defined in the project.

--- a/docs/markdown/packagemgrs/lerna.md
+++ b/docs/markdown/packagemgrs/lerna.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Flerna.html)
+[Detector properties](../properties/detectors/lerna.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/maven.md
+++ b/docs/markdown/packagemgrs/maven.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fmaven.html)
+[Detector properties](../properties/detectors/maven.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/maven.md
+++ b/docs/markdown/packagemgrs/maven.md
@@ -1,5 +1,11 @@
 # Maven support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fmaven.html)
+
+## Overview
+
 [solution_name] has two detectors for Maven:
 
 * Maven Pom detector

--- a/docs/markdown/packagemgrs/npm.md
+++ b/docs/markdown/packagemgrs/npm.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fnpm.html)
+[Detector properties](../properties/detectors/npm.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/npm.md
+++ b/docs/markdown/packagemgrs/npm.md
@@ -1,5 +1,11 @@
 # npm support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fnpm.html)
+
+## Overview
+
 [solution_name] has the following npm detectors:
 
 * npm package lock detector

--- a/docs/markdown/packagemgrs/nuget.md
+++ b/docs/markdown/packagemgrs/nuget.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fnuget.html)
+[Detector properties](../properties/detectors/nuget.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/nuget.md
+++ b/docs/markdown/packagemgrs/nuget.md
@@ -1,5 +1,11 @@
 # NuGet support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fnuget.html)
+
+## Overview
+
 The NuGet detectors can discover dependencies of NuGet projects.
 
 ## Overview

--- a/docs/markdown/packagemgrs/pnpm.md
+++ b/docs/markdown/packagemgrs/pnpm.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fpnpm.html)
+[Detector properties](../properties/detectors/pnpm.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/pnpm.md
+++ b/docs/markdown/packagemgrs/pnpm.md
@@ -1,5 +1,11 @@
 # pnpm support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fpnpm.html)
+
+## Overview
+
 [solution_name] runs the pnpm detector if it finds a pnpm-lock.yaml file in your project, and parses the file to obtain information on your project's dependencies.
 
 To specify which types of dependencies you want [solution_name] to exclude from the BOM (Dev and Optional dependencies) use the detect.pnpm.dependency.types.excluded property.

--- a/docs/markdown/packagemgrs/python.md
+++ b/docs/markdown/packagemgrs/python.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fpython.html)
+[Detector properties](../properties/detectors/python.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/python.md
+++ b/docs/markdown/packagemgrs/python.md
@@ -1,5 +1,11 @@
 # Python support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fpython.html)
+
+## Overview
+
 [solution_name] has three detectors for Python:
 
 * Pip detector

--- a/docs/markdown/packagemgrs/sbt.md
+++ b/docs/markdown/packagemgrs/sbt.md
@@ -2,9 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fsbt.html)
-
-[Path properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fpaths.html)
+[Detector properties](../properties/detectors/sbt.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/sbt.md
+++ b/docs/markdown/packagemgrs/sbt.md
@@ -1,5 +1,13 @@
 # SBT support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fsbt.html)
+
+[Path properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fpaths.html)
+
+## Overview
+
 [solution_name] runs the dependecyDot task when it finds the following in your project
 
 * build.sbt

--- a/docs/markdown/packagemgrs/swift.md
+++ b/docs/markdown/packagemgrs/swift.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Path properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fpaths.html)
+[Detector properties](../properties/detectors/swift.md)
 
 ## Overview
 

--- a/docs/markdown/packagemgrs/swift.md
+++ b/docs/markdown/packagemgrs/swift.md
@@ -1,4 +1,11 @@
 # Swift support
+
+## Related properties
+
+[Path properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fpaths.html)
+
+## Overview
+
 [solution_name] has two detectors for Swift:
 
 * Xcode Swift detector

--- a/docs/markdown/packagemgrs/yarn.md
+++ b/docs/markdown/packagemgrs/yarn.md
@@ -1,5 +1,11 @@
 # Yarn support
 
+## Related properties
+
+[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fyarn.html)
+
+## Overview
+
 [solution_name] runs the Yarn detector if it finds both of the following files in your project:
 
 * yarn.lock

--- a/docs/markdown/packagemgrs/yarn.md
+++ b/docs/markdown/packagemgrs/yarn.md
@@ -2,7 +2,7 @@
 
 ## Related properties
 
-[Detector properties](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fdetectors%2Fyarn.html)
+[Detector properties](../properties/detectors/yarn.md)
 
 ## Overview
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1208,7 +1208,7 @@ public class DetectProperties {
         NullablePathProperty.newBuilder("detect.swift.path")
             .setInfo("Swift Executable", DetectPropertyFromVersion.VERSION_6_0_0)
             .setHelp("Path of the swift executable.")
-            .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
+            .setGroups(DetectGroup.SWIFT, DetectGroup.GLOBAL)
             .build();
 
     public static final AllNoneEnumListProperty<PolicyRuleSeverityType> DETECT_POLICY_CHECK_FAIL_ON_SEVERITIES =
@@ -1504,7 +1504,7 @@ public class DetectProperties {
             .setInfo("Sbt Executable", DetectPropertyFromVersion.VERSION_3_0_0)
             .setHelp("Path to the Sbt executable.", "If set, Detect will use the given Sbt executable instead of searching for one.")
             .setExample("C:\\Program Files (x86)\\sbt\\bin\\sbt.bat")
-            .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
+            .setGroups(DetectGroup.SBT, DetectGroup.GLOBAL)
             .build();
 
     public static final NullableStringProperty DETECT_SBT_ARGUMENTS =

--- a/src/main/java/com/synopsys/integration/detect/configuration/enumeration/DetectGroup.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/enumeration/DetectGroup.java
@@ -57,6 +57,7 @@ public enum DetectGroup implements Group {
     PYTHON("python", DETECTORS),
     RUBY("ruby", DETECTORS),
     SBT("sbt", DETECTORS),
+    SWIFT("swift", DETECTORS),
     YARN("yarn", DETECTORS),
 
     //Additional groups (should not be used as a primary group


### PR DESCRIPTION
For each package manager that has properties, added links to the property page to the top of the package manager page.
