### PR TITLE
Cargo stop root-pruning

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cargo/CargoDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cargo/CargoDetectable.java
@@ -15,7 +15,6 @@ import com.synopsys.integration.detectable.detectable.result.DetectableResult;
 import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
-import com.synopsys.integration.detectable.util.CycleDetectedException;
 
 @DetectableInfo(language = "Rust", forge = "crates", requirementsMarkdown = "Files: Cargo.lock, Cargo.toml")
 public class CargoDetectable extends Detectable {
@@ -50,7 +49,7 @@ public class CargoDetectable extends Detectable {
     }
 
     @Override
-    public Extraction extract(ExtractionEnvironment extractionEnvironment) throws IOException, CycleDetectedException, DetectableException, MissingExternalIdException {
+    public Extraction extract(ExtractionEnvironment extractionEnvironment) throws IOException, DetectableException, MissingExternalIdException {
         return cargoExtractor.extract(cargoLock, cargoToml);
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cargo/CargoExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cargo/CargoExtractor.java
@@ -22,7 +22,6 @@ import com.synopsys.integration.detectable.detectables.cargo.parse.CargoTomlPars
 import com.synopsys.integration.detectable.detectables.cargo.transform.CargoLockPackageDataTransformer;
 import com.synopsys.integration.detectable.detectables.cargo.transform.CargoLockPackageTransformer;
 import com.synopsys.integration.detectable.extraction.Extraction;
-import com.synopsys.integration.detectable.util.CycleDetectedException;
 import com.synopsys.integration.util.NameVersion;
 
 public class CargoExtractor {
@@ -40,7 +39,7 @@ public class CargoExtractor {
         this.cargoLockPackageTransformer = cargoLockPackageTransformer;
     }
 
-    public Extraction extract(File cargoLockFile, @Nullable File cargoTomlFile) throws IOException, CycleDetectedException, DetectableException, MissingExternalIdException {
+    public Extraction extract(File cargoLockFile, @Nullable File cargoTomlFile) throws IOException, DetectableException, MissingExternalIdException {
         CargoLockData cargoLockData = new Toml().read(cargoLockFile).to(CargoLockData.class);
         List<CargoLockPackage> packages = cargoLockData.getPackages()
             .orElse(new ArrayList<>()).stream()

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cargo/transform/CargoLockPackageTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cargo/transform/CargoLockPackageTransformer.java
@@ -12,15 +12,13 @@ import com.synopsys.integration.bdio.model.dependency.DependencyFactory;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.detectable.detectables.cargo.model.CargoLockPackage;
-import com.synopsys.integration.detectable.util.CycleDetectedException;
 import com.synopsys.integration.detectable.util.NameOptionalVersion;
-import com.synopsys.integration.detectable.util.RootPruningGraphUtil;
 
 public class CargoLockPackageTransformer {
     private final ExternalIdFactory externalIdFactory = new ExternalIdFactory();
     private final DependencyFactory dependencyFactory = new DependencyFactory(externalIdFactory);
 
-    public DependencyGraph transformToGraph(List<CargoLockPackage> lockPackages) throws MissingExternalIdException, CycleDetectedException, DetectableException {
+    public DependencyGraph transformToGraph(List<CargoLockPackage> lockPackages) throws MissingExternalIdException, DetectableException {
         verifyNoDuplicatePackages(lockPackages);
 
         LazyExternalIdDependencyGraphBuilder graph = new LazyExternalIdDependencyGraphBuilder();
@@ -45,7 +43,7 @@ public class CargoLockPackageTransformer {
             });
         });
 
-        return RootPruningGraphUtil.prune(graph.build());
+        return graph.build();
     }
 
     private void verifyNoDuplicatePackages(List<CargoLockPackage> lockPackages) throws DetectableException {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/util/RootPruningGraphUtil.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/util/RootPruningGraphUtil.java
@@ -49,6 +49,7 @@ public class RootPruningGraphUtil {
         for (Dependency currentLevelDependency : currentLevel) {
             Set<Dependency> children = graph.getChildrenForParent(currentLevelDependency);
             if (children.contains(target) || isDependencyInGraph(target, children, graph)) {
+                // TODO: YES! IDETECT-3224 is caused by cycles ^
                 return true;
             }
         }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cargo/functional/CargoDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cargo/functional/CargoDetectableTest.java
@@ -73,6 +73,11 @@ public class CargoDetectableTest extends DetectableFunctionalTest {
         graphAssert.hasParentChildRelationship("abscissa_core", "0.5.2", "abscissa_derive", "0.5.0");
         graphAssert.hasParentChildRelationship("abscissa_core", "0.5.2", "backtrace", "0.3.46");
         graphAssert.hasParentChildRelationship("abscissa_derive", "0.5.0", "darling", "0.10.2");
-        graphAssert.hasRootSize(1);
+
+        graphAssert.hasRootDependency("abscissa_derive", "0.5.0");
+        graphAssert.hasRootDependency("backtrace", "0.3.46");
+        graphAssert.hasRootDependency("darling", "0.10.2");
+
+        graphAssert.hasRootSize(4);
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cargo/transform/CargoLockPackageTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cargo/transform/CargoLockPackageTransformerTest.java
@@ -46,7 +46,7 @@ public class CargoLockPackageTransformerTest {
     }
 
     @Test
-    public void testCorrectNumberOfRootDependencies() throws DetectableException, MissingExternalIdException, CycleDetectedException {
+    public void testCorrectNumberOfRootDependencies() throws DetectableException, MissingExternalIdException {
         List<CargoLockPackage> input = new ArrayList<>();
         input.add(createPackage("test1", "1.0.0",
             new NameOptionalVersion("dep1"),
@@ -58,7 +58,10 @@ public class CargoLockPackageTransformerTest {
         DependencyGraph graph = cargoLockPackageTransformer.transformToGraph(input);
 
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.CRATES, graph);
-        graphAssert.hasRootSize(1);
+        graphAssert.hasRootDependency("test1", "1.0.0");
+        graphAssert.hasRootDependency("dep1", "0.5.0");
+        graphAssert.hasRootDependency("dep2", "0.6.0");
+        graphAssert.hasRootSize(3);
     }
 
     private CargoLockPackage createPackage(String name, String version, NameOptionalVersion... dependencies) {

--- a/docs/markdown/releasenotes.md
+++ b/docs/markdown/releasenotes.md
@@ -1,9 +1,18 @@
 # Release notes
 
-## Version 7.13.0
+## Version 8.0.0
 
 ### New features
 
+### Changed features
+* Cargo project dependency graphs are no longer post-processed to reduce Direct dependencies in the BOM.
+
+### Resolved issues
+* (IDETECT-3224) Resolved an issue where Cargo projects with Cyclical dependencies could cause a failure of [solution_name].
+
+## Version 7.13.0
+
+### New features
 * Added support for a buildless Pipenv detector that parses the Pipfile.lock file (see the [python support page](packagemgrs/python.md) for more details).
 * [solution_name] now includes pass-through properties when logging configuration at the beginning of a run.
 * Added support for Xcode Workspaces (see the [swift support page](packagemgrs/swift.md) for more details).
@@ -13,7 +22,6 @@
 * Deprecated property detect.detector.buildless, to be replaced with detect.accuracy.required. See [property description](properties/configuration/detector.md#detector-accuracy-requirements-advanced) for more details.
 
 ### Resolved issues
-
 * (IDETECT-3136) Resolved an issue where NPM's `package-lock.json` was prioritized over `npm-shrinkwrap.json`.
 * (IDETECT-3184) Resolved an issue that prevented matches for Bazel maven_install components with complex (>3 parts) maven_coordinates values.
 * (IDETECT-3207) Resolved an issue that prevented Bazel and Docker Tool issues from being reported in the issues section of the [solution_name] log and status file.


### PR DESCRIPTION
Stops root pruning Cargo graphs for IDETECT-3240.
Also fixes IDETECT-3224 by not running the `DependencyGraph` through the `RootPruningGraphUtil` where the bug resides.
