### PR TITLE
Sb rapid scan fix

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanWaitJob.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanWaitJob.java
@@ -21,6 +21,7 @@ import com.synopsys.integration.wait.ResilientJob;
 public class DetectRapidScanWaitJob implements ResilientJob<List<DeveloperScanComponentResultView>> {
     private final BlackDuckApiClient blackDuckApiClient;
     private final List<HttpUrl> remainingUrls;
+    private List<HttpUrl> completedUrls = new ArrayList<>();
 
     private static final String JOB_NAME = "Waiting for Rapid Scans";
 
@@ -39,14 +40,14 @@ public class DetectRapidScanWaitJob implements ResilientJob<List<DeveloperScanCo
             return;
         }
 
-        List<HttpUrl> completed = new ArrayList<>();
+        completedUrls = new ArrayList<>();
         for (HttpUrl url : remainingUrls) {
             if (isComplete(url)) {
-                completed.add(url);
+                completedUrls.add(url);
             }
         }
 
-        remainingUrls.removeAll(completed);
+        remainingUrls.removeAll(completedUrls);
         complete = remainingUrls.isEmpty();
     }
 
@@ -79,7 +80,7 @@ public class DetectRapidScanWaitJob implements ResilientJob<List<DeveloperScanCo
     @Override
     public List<DeveloperScanComponentResultView> onCompletion() throws IntegrationException {
         List<DeveloperScanComponentResultView> allComponents = new ArrayList<>();
-        for (HttpUrl url : remainingUrls) {
+        for (HttpUrl url : completedUrls) {
             allComponents.addAll(getScanResultsForUrl(url));
         }
         return allComponents;

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanWaitJob.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanWaitJob.java
@@ -21,7 +21,7 @@ import com.synopsys.integration.wait.ResilientJob;
 public class DetectRapidScanWaitJob implements ResilientJob<List<DeveloperScanComponentResultView>> {
     private final BlackDuckApiClient blackDuckApiClient;
     private final List<HttpUrl> remainingUrls;
-    private List<HttpUrl> completedUrls = new ArrayList<>();
+    private final List<HttpUrl> completedUrls;
 
     private static final String JOB_NAME = "Waiting for Rapid Scans";
 
@@ -31,6 +31,7 @@ public class DetectRapidScanWaitJob implements ResilientJob<List<DeveloperScanCo
         this.blackDuckApiClient = blackDuckApiClient;
         this.remainingUrls = new ArrayList<>();
         remainingUrls.addAll(resultUrl);
+        this.completedUrls = new ArrayList<>(remainingUrls.size());
     }
 
     @Override
@@ -39,8 +40,7 @@ public class DetectRapidScanWaitJob implements ResilientJob<List<DeveloperScanCo
             complete = true;
             return;
         }
-
-        completedUrls = new ArrayList<>();
+        
         for (HttpUrl url : remainingUrls) {
             if (isComplete(url)) {
                 completedUrls.add(url);


### PR DESCRIPTION
fix for [IDETECT-3299](https://jira-sig.internal.synopsys.com/browse/IDETECT-3299): rapid scan not returning results (the onComplete method was processing the remainingUrl list, always empty by that time, rather than the completedUrl list).
