### PR TITLE
feat: ignore MACOSX directory for signature scans by default

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/enumeration/DefaultSignatureScannerExcludedDirectories.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/enumeration/DefaultSignatureScannerExcludedDirectories.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 public enum DefaultSignatureScannerExcludedDirectories {
     DOT_GRADLE(".gradle"),
+    MACOSX("__MACOSX"),
     NODE_MODULES("node_modules"),
     GIT(".git"),
     SYNOPSYS(".synopsys");

--- a/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
+++ b/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.detect.configuration;
 import static com.synopsys.integration.detect.configuration.DetectConfigurationFactoryTestUtils.factoryOf;
 import static com.synopsys.integration.detect.configuration.DetectConfigurationFactoryTestUtils.spyFactoryOf;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.common.util.Bdo;
+import com.synopsys.integration.detect.configuration.enumeration.DefaultSignatureScannerExcludedDirectories;
 import com.synopsys.integration.rest.credentials.Credentials;
 
 public class DetectConfigurationFactoryTests {
@@ -50,5 +52,16 @@ public class DetectConfigurationFactoryTests {
     }
 
     //#endregion Parallel Processors
+
+    @Test
+    public void testDefaultSignatureScannerExcludedDirectories() {
+        DetectConfigurationFactory factory = factoryOf();
+
+        List<String> actualExcludedDirectories = factory.collectSignatureScannerDirectoryExclusions();
+
+        List<String> defaultExcludedDirectories = DefaultSignatureScannerExcludedDirectories.getDirectoryNames();
+
+        Assertions.assertEquals(defaultExcludedDirectories, actualExcludedDirectories);
+    }
 
 }


### PR DESCRIPTION
# Description

Ignore MACOSX directory by default when doing signature scans
