### PR TITLE
feat: ignore __MACOSX directory when determining applicable detectors

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -239,7 +239,7 @@ public class DetectConfigurationFactory {
         return directoryExclusionPatterns;
     }
 
-    private List<String> collectDetectorSearchDirectoryExclusions() {
+    public List<String> collectDetectorSearchDirectoryExclusions() {
         List<String> directoryExclusionPatterns = new ArrayList<>(detectConfiguration.getValue(DetectProperties.DETECT_EXCLUDED_DIRECTORIES));
 
         if (Boolean.FALSE.equals(detectConfiguration.getValue(DetectProperties.DETECT_EXCLUDED_DIRECTORIES_DEFAULTS_DISABLED))) {

--- a/src/main/java/com/synopsys/integration/detect/configuration/enumeration/DefaultDetectorSearchExcludedDirectories.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/enumeration/DefaultDetectorSearchExcludedDirectories.java
@@ -9,6 +9,7 @@ public enum DefaultDetectorSearchExcludedDirectories {
     BUILD("build"),
     DOT_BUILD(".build"),
     DOT_GRADLE(".gradle"),
+    MACOSX("__MACOSX"),
     NODE_MODULES("node_modules"),
     OUT("out"),
     PACKAGES("packages"),

--- a/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
+++ b/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.detect.configuration;
 import static com.synopsys.integration.detect.configuration.DetectConfigurationFactoryTestUtils.factoryOf;
 import static com.synopsys.integration.detect.configuration.DetectConfigurationFactoryTestUtils.spyFactoryOf;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.common.util.Bdo;
+import com.synopsys.integration.detect.configuration.enumeration.DefaultDetectorSearchExcludedDirectories;
 import com.synopsys.integration.rest.credentials.Credentials;
 
 public class DetectConfigurationFactoryTests {
@@ -51,4 +53,14 @@ public class DetectConfigurationFactoryTests {
 
     //#endregion Parallel Processors
 
+    @Test
+    public void testDefaultSignatureScannerExcludedDirectories() {
+        DetectConfigurationFactory factory = factoryOf();
+
+        List<String> actualExcludedDirectories = factory.collectDetectorSearchDirectoryExclusions();
+
+        List<String> defaultExcludedDirectories = DefaultDetectorSearchExcludedDirectories.getDirectoryNames();
+
+        Assertions.assertEquals(defaultExcludedDirectories, actualExcludedDirectories);
+    }
 }


### PR DESCRIPTION
Ignore __MACOSX directory when determining which detectors are applicable for a project.