### PR TITLE
resolved inspector fix

### DIFF
--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -10,6 +10,8 @@
 
 ### Resolved issues
 
+* (IDETECT-3419) Resolved an issue where the NuGet inspector cannot be found when a solution file cannot be found but multiple C# projects are found by Detect.
+
 ## Version 8.0.0
 
 ### New features

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/nuget/OnlineNugetInspectorResolver.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/nuget/OnlineNugetInspectorResolver.java
@@ -53,8 +53,7 @@ public class OnlineNugetInspectorResolver implements NugetInspectorResolver {
             if (inspectorFile == null) {
                 // Remote installation has failed
                 logger.debug("Attempting to locate previous install of detect nuget inspector.");
-                return installedToolLocator.locateTool(INSPECTOR_NAME)
-                    .map(ExecutableTarget::forFile)
+                inspectorFile = installedToolLocator.locateTool(INSPECTOR_NAME)
                     .orElseThrow(() ->
                         new DetectableException("Unable to locate previous install of the detect nuget inspector.")
                     );


### PR DESCRIPTION
# Description

When multiple projects are found by detect and no solution file is present the inspector is found for only the first project.
The code returns right away when the inspector was found rather than storing it in the local variable to be used again later.  That is why the first project finds the inspector and other projects do not.  The inspector isn't cached to be reused by subsequent invocations of NugetProjectDetectable.

# Github Issues

(Optional) Please link to any applicable github issues.
