### PR TITLE
stop NPE when no modules are detected by project inspector

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
@@ -1,6 +1,7 @@
 package com.synopsys.integration.detectable.detectables.projectinspector;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,8 +35,13 @@ public class ProjectInspectorParser {
 
     public List<CodeLocation> parse(String inspectionOutput) {
         ProjectInspectorOutput projectInspectorOutput = gson.fromJson(inspectionOutput, ProjectInspectorOutput.class);
-        // TODO: Could maybe use some null-safety around the presence of the 'modules' field
-        //  There should be more safety (at least @Nullable) in all the ProjectInspector model objects
+
+        // If modules is not present in the output then project inspector has not found any open source dependencies.
+        // Return an empty list so callers do not fail when examining the results.
+        if (projectInspectorOutput.modules == null) {
+            return Collections.emptyList();
+        }
+
         return projectInspectorOutput.modules.values().stream()
             .map(this::codeLocationFromModule)
             .collect(Collectors.toList());

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/nuget/functional/NugetProjectInspectorParseTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/nuget/functional/NugetProjectInspectorParseTest.java
@@ -33,4 +33,12 @@ public class NugetProjectInspectorParseTest {
 
         consoleApp3.hasParentChildRelationship("Newtonsoft.Json.Bson", "1.0.2", "Newtonsoft.Json", "12.0.1");
     }
+
+    @Test
+    void checkParsingWithNoResults() {
+        String inspectorOutput = FunctionalTestFiles.asString("/nuget/project_inspector/ProjectInspectorNoResults.json");
+        List<CodeLocation> codeLocations = new ProjectInspectorParser(new Gson(), new ExternalIdFactory()).parse(inspectorOutput);
+
+        Assertions.assertEquals(0, codeLocations.size());
+    }
 }

--- a/detectable/src/test/resources/detectables/functional/nuget/project_inspector/ProjectInspectorNoResults.json
+++ b/detectable/src/test/resources/detectables/functional/nuget/project_inspector/ProjectInspectorNoResults.json
@@ -1,0 +1,3 @@
+{
+  "Dir": "C:\\Users\\userx\\source\\repos\\no-dependencies-repo"
+}


### PR DESCRIPTION
# Description

The code assumes that a modules array is always included in the JSON. This is not necessarily true. In cases where there are no modules detected, return an empty List so callers don't fail on null values.
