### PR TITLE
fix: use prefix and suffix in aggregate code location naming

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGenerator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGenerator.java
@@ -59,7 +59,7 @@ public class CodeLocationNameGenerator {
         String externalIdPiece = StringUtils.join(detectCodeLocation.getExternalId().getExternalIdPieces(), "/");
 
         // misc pieces
-        String codeLocationTypeString = CodeLocationNameType.BOM.toString().toLowerCase();
+        String codeLocationTypeString = CodeLocationNameType.BOM.getName();
         String bomToolTypeString = deriveCreator(detectCodeLocation).toLowerCase();
 
         List<String> bomCodeLocationNamePieces = new ArrayList<>();
@@ -75,7 +75,7 @@ public class CodeLocationNameGenerator {
     }
 
     public String createDockerScanCodeLocationName(File dockerTar, String projectName, String projectVersionName) {
-        String codeLocationTypeString = CodeLocationNameType.SCAN.toString().toLowerCase();
+        String codeLocationTypeString = CodeLocationNameType.SCAN.getName();
 
         String dockerTarFileName = DetectFileUtils.tryGetCanonicalName(dockerTar);
         List<String> fileCodeLocationNamePieces = Arrays.asList(dockerTarFileName, projectName, projectVersionName);
@@ -86,7 +86,7 @@ public class CodeLocationNameGenerator {
 
     public String createScanCodeLocationName(File sourcePath, File scanTargetPath, String projectName, String projectVersionName) {
         String pathPiece = cleanScanTargetPath(scanTargetPath, sourcePath);
-        String codeLocationTypeString = CodeLocationNameType.SCAN.toString().toLowerCase();
+        String codeLocationTypeString = CodeLocationNameType.SCAN.getName();
 
         List<String> fileCodeLocationNamePieces = Arrays.asList(pathPiece, projectName, projectVersionName);
         List<String> fileCodeLocationEndPieces = Collections.singletonList(codeLocationTypeString);
@@ -95,7 +95,7 @@ public class CodeLocationNameGenerator {
     }
 
     public String createBinaryScanCodeLocationName(File targetFile, String projectName, String projectVersionName) {
-        String codeLocationTypeString = CodeLocationNameType.SCAN.toString().toLowerCase();
+        String codeLocationTypeString = CodeLocationNameType.SCAN.getName();
 
         String canonicalFileName = DetectFileUtils.tryGetCanonicalName(targetFile);
         List<String> fileCodeLocationNamePieces = Arrays.asList(canonicalFileName, projectName, projectVersionName);
@@ -105,7 +105,7 @@ public class CodeLocationNameGenerator {
     }
 
     public String createImpactAnalysisCodeLocationName(File sourceDirectory, String projectName, String projectVersionName) {
-        String codeLocationTypeString = CodeLocationNameType.IMPACT_ANALYSIS.toString().toLowerCase();
+        String codeLocationTypeString = CodeLocationNameType.IMPACT_ANALYSIS.getName();
 
         String canonicalFileName = DetectFileUtils.tryGetCanonicalName(sourceDirectory);
         List<String> fileCodeLocationNamePieces = Arrays.asList(canonicalFileName, projectName, projectVersionName);
@@ -118,7 +118,7 @@ public class CodeLocationNameGenerator {
         File targetFile, String projectName, String projectVersionName, @Nullable String prefix,
         @Nullable String suffix
     ) {
-        String codeLocationTypeString = CodeLocationNameType.IAC.toString().toLowerCase();
+        String codeLocationTypeString = CodeLocationNameType.IAC.getName();
 
         String canonicalFileName = DetectFileUtils.tryGetCanonicalName(targetFile);
         List<String> fileCodeLocationNamePieces = Arrays.asList(canonicalFileName, projectName, projectVersionName);
@@ -132,7 +132,7 @@ public class CodeLocationNameGenerator {
         // Add Black Duck I/O Export at the end of the code location name, even after the user suffix. This
         // indicates a package manager scan.
         List<String> codeLocationNamePieces = Arrays.asList(projectNameVersion.getName(), projectNameVersion.getVersion());
-        List<String> codeLocationEndPieces = Collections.singletonList("Black Duck I/O Export");
+        List<String> codeLocationEndPieces = Collections.singletonList(CodeLocationNameType.BOM.getName());
 
         return createCodeLocationName(prefix, codeLocationNamePieces, suffix, codeLocationEndPieces);
     }
@@ -201,7 +201,7 @@ public class CodeLocationNameGenerator {
     }
 
     public String getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType codeLocationNameType) {
-        String baseName = codeLocationNameOverride + " " + codeLocationNameType.toString().toLowerCase();
+        String baseName = codeLocationNameOverride + " " + codeLocationNameType.getName();
         int nameIndex = deriveNameNumber(baseName);
         return deriveUniqueCodeLocationName(baseName, nameIndex);
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGenerator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGenerator.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.detect.workflow.file.DetectFileUtils;
+import com.synopsys.integration.util.NameVersion;
 
 public class CodeLocationNameGenerator {
     private static final int MAXIMUM_CODE_LOCATION_NAME_LENGTH = 250;
@@ -126,6 +127,16 @@ public class CodeLocationNameGenerator {
         return createCodeLocationName(prefix, fileCodeLocationNamePieces, suffix, fileCodeLocationEndPieces);
     }
 
+    public String createAggregateStandardCodeLocationName(NameVersion projectNameVersion) {
+        // Add the user supplied prefix and suffix, if they exist, to the project name and project version name.
+        // Add Black Duck I/O Export at the end of the code location name, even after the user suffix. This
+        // indicates a package manager scan.
+        List<String> codeLocationNamePieces = Arrays.asList(projectNameVersion.getName(), projectNameVersion.getVersion());
+        List<String> codeLocationEndPieces = Collections.singletonList("Black Duck I/O Export");
+
+        return createCodeLocationName(prefix, codeLocationNamePieces, suffix, codeLocationEndPieces);
+    }
+
     private String createCodeLocationName(@Nullable String prefix, List<String> codeLocationNamePieces, @Nullable String suffix, List<String> codeLocationEndPieces) {
         String codeLocationName = createCommonName(prefix, codeLocationNamePieces, suffix, codeLocationEndPieces);
 
@@ -220,5 +231,4 @@ public class CodeLocationNameGenerator {
         nameCounters.put(baseName, nameIndex);
         return nameIndex;
     }
-
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameManager.java
@@ -19,7 +19,7 @@ public class CodeLocationNameManager {
             // The aggregate is exclusively used for the bdio and not the scans
             aggregateCodeLocationName = codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.BOM);
         } else {
-            aggregateCodeLocationName = String.format("%s/%s Black Duck I/O Export", projectNameVersion.getName(), projectNameVersion.getVersion());
+            aggregateCodeLocationName = codeLocationNameGenerator.createAggregateStandardCodeLocationName(projectNameVersion);
         }
         return aggregateCodeLocationName;
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameType.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameType.java
@@ -1,9 +1,19 @@
 package com.synopsys.integration.detect.workflow.codelocation;
 
 public enum CodeLocationNameType {
-    BOM,
-    DOCKER,
-    IMPACT_ANALYSIS,
-    SCAN,
-    IAC
+    BOM("Black Duck I/O Export"),
+    DOCKER("docker"),
+    IMPACT_ANALYSIS("impact_analysis"),
+    SCAN("scan"),
+    IAC("iac");
+
+    private final String name;
+
+    CodeLocationNameType(String name) {
+        this.name = name;
+    }
+
+    String getName() {
+        return this.name;
+    }
 }

--- a/src/test/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGeneratorTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGeneratorTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.bdio.model.externalid.ExternalId;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.util.NameVersion;
 
 public class CodeLocationNameGeneratorTest {
     @Test
@@ -150,5 +151,15 @@ public class CodeLocationNameGeneratorTest {
         assertEquals("myscanname scan 2", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.SCAN));
         assertEquals("myscanname bom", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.BOM));
         assertEquals("myscanname bom 2", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.BOM));
+    }
+
+    @Test
+    public void testCreateAggregateStandardCodeLocationName() {
+        NameVersion nameAndVersion = new NameVersion("project", "version");
+        CodeLocationNameGenerator codeLocationNameGenerator = CodeLocationNameGenerator.withPrefixSuffix("prefix", "suffix");
+
+        String codeLocationName = codeLocationNameGenerator.createAggregateStandardCodeLocationName(nameAndVersion);
+
+        assertEquals("prefix/project/version/suffix Black Duck I/O Export", codeLocationName);
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGeneratorTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGeneratorTest.java
@@ -51,7 +51,7 @@ public class CodeLocationNameGeneratorTest {
 
     @Test
     public void testBomCodeLocationName() {
-        final String expected = "projectName/projectVersion/child/group/name/version npm/bom";
+        final String expected = "projectName/projectVersion/child/group/name/version npm/Black Duck I/O Export";
         // = path/externalId tool/type
 
         ExternalIdFactory factory = new ExternalIdFactory();
@@ -97,7 +97,7 @@ public class CodeLocationNameGeneratorTest {
 
     @Test
     public void testLongCodeLocationNames() {
-        final String expected = "projectName/projectVersion/common-rest-common-...n-rest-common-rest/group/name/version npm/bom";
+        final String expected = "projectName/projectVersion/common-rest-common-...n-rest-common-rest/group/name/version npm/Black Duck I/O Export";
         ExternalIdFactory factory = new ExternalIdFactory();
         ExternalId externalId = factory.createMavenExternalId("group", "name", "version");
         CodeLocationNameGenerator codeLocationNameGenerator = CodeLocationNameGenerator.noChanges();
@@ -134,7 +134,7 @@ public class CodeLocationNameGeneratorTest {
             "projectVersion",
             detectCodeLocation
         );
-        assertEquals("testPrefix/projectName/projectVersion/bbb/externalIdPath/testSuffix detect/bom", actual);
+        assertEquals("testPrefix/projectName/projectVersion/bbb/externalIdPath/testSuffix detect/Black Duck I/O Export", actual);
     }
 
     @Test
@@ -149,8 +149,8 @@ public class CodeLocationNameGeneratorTest {
 
         assertEquals("myscanname scan", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.SCAN));
         assertEquals("myscanname scan 2", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.SCAN));
-        assertEquals("myscanname bom", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.BOM));
-        assertEquals("myscanname bom 2", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.BOM));
+        assertEquals("myscanname Black Duck I/O Export", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.BOM));
+        assertEquals("myscanname Black Duck I/O Export 2", codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.BOM));
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGeneratorTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGeneratorTest.java
@@ -160,6 +160,6 @@ public class CodeLocationNameGeneratorTest {
 
         String codeLocationName = codeLocationNameGenerator.createAggregateStandardCodeLocationName(nameAndVersion);
 
-        assertEquals("prefix/project/version/suffix Black Duck I/O Export", codeLocationName);
+        assertEquals("prefix/project/version/suffix " + CodeLocationNameType.BOM.getName(), codeLocationName);
     }
 }


### PR DESCRIPTION
# Description

In 8.0 user supplied prefixes and suffixes entered via the detect.project.codelocation.prefix
detect.project.codelocation.suffix properties are not honored when the code location name is created. 

This seems to happen when aggregate code location name are generated, which seems to be the only approach in 8.0. In 7.14 the aggregate approach exists but it does not seem to be the default path and the non-aggregate approach honors the suffix and prefix.