### PR TITLE
style(log): Warn when project inspector fails

### DIFF
--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -13,6 +13,7 @@
 * (IDETECT-3419) Resolved an issue where the NuGet inspector cannot be found when a solution file cannot be found but multiple C# projects are found by Detect.
 * (IDETECT-3306) Resolved an issue where a NullPointerException would occur when project inspector discovered no modules for a project.
 * (IDETECT-3308) The __MACOSX directory will now be ignored by default when determining which detectors are applicable for a project.
+* (IDETECT-3307) Warn when project inspector cannot be downloaded, installed, or found.
 
 ## Version 8.0.0
 

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/ArtifactoryZipInstaller.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/ArtifactoryZipInstaller.java
@@ -56,13 +56,18 @@ public class ArtifactoryZipInstaller {
             try {
                 artifactResolver.downloadArtifact(zipFile, source);
             } catch (IOException e) {
+            	logger.warn("Failed to download artifact: " + source);
                 throw new IntegrationException("Failed to download artifact: " + source, e);
             }
             logger.debug("Extracting inspector.");
             try {
                 DetectZipUtil.unzip(zipFile, inspectorFolder, Charset.defaultCharset());
             } catch (IOException e) {
+            	if (logger.isTraceEnabled()) {
                 logger.trace("Exception extracting:", e);
+            	} else {
+            		logger.warn("Failed to unzip artifact: " + zipFile);
+            	}
                 throw new IntegrationException("Failed to unzip artifact: " + zipFile, e);
             }
             logger.debug("Unzipped, deleting downloaded zip.");

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/ArtifactoryZipInstaller.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/ArtifactoryZipInstaller.java
@@ -56,18 +56,18 @@ public class ArtifactoryZipInstaller {
             try {
                 artifactResolver.downloadArtifact(zipFile, source);
             } catch (IOException e) {
-            	logger.warn("Failed to download artifact: " + source);
+                logger.warn("Failed to download artifact: " + source);
                 throw new IntegrationException("Failed to download artifact: " + source, e);
             }
             logger.debug("Extracting inspector.");
             try {
                 DetectZipUtil.unzip(zipFile, inspectorFolder, Charset.defaultCharset());
             } catch (IOException e) {
-            	if (logger.isTraceEnabled()) {
-                logger.trace("Exception extracting:", e);
-            	} else {
-            		logger.warn("Failed to unzip artifact: " + zipFile);
-            	}
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Exception extracting:", e);
+                } else {
+                    logger.warn("Failed to unzip artifact: " + zipFile);
+                }
                 throw new IntegrationException("Failed to unzip artifact: " + zipFile, e);
             }
             logger.debug("Unzipped, deleting downloaded zip.");

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/nuget/OnlineNugetInspectorResolver.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/nuget/OnlineNugetInspectorResolver.java
@@ -47,16 +47,21 @@ public class OnlineNugetInspectorResolver implements NugetInspectorResolver {
             try {
                 inspectorFile = installer.install(installDirectory);
             } catch (DetectableException e) {
-                logger.debug("Unable to install the detect nuget inspector from Artifactory.", e);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Unable to install the detect nuget inspector from Artifactory.", e);
+                } else {
+                    logger.warn("Unable to install the detect nuget inspector from Artifactory.");
+                }
             }
 
             if (inspectorFile == null) {
                 // Remote installation has failed
                 logger.debug("Attempting to locate previous install of detect nuget inspector.");
                 inspectorFile = installedToolLocator.locateTool(INSPECTOR_NAME)
-                    .orElseThrow(() ->
-                        new DetectableException("Unable to locate previous install of the detect nuget inspector.")
-                    );
+                    .orElseThrow(() -> {
+                        logger.warn("Unable to locate previous install of the detect nuget inspector.");
+                        return new DetectableException("Unable to locate previous install of the detect nuget inspector.");
+                    });
             } else {
                 installedToolManager.saveInstalledToolLocation(INSPECTOR_NAME, inspectorFile.getAbsolutePath());
             }

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/projectinspector/OnlineProjectInspectorResolver.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/projectinspector/OnlineProjectInspectorResolver.java
@@ -45,12 +45,13 @@ public class OnlineProjectInspectorResolver implements com.synopsys.integration.
             try {
                 projectInspectorExeFile = projectInspectorInstaller.install(installDirectory);
             } catch (DetectableException e) {
-                logger.debug("Unable to install the project inspector.");
+                logger.warn("Unable to install the project inspector.");
             }
             if (projectInspectorExeFile == null) {
                 if (projectInspectorInstaller.shouldFallbackToPreviousInstall()) {
                     return findExistingInstallation();
                 } else {
+                	logger.warn("Unable to locate given project inspector zip file.");
                     throw new DetectableException("Unable to locate given project inspector zip file.");
                 }
             } else {
@@ -64,8 +65,9 @@ public class OnlineProjectInspectorResolver implements com.synopsys.integration.
         logger.debug("Attempting to locate previous install of project inspector.");
         return installedToolLocator.locateTool(INSTALLED_TOOL_JSON_KEY)
             .map(ExecutableTarget::forFile)
-            .orElseThrow(() ->
-                new DetectableException("Unable to locate previous install of the project inspector.")
-            );
+            .orElseThrow(() -> {
+            	logger.warn("Unable to locate previous install of the project inspector.");
+            	return new DetectableException("Unable to locate previous install of the project inspector.");
+            });
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/projectinspector/OnlineProjectInspectorResolver.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/projectinspector/OnlineProjectInspectorResolver.java
@@ -51,7 +51,7 @@ public class OnlineProjectInspectorResolver implements com.synopsys.integration.
                 if (projectInspectorInstaller.shouldFallbackToPreviousInstall()) {
                     return findExistingInstallation();
                 } else {
-                	logger.warn("Unable to locate given project inspector zip file.");
+                    logger.warn("Unable to locate given project inspector zip file.");
                     throw new DetectableException("Unable to locate given project inspector zip file.");
                 }
             } else {
@@ -66,8 +66,8 @@ public class OnlineProjectInspectorResolver implements com.synopsys.integration.
         return installedToolLocator.locateTool(INSTALLED_TOOL_JSON_KEY)
             .map(ExecutableTarget::forFile)
             .orElseThrow(() -> {
-            	logger.warn("Unable to locate previous install of the project inspector.");
-            	return new DetectableException("Unable to locate previous install of the project inspector.");
+                logger.warn("Unable to locate previous install of the project inspector.");
+                return new DetectableException("Unable to locate previous install of the project inspector.");
             });
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/airgap/NugetInspectorAirGapCreator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/airgap/NugetInspectorAirGapCreator.java
@@ -41,7 +41,7 @@ public class NugetInspectorAirGapCreator {
             FileUtils.copyDirectory(downloaded, destination); //move 'destination/zipName' to 'destination'
             FileUtils.deleteDirectory(downloaded); //delete 'destination/zipName'
         } catch (DetectableException | IOException e) {
-        	logger.warn("An error occurred installing project-inspector to the " + targetDirectory + " folder.");
+            logger.warn("An error occurred installing project-inspector to the " + targetDirectory + " folder.");
             throw new DetectUserFriendlyException("An error occurred installing project-inspector to the " + targetDirectory + " folder.", e, ExitCodeType.FAILURE_GENERAL_ERROR);
         }
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/airgap/NugetInspectorAirGapCreator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/airgap/NugetInspectorAirGapCreator.java
@@ -41,6 +41,7 @@ public class NugetInspectorAirGapCreator {
             FileUtils.copyDirectory(downloaded, destination); //move 'destination/zipName' to 'destination'
             FileUtils.deleteDirectory(downloaded); //delete 'destination/zipName'
         } catch (DetectableException | IOException e) {
+        	logger.warn("An error occurred installing project-inspector to the " + targetDirectory + " folder.");
             throw new DetectUserFriendlyException("An error occurred installing project-inspector to the " + targetDirectory + " folder.", e, ExitCodeType.FAILURE_GENERAL_ERROR);
         }
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/airgap/ProjectInspectorAirGapCreator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/airgap/ProjectInspectorAirGapCreator.java
@@ -41,6 +41,7 @@ public class ProjectInspectorAirGapCreator {
             FileUtils.copyDirectory(downloaded, destination); //move 'destination/zipName' to 'destination'
             FileUtils.deleteDirectory(downloaded); //delete 'destination/zipName'
         } catch (DetectableException | IOException e) {
+        	logger.warn("An error occurred installing project-inspector to the " + targetDirectory + " folder.");
             throw new DetectUserFriendlyException("An error occurred installing project-inspector to the " + targetDirectory + " folder.", e, ExitCodeType.FAILURE_GENERAL_ERROR);
         }
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/airgap/ProjectInspectorAirGapCreator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/airgap/ProjectInspectorAirGapCreator.java
@@ -41,7 +41,7 @@ public class ProjectInspectorAirGapCreator {
             FileUtils.copyDirectory(downloaded, destination); //move 'destination/zipName' to 'destination'
             FileUtils.deleteDirectory(downloaded); //delete 'destination/zipName'
         } catch (DetectableException | IOException e) {
-        	logger.warn("An error occurred installing project-inspector to the " + targetDirectory + " folder.");
+            logger.warn("An error occurred installing project-inspector to the " + targetDirectory + " folder.");
             throw new DetectUserFriendlyException("An error occurred installing project-inspector to the " + targetDirectory + " folder.", e, ExitCodeType.FAILURE_GENERAL_ERROR);
         }
     }


### PR DESCRIPTION
# Description

Add a warning message to the log whenever project inspector cannot be found, downloaded, or installed.

There are several code paths where this could happen:

- When the zip is being downloaded. A warning was added at this low level which handles all callers.
- When the zip is being decompressed and copied to more permanent places. Specifically when: 
-- 1) A NuGet air gap jar is being created. 
-- 2) When the NuGet inspector is downloading the zip. 
-- 3) When a standard air gap detect jar is being created. 
-- 4) When a standard run of detect downloads the jar.
- When a previous version is being looked for. Code changes handle both the NuGet and standard case.