### PR TITLE
Update integration-common and jackson-databind libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ allprojects {
         implementation 'org.jetbrains:annotations:20.1.0'
         implementation 'net.minidev:json-smart:2.4.7'
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
 
         implementation 'org.freemarker:freemarker:2.3.31'
         implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.13'

--- a/src/main/resources/create-gradle-airgap-script.ftl
+++ b/src/main/resources/create-gradle-airgap-script.ftl
@@ -9,8 +9,8 @@ configurations {
 }
 
 dependencies {
-    airGap 'com.synopsys.integration:integration-common:25.3.3'
-    airGap 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    airGap 'com.synopsys.integration:integration-common:26.0.2'
+    airGap 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
 }
 
 task installDependencies(type: Copy) {


### PR DESCRIPTION
# Description

This work updates the jackson-databind library as well as the integration-common library (primarily to obtain an updated gson). This reduces vulnerabilities in detect from third party libraries. Also confirmed that we are using the latest version of blackduck-common.
