### PR TITLE
feat: add detect.status.json.output.path to specify status.json path

### DIFF
--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -14,6 +14,7 @@
 * (IDETECT-3306) Resolved an issue where a NullPointerException would occur when project inspector discovered no modules for a project.
 * (IDETECT-3308) The __MACOSX directory will now be ignored by default when determining which detectors are applicable for a project.
 * (IDETECT-3307) Warn when project inspector cannot be downloaded, installed, or found.
+* (IDETECT-3229) Added the detect.status.json.output.path to place a copy of the status.json in a specified directory location.
 
 ## Version 8.0.0
 

--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -209,10 +209,12 @@ public class Application implements ApplicationRunner {
             String json = formattedGson.toJson(formattedOutputManager.createFormattedOutput(detectInfo));
             FileUtils.writeStringToFile(statusFile, json, Charset.defaultCharset());
             
-            File statusCopyFile = new File(directoryManager.getJsonStatusOutputDirectory(), "status.json");
-            logger.info("Creating copy of status file: {}", statusCopyFile);
-            FileUtils.writeStringToFile(statusCopyFile, json, Charset.defaultCharset());
-            
+
+            if (directoryManager.getJsonStatusOutputDirectory() != null) {
+                File statusCopyFile = new File(directoryManager.getJsonStatusOutputDirectory(), "status.json");
+                logger.info("Creating copy of status file: {}", statusCopyFile);
+                FileUtils.writeStringToFile(statusCopyFile, json, Charset.defaultCharset());  
+            }
         } catch (Exception e) {
             logger.warn("There was a problem writing the status output file. The detect run was not affected.");
             logger.debug("The problem creating the status file was: ", e);

--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -208,6 +208,11 @@ public class Application implements ApplicationRunner {
             Gson formattedGson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
             String json = formattedGson.toJson(formattedOutputManager.createFormattedOutput(detectInfo));
             FileUtils.writeStringToFile(statusFile, json, Charset.defaultCharset());
+            
+            File statusCopyFile = new File(directoryManager.getJsonStatusOutputDirectory(), "status.json");
+            logger.info("Creating copy of status file: {}", statusCopyFile);
+            FileUtils.writeStringToFile(statusCopyFile, json, Charset.defaultCharset());
+            
         } catch (Exception e) {
             logger.warn("There was a problem writing the status output file. The detect run was not affected.");
             logger.debug("The problem creating the status file was: ", e);

--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -209,7 +209,6 @@ public class Application implements ApplicationRunner {
             String json = formattedGson.toJson(formattedOutputManager.createFormattedOutput(detectInfo));
             FileUtils.writeStringToFile(statusFile, json, Charset.defaultCharset());
             
-
             if (directoryManager.getJsonStatusOutputDirectory() != null) {
                 File statusCopyFile = new File(directoryManager.getJsonStatusOutputDirectory(), "status.json");
                 logger.info("Creating copy of status file: {}", statusCopyFile);

--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -58,6 +58,8 @@ public class Application implements ApplicationRunner {
     private final Logger logger = LoggerFactory.getLogger(Application.class);
 
     private static boolean SHOULD_EXIT = true;
+    
+    private static String STATUS_JSON_FILE_NAME = "status.json";
 
     private final ConfigurableEnvironment environment;
 
@@ -202,7 +204,7 @@ public class Application implements ApplicationRunner {
     private void createStatusOutputFile(FormattedOutputManager formattedOutputManager, DetectInfo detectInfo, DirectoryManager directoryManager) {
         logger.info("");
         try {
-            File statusFile = new File(directoryManager.getStatusOutputDirectory(), "status.json");
+            File statusFile = new File(directoryManager.getStatusOutputDirectory(), STATUS_JSON_FILE_NAME);
             logger.info("Creating status file: {}", statusFile);
 
             Gson formattedGson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
@@ -210,7 +212,7 @@ public class Application implements ApplicationRunner {
             FileUtils.writeStringToFile(statusFile, json, Charset.defaultCharset());
             
             if (directoryManager.getJsonStatusOutputDirectory() != null) {
-                File statusCopyFile = new File(directoryManager.getJsonStatusOutputDirectory(), "status.json");
+                File statusCopyFile = new File(directoryManager.getJsonStatusOutputDirectory(), STATUS_JSON_FILE_NAME);
                 logger.info("Creating copy of status file: {}", statusCopyFile);
                 FileUtils.writeStringToFile(statusCopyFile, json, Charset.defaultCharset());  
             }

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -226,7 +226,8 @@ public class DetectConfigurationFactory {
         Path scanPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_SCAN_OUTPUT_PATH);
         Path toolsOutputPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_TOOLS_OUTPUT_PATH);
         Path impactOutputPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_IMPACT_ANALYSIS_OUTPUT_PATH);
-        return new DirectoryOptions(sourcePath, outputPath, bdioPath, scanPath, toolsOutputPath, impactOutputPath);
+        Path statusJsonPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_STATUS_JSON_OUTPUT_PATH);
+        return new DirectoryOptions(sourcePath, outputPath, bdioPath, scanPath, toolsOutputPath, impactOutputPath, statusJsonPath);
     }
 
     public List<String> collectSignatureScannerDirectoryExclusions() {

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1709,7 +1709,7 @@ public class DetectProperties {
     
     public static final NullablePathProperty DETECT_STATUS_JSON_OUTPUT_PATH =
             NullablePathProperty.newBuilder("detect.status.json.output.path")
-                .setInfo("Status.json Output Path", DetectPropertyFromVersion.VERSION_8_1_0)
+                .setInfo("Status JSON Output Path", DetectPropertyFromVersion.VERSION_8_1_0)
                 .setHelp(
                     "The directory to place a copy of the status.json file.",
                     "If set, Detect will use the given directory to store a copy of the status.json file."

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1706,6 +1706,16 @@ public class DetectProperties {
             .setGroups(DetectGroup.RAPID_SCAN, DetectGroup.BLACKDUCK_SERVER, DetectGroup.BLACKDUCK, DetectGroup.GLOBAL)
             .setCategory(DetectCategory.Advanced)
             .build();
+    
+    public static final NullablePathProperty DETECT_STATUS_JSON_OUTPUT_PATH =
+            NullablePathProperty.newBuilder("detect.status.json.output.path")
+                .setInfo("Status.json Output Path", DetectPropertyFromVersion.VERSION_8_1_0)
+                .setHelp(
+                    "The directory to place a copy of the status.json file.",
+                    "If set, Detect will use the given directory to store a copy of the status.json file."
+                )
+                .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
+                .build();
 
     //#endregion Active Properties
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/file/DirectoryManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/file/DirectoryManager.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +45,7 @@ public class DirectoryManager {
         SCAN("scan"),
         SHARED("shared"),
         STATUS("status"),
+        STATUS_COPY("status-copy"),
         IAC("iac");
 
         private final String directoryName;
@@ -105,7 +107,10 @@ public class DirectoryManager {
 
         logger.info("Run directory: " + runDirectory.getAbsolutePath());
 
-        EnumSet.allOf(RunDirectory.class)
+        EnumSet.allOf(RunDirectory.class).stream()
+            // Do not initialize the directory to copy the status.json file into, we'll set 
+            // it later if the user specified the detect.status.json.output.path property.
+            .filter(it -> !it.equals(RunDirectory.STATUS_COPY))
             .forEach(it -> runDirectories.put(it, new File(runDirectory, it.getDirectoryName())));
 
         //overrides
@@ -120,6 +125,10 @@ public class DirectoryManager {
         directoryOptions.getImpactOutputPathOverride()
             .map(Path::toFile)
             .ifPresent(scanOutputPath -> runDirectories.put(RunDirectory.IMPACT_ANALYSIS, scanOutputPath));
+        
+        directoryOptions.getStatusJsonOutputPathOverride()
+            .map(Path::toFile)
+            .ifPresent(scanOutputPath -> runDirectories.put(RunDirectory.STATUS_COPY, scanOutputPath));
     }
 
     public File getUserHome() {
@@ -180,6 +189,10 @@ public class DirectoryManager {
 
     public File getStatusOutputDirectory() {
         return getRunDirectory(RunDirectory.STATUS);
+    }
+    
+    public File getJsonStatusOutputDirectory() {
+        return getRunDirectory(RunDirectory.STATUS_COPY);
     }
 
     public File getExecutableOutputDirectory() {

--- a/src/main/java/com/synopsys/integration/detect/workflow/file/DirectoryManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/file/DirectoryManager.java
@@ -192,7 +192,11 @@ public class DirectoryManager {
     }
     
     public File getJsonStatusOutputDirectory() {
-        return getRunDirectory(RunDirectory.STATUS_COPY);
+        File actualDirectory = runDirectories.get(RunDirectory.STATUS_COPY);
+        if (actualDirectory != null && !actualDirectory.exists()) {
+            actualDirectory.mkdirs();
+        }
+        return actualDirectory;
     }
 
     public File getExecutableOutputDirectory() {

--- a/src/main/java/com/synopsys/integration/detect/workflow/file/DirectoryOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/file/DirectoryOptions.java
@@ -13,14 +13,16 @@ public class DirectoryOptions {
     private final Path scanOutputPath;
     private final Path toolsOutputPath;
     private final Path impactOutputPath;
+    private final Path statusJsonOutputPath;
 
-    public DirectoryOptions(Path sourcePath, Path outputPath, Path bdioOutputPath, Path scanOutputPath, Path toolsOutputPath, Path impactOutputPath) throws IOException {
+    public DirectoryOptions(Path sourcePath, Path outputPath, Path bdioOutputPath, Path scanOutputPath, Path toolsOutputPath, Path impactOutputPath, Path statusJsonPath) throws IOException {
         this.sourcePath = toRealPath(sourcePath);
         this.outputPath = toRealPath(outputPath);
         this.bdioOutputPath = toRealPath(bdioOutputPath);
         this.scanOutputPath = toRealPath(scanOutputPath);
         this.toolsOutputPath = toRealPath(toolsOutputPath);
         this.impactOutputPath = toRealPath(impactOutputPath);
+        this.statusJsonOutputPath = toRealPath(statusJsonPath);
     }
 
     public Optional<Path> getSourcePathOverride() {
@@ -41,6 +43,10 @@ public class DirectoryOptions {
 
     public Optional<Path> getImpactOutputPathOverride() {
         return Optional.ofNullable(impactOutputPath);
+    }
+
+    public Optional<Path> getStatusJsonOutputPathOverride() {
+        return Optional.ofNullable(statusJsonOutputPath);
     }
 
     public Optional<Path> getToolsOutputPath() {

--- a/src/test/java/com/synopsys/integration/detect/FontLoaderTestIT.java
+++ b/src/test/java/com/synopsys/integration/detect/FontLoaderTestIT.java
@@ -50,7 +50,7 @@ public class FontLoaderTestIT {
         InstalledToolManager installedToolManager = new InstalledToolManager();
         InstalledToolLocator installedToolLocator = new InstalledToolLocator(Paths.get(""), new Gson());
         DetectFontInstaller installer = new DetectFontInstaller(artifactResolver, installedToolManager, installedToolLocator);
-        DirectoryOptions directoryOptions = new DirectoryOptions(null, null, null, null, fontDirectory.toPath(), null);
+        DirectoryOptions directoryOptions = new DirectoryOptions(null, null, null, null, fontDirectory.toPath(), null, null);
         DirectoryManager directoryManager = new DirectoryManager(directoryOptions, DetectRunId.createDefault());
         detectFontLocator = new OnlineDetectFontLocator(installer, directoryManager);
     }

--- a/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeGenerateJsonOperationTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeGenerateJsonOperationTest.java
@@ -29,7 +29,7 @@ public class RapidModeGenerateJsonOperationTest {
 
         File tempDir = tempPath.toFile();
         File scanDir = new File(tempDir, "scan");
-        DirectoryOptions directoryOptions = new DirectoryOptions(null, null, null, scanDir.toPath(), null, null);
+        DirectoryOptions directoryOptions = new DirectoryOptions(null, null, null, scanDir.toPath(), null, null, null);
         DetectRunId detectRunId = new DetectRunId("testId");
         DirectoryManager directoryManager = new DirectoryManager(directoryOptions, detectRunId);
         RapidModeGenerateJsonOperation op = new RapidModeGenerateJsonOperation(gson, directoryManager);

--- a/src/test/java/com/synopsys/integration/detect/workflow/status/DetectStatusOutputTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/status/DetectStatusOutputTest.java
@@ -1,0 +1,27 @@
+package com.synopsys.integration.detect.workflow.status;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.synopsys.integration.detect.workflow.DetectRunId;
+import com.synopsys.integration.detect.workflow.file.DirectoryManager;
+import com.synopsys.integration.detect.workflow.file.DirectoryOptions;
+
+public class DetectStatusOutputTest {
+    @Test
+    void testJsonStatusOutputDirectory(@TempDir Path tempPath) throws IOException {
+        File tempDir = tempPath.toFile();
+        File scanDir = new File(tempDir, "scan");
+        DirectoryOptions directoryOptions = new DirectoryOptions(null, null, null, scanDir.toPath(), null, null, tempPath);
+        DetectRunId detectRunId = new DetectRunId("testId");
+        DirectoryManager directoryManager = new DirectoryManager(directoryOptions, detectRunId);
+        
+        assertEquals(tempPath.toFile(), directoryManager.getJsonStatusOutputDirectory());
+    }
+}


### PR DESCRIPTION
# Description

This work adds the new --detect.status.json.output.path property which should be set to a directory where a single status.json file will be written. Please note that the status.json file still will be written to the main detect run directory. This is simply a duplicate copy with a more predictable path so that tools can more easily process the file.
