### PR TITLE
fix: Add Black Duck API error response body to messages for failed operation

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/status/Operation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/Operation.java
@@ -21,6 +21,8 @@ public class Operation {
     private final String name;
     private StatusType statusType;
     private Exception exception;
+    @Nullable
+    private String troubleshootingDetails;
     private final OperationType operationType;
     @Nullable
     private final String phoneHomeKey;
@@ -87,6 +89,14 @@ public class Operation {
     public void error(Exception e) {
         this.statusType = StatusType.FAILURE;
         this.exception = e;
+        this.troubleshootingDetails = null;
+        finish();
+    }
+
+    public void error(Exception e, String troubleshootingDetails) {
+        this.statusType = StatusType.FAILURE;
+        this.exception = e;
+        this.troubleshootingDetails = troubleshootingDetails;
         finish();
     }
 
@@ -115,6 +125,10 @@ public class Operation {
     }
 
     public Optional<Exception> getException() {return Optional.ofNullable(exception);}
+
+    public Optional<String> getTroubleshootingDetails() {
+        return Optional.ofNullable(troubleshootingDetails);
+    }
 
     public OperationType getOperationType() {
         return operationType;

--- a/src/main/java/com/synopsys/integration/detect/workflow/status/OperationSystem.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/OperationSystem.java
@@ -1,8 +1,9 @@
 package com.synopsys.integration.detect.workflow.status;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -23,7 +24,10 @@ public class OperationSystem {
 
     private void publishOperationIssues(Operation operation) {
         operation.getException().ifPresent(exception -> {
-            statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.EXCEPTION, operation.getName(), Arrays.asList(ExceptionUtility.summarizeException(exception))));
+            List<String> messages = new ArrayList<>();
+            messages.add(ExceptionUtility.summarizeException(exception));
+            operation.getTroubleshootingDetails().ifPresent(details -> messages.add(details));
+            statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.EXCEPTION, operation.getName(), messages));
         });
     }
 


### PR DESCRIPTION
In OperationWrapper, added a catch clause for BlackDuckApiException, read the response body and store it into (a new field in) the Operation object. Then later in OperationSystem includes it in the messages for the failed operation.
