### PR TITLE
IDETECT-3187 | work to get more reasonable and informative error mess…

### DIFF
--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -7,7 +7,7 @@
 ### Changed features
 
 * Added property detect.project.inspector.path to enable pointing [solution_name] to a local Project Inspector zip file.
-* Enhancements to error reporting to ensure that any exception will have the root cause reported in the error message for certain exception types. Also included in the reporting is the Black Duck response content of the transaction for api exceptions.
+* Enhancements to error reporting to ensure that any exception will have the root cause reported in the error message for certain exception types.
 
 ### Resolved issues
 

--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -7,6 +7,7 @@
 ### Changed features
 
 * Added property detect.project.inspector.path to enable pointing [solution_name] to a local Project Inspector zip file.
+* Enhancements to error reporting to ensure that any exception will have the root cause reported in the error message for certain exception types. Also included in the reporting is the Black Duck response content of the transaction for api exceptions.
 
 ### Resolved issues
 
@@ -15,6 +16,7 @@
 * (IDETECT-3308) The __MACOSX directory will now be ignored by default when determining which detectors are applicable for a project.
 * (IDETECT-3307) Warn when project inspector cannot be downloaded, installed, or found.
 * (IDETECT-3229) Added the detect.status.json.output.path to place a copy of the status.json in a specified directory location.
+* (IDETECT-3187) Report Black Duck provided error message (from response body) whenever a Black Duck api call returns an error code
 
 ## Version 8.0.0
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
@@ -46,6 +46,16 @@ public class OperationWrapper {
             operation.error(e);
             errorConsumer.accept(e);
             throw e;
+        } catch (BlackDuckApiException e) {
+            String contentDetails = "Black Duck response body: " + e.getOriginalIntegrationRestException().getHttpResponseContent();
+            if (StringUtils.isNotBlank(contentDetails)) {
+                if (contentDetails.length() > MESSAGE_LENGTH_LIMIT) {
+                    contentDetails = contentDetails.substring(0, MESSAGE_LENGTH_LIMIT) + "...";
+                }
+                operation.error(e, contentDetails);
+            } else {
+                operation.error(e);
+            }
         } catch (Exception e) {
             // in some cases, the problem is buried in a nested exception 
             // (i.e. a "caused by" exception.  This will drill into that 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
@@ -3,12 +3,18 @@ package com.synopsys.integration.detect.lifecycle.run.step.utility;
 import java.io.IOException;
 import java.util.function.Consumer;
 
+import org.apache.commons.lang3.StringUtils;
+
+import com.synopsys.integration.blackduck.exception.BlackDuckApiException;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
 import com.synopsys.integration.detect.lifecycle.OperationException;
 import com.synopsys.integration.detect.workflow.status.Operation;
 import com.synopsys.integration.exception.IntegrationException;
 
 public class OperationWrapper {
+
+    private static final int MESSAGE_LENGTH_LIMIT = 600;
+
     public void wrapped(Operation operation, OperationFunction supplier) throws OperationException {
         wrapped(operation, () -> { //To reduce duplication, calling the supplier with a return type but throwing away the returned result.
             supplier.execute();
@@ -41,12 +47,33 @@ public class OperationWrapper {
             errorConsumer.accept(e);
             throw e;
         } catch (Exception e) {
-            operation.error(e);
+            // in some cases, the problem is buried in a nested exception 
+            // (i.e. a "caused by" exception.  This will drill into that 
+            // hierarchy and get the real error message.
+            if (null != e.getCause()) {
+                String rootMessage = rootCauseMessage(e);
+                operation.error(e, rootMessage);
+            } else {
+                operation.error(e);
+            }
             errorConsumer.accept(e);
             throw new OperationException(e);
         } finally {
             operation.finish();
         }
+    }
+    
+    private String rootCauseMessage(Exception e) {
+        String msg = "";
+        Throwable t = e.getCause();
+        if (null == t) {
+            return e.getMessage();
+        } else if (t instanceof Exception) {
+            msg = this.rootCauseMessage((Exception)t);
+        } else {
+            msg = e.getMessage();
+        }
+        return msg;
     }
 
     @FunctionalInterface

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
@@ -56,6 +56,7 @@ public class OperationWrapper {
             } else {
                 operation.error(e);
             }
+            errorConsumer.accept(e);
             throw new OperationException(e);
         } catch (Exception e) {
             // in some cases, the problem is buried in a nested exception 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/utility/OperationWrapper.java
@@ -56,6 +56,7 @@ public class OperationWrapper {
             } else {
                 operation.error(e);
             }
+            throw new OperationException(e);
         } catch (Exception e) {
             // in some cases, the problem is buried in a nested exception 
             // (i.e. a "caused by" exception.  This will drill into that 

--- a/src/main/java/com/synopsys/integration/detect/workflow/status/Operation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/Operation.java
@@ -21,6 +21,8 @@ public class Operation {
     private final String name;
     private StatusType statusType;
     private Exception exception;
+    @Nullable
+    private String troubleshootingDetails;
     private final OperationType operationType;
     @Nullable
     private final String phoneHomeKey;
@@ -87,9 +89,17 @@ public class Operation {
     public void error(Exception e) {
         this.statusType = StatusType.FAILURE;
         this.exception = e;
+        this.troubleshootingDetails = null;
         finish();
     }
 
+    public void error(Exception e, String troubleshootingDetails) {
+        this.statusType = StatusType.FAILURE;
+        this.exception = e;
+        this.troubleshootingDetails = troubleshootingDetails;
+        finish();
+    }
+    
     public Instant getStartTime() {
         return startTime;
     }
@@ -116,6 +126,10 @@ public class Operation {
 
     public Optional<Exception> getException() {return Optional.ofNullable(exception);}
 
+    public Optional<String> getTroubleshootingDetails() {
+        return Optional.ofNullable(troubleshootingDetails);
+    }
+    
     public OperationType getOperationType() {
         return operationType;
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/status/OperationSystem.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/OperationSystem.java
@@ -1,8 +1,9 @@
 package com.synopsys.integration.detect.workflow.status;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -23,8 +24,10 @@ public class OperationSystem {
 
     private void publishOperationIssues(Operation operation) {
         operation.getException().ifPresent(exception -> {
-            statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.EXCEPTION, operation.getName(), Arrays.asList(ExceptionUtility.summarizeException(exception))));
-        });
+            List<String> messages = new ArrayList<>();
+            messages.add(ExceptionUtility.summarizeException(exception));
+            operation.getTroubleshootingDetails().ifPresent(details -> messages.add(details));
+            statusEventPublisher.publishIssue(new DetectIssue(DetectIssueType.EXCEPTION, operation.getName(), messages));        });
     }
 
     public Operation startOperation(String operationName, OperationType type) {


### PR DESCRIPTION
…ages to show in the "ISSUES" section of the detect output | jppetrakis

Code to (when appropriate) obtain the base error message.  Currently, the actual root cause can be obscured by exception messages which obscure the true nature of the problem.  These are reported in the "ISSUES" section of the detect output which appears to be where one would go to find an actual problem cause.

Change to accept the extra messaging provided by the child exception of the high-level "OperationException" type, along with logic to drill down into the cause-throwables to obtain the base message and report it along with the higher level message.

# Github Issues

(Optional) Please link to any applicable github issues.
