### PR TITLE
Sb fix policychecker filtering

### DIFF
--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -17,6 +17,7 @@
 * (IDETECT-3307) Warn when project inspector cannot be downloaded, installed, or found.
 * (IDETECT-3229) Added the detect.status.json.output.path to place a copy of the status.json in a specified directory location.
 * (IDETECT-3187) Report Black Duck provided error message (from response body) whenever a Black Duck api call returns an error code
+* (IDETECT-3449) Resolved an issue that caused overridden violations to be reported as violations when the BOM also contained legitimate violations.
 
 ## Version 8.0.0
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/policy/PolicyChecker.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/policy/PolicyChecker.java
@@ -97,7 +97,7 @@ public class PolicyChecker {
 
         List<ProjectVersionComponentVersionView> bomComponents = projectBomService.getComponentsForProjectVersion(projectVersionView);
         for (ProjectVersionComponentVersionView projectVersionComponentView : bomComponents) {
-            if (projectVersionComponentView.getPolicyStatus().equals(ProjectVersionComponentPolicyStatusType.NOT_IN_VIOLATION)) {
+            if (!projectVersionComponentView.getPolicyStatus().equals(ProjectVersionComponentPolicyStatusType.IN_VIOLATION)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixed code that is supposed to filter out all not-in-violation bom components that in fact let in-violation-but-overridden components slip through and get reported as violations.
