### PR TITLE
construct errors and warnings for non-persistent signature scans

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
@@ -1,10 +1,18 @@
 package com.synopsys.integration.detect.workflow.blackduck.developer.aggregate;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang3.StringUtils;
+
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesView;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesView;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView;
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsViolatingPoliciesView;
+import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 
 public class RapidScanComponentGroupDetail {
     private final RapidScanDetailGroup group;
@@ -71,5 +79,114 @@ public class RapidScanComponentGroupDetail {
         if (StringUtils.isNotBlank(warningMessage)) {
             addWarning(warningMessage);
         }
+    }
+
+    public void addComponentMessages(DeveloperScansScanView resultView) {
+        String baseMessage = getBaseMessage(resultView);
+
+        List<DeveloperScansScanItemsViolatingPoliciesView> violatingPolicies = resultView.getViolatingPolicies();
+
+        String errorMessage = "", warningMessage = "";
+
+        for (int i = 0; i < violatingPolicies.size(); i++) {
+            DeveloperScansScanItemsViolatingPoliciesView violation = violatingPolicies.get(i);
+
+            if (violation.getPolicySeverity().equals("CRITICAL") || violation.getPolicySeverity().equals("BLOCKER")) {
+                if (errorMessage.equals("")) {
+                    errorMessage = baseMessage;
+                } else {
+                    errorMessage += ", ";
+                }
+                
+                errorMessage += violation.getPolicyName();
+            } else {
+                if (warningMessage.equals("")) {
+                    warningMessage = baseMessage;
+                } else {
+                    warningMessage += ", ";
+                }
+                
+                warningMessage += violation.getPolicyName();
+            }
+        }
+        addMessages(errorMessage, warningMessage);
+    }
+
+    public void addLicenseMessages(DeveloperScansScanView resultView, DeveloperScansScanItemsPolicyViolationLicensesView licensePolicyViolation) {
+        String baseMessage = getBaseMessage(resultView);
+        
+        List<DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView> violatingPolicies = licensePolicyViolation.getViolatingPolicies();
+        
+        String errorMessage = "", warningMessage = "";
+        
+        for (int i = 0; i < violatingPolicies.size(); i++) {
+            DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView violation = violatingPolicies.get(i);
+                    
+            if (violation.getPolicySeverity().equals("CRITICAL") || violation.getPolicySeverity().equals("BLOCKER")) {
+                if (errorMessage.equals("")) {
+                    errorMessage = baseMessage;
+                } else {
+                    errorMessage += ", ";
+                }
+                
+                errorMessage += violation.getPolicyName() + ": license " + licensePolicyViolation.getName();
+            } else {
+                if (warningMessage.equals("")) {
+                    warningMessage = baseMessage;
+                } else {
+                    warningMessage += ", ";
+                }
+                
+                warningMessage += violation.getPolicyName() + ": license " + licensePolicyViolation.getName();
+            }
+        }
+        addMessages(errorMessage, warningMessage);
+    }
+    
+    public void addVulnerabilityMessages(DeveloperScansScanView resultView,
+            DeveloperScansScanItemsPolicyViolationVulnerabilitiesView vulnerability) {
+        String baseMessage = getBaseMessage(resultView);
+        
+        List<DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView> violatingPolicies = vulnerability.getViolatingPolicies();
+        
+        String errorMessage = "", warningMessage = "";
+        
+        for (int i = 0; i < violatingPolicies.size(); i++) {
+            DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView violation = violatingPolicies.get(i);
+            
+            if (violation.getPolicySeverity().equals("CRITICAL") || violation.getPolicySeverity().equals("BLOCKER")) {
+                if (errorMessage.equals("")) {
+                    errorMessage = baseMessage;
+                } else {
+                    errorMessage += ", ";
+                }
+                
+                errorMessage += violation.getPolicyName();
+                errorMessage += ": found vulnerability " + vulnerability.getName();
+                errorMessage += " with severity " + vulnerability.getVulnSeverity();
+                errorMessage += " and CVSS score " + vulnerability.getOverallScore();
+            } else {
+                if (warningMessage.equals("")) {
+                    warningMessage = baseMessage;
+                } else {
+                    warningMessage += ", ";
+                }
+                
+                warningMessage += violation.getPolicyName();
+                warningMessage += ": found vulnerability " + vulnerability.getName();
+                warningMessage += " with severity " + vulnerability.getVulnSeverity();
+                warningMessage += " and CVSS score " + vulnerability.getOverallScore();
+            }
+        }
+        addMessages(errorMessage, warningMessage);
+    }
+    
+    private String getBaseMessage(DeveloperScansScanView resultView) {
+        String baseMessage = "Component " + resultView.getComponentName() + " version " + resultView.getVersionName();
+        if (StringUtils.isNotBlank(resultView.getExternalId())) {
+            baseMessage += " with ID " + resultView.getExternalId();
+        }
+        baseMessage += " violates policy ";
+        return baseMessage;
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
@@ -126,20 +126,30 @@ public class RapidScanComponentGroupDetail {
                 if (errorMessage.equals("")) {
                     errorMessage = baseMessage;
                 } else {
-                    errorMessage += ", ";
+                    errorMessage += "/";
                 }
                 
-                errorMessage += violation.getPolicyName() + ": license " + licensePolicyViolation.getName();
+                errorMessage += violation.getPolicyName();
             } else {
                 if (warningMessage.equals("")) {
                     warningMessage = baseMessage;
                 } else {
-                    warningMessage += ", ";
+                    warningMessage += "/";
                 }
                 
-                warningMessage += violation.getPolicyName() + ": license " + licensePolicyViolation.getName();
+                warningMessage += violation.getPolicyName();
             }
         }
+        
+        String summaryMessage = ": license " + licensePolicyViolation.getName();
+        
+        if (StringUtils.isNotBlank(errorMessage)) {
+            errorMessage += summaryMessage;
+        }
+        if (StringUtils.isNotBlank(warningMessage)) {
+            warningMessage += summaryMessage;
+        }
+        
         addMessages(errorMessage, warningMessage);
     }
     
@@ -158,26 +168,31 @@ public class RapidScanComponentGroupDetail {
                 if (errorMessage.equals("")) {
                     errorMessage = baseMessage;
                 } else {
-                    errorMessage += ", ";
+                    errorMessage += "/";
                 }
                 
                 errorMessage += violation.getPolicyName();
-                errorMessage += ": found vulnerability " + vulnerability.getName();
-                errorMessage += " with severity " + vulnerability.getVulnSeverity();
-                errorMessage += " and CVSS score " + vulnerability.getOverallScore();
             } else {
                 if (warningMessage.equals("")) {
                     warningMessage = baseMessage;
                 } else {
-                    warningMessage += ", ";
+                    warningMessage += "/";
                 }
                 
                 warningMessage += violation.getPolicyName();
-                warningMessage += ": found vulnerability " + vulnerability.getName();
-                warningMessage += " with severity " + vulnerability.getVulnSeverity();
-                warningMessage += " and CVSS score " + vulnerability.getOverallScore();
             }
         }
+        
+        String summaryMessage = ": found vulnerability " + vulnerability.getName() + " with severity "
+                + vulnerability.getVulnSeverity() + " and CVSS score " + vulnerability.getOverallScore();
+        
+        if (StringUtils.isNotBlank(errorMessage)) {
+            errorMessage += summaryMessage;
+        }
+        if (StringUtils.isNotBlank(warningMessage)) {
+            warningMessage += summaryMessage;
+        }
+        
         addMessages(errorMessage, warningMessage);
     }
     

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanResultAggregator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanResultAggregator.java
@@ -103,8 +103,8 @@ public class RapidScanResultAggregator {
 
             addVulnerabilityData(resultView, vulnerabilityViolations, securityGroupDetail);
             addLicenseData(resultView, licenseViolations, licenseGroupDetail);
-
-            componentGroupDetail.addMessages(constructOverviewErrorMessage(resultView), null);
+            
+            componentGroupDetail.addComponentMessages(resultView);
         }
         return componentDetails;
     }
@@ -133,100 +133,13 @@ public class RapidScanResultAggregator {
     private void addVulnerabilityData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsPolicyViolationVulnerabilitiesView> vulnerabilities,
             RapidScanComponentGroupDetail securityDetail) {
         for (DeveloperScansScanItemsPolicyViolationVulnerabilitiesView vulnerabilityPolicyViolation : vulnerabilities) {
-            securityDetail.addMessages(constructVulnerabilityErrorMessage(resultView, vulnerabilityPolicyViolation),
-                    null);
+            securityDetail.addVulnerabilityMessages(resultView, vulnerabilityPolicyViolation);
         }
     }
 
     private void addLicenseData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsPolicyViolationLicensesView> licenses, RapidScanComponentGroupDetail licenseDetail) {
         for (DeveloperScansScanItemsPolicyViolationLicensesView licensePolicyViolation : licenses) {
-            licenseDetail.addMessages(constructLicenseErrorMessage(resultView, licensePolicyViolation),
-                    null);
+            licenseDetail.addLicenseMessages(resultView, licensePolicyViolation);
         }
-    }
-    
-    /**
-     * In v5 there are no error messages supplied by hub as there were in v4 of the
-     * developer-scans endpoint. We can construct a rough error message from the other
-     * fields.
-     * 
-     * @param resultView
-     * @return
-     */
-    private String constructOverviewErrorMessage(DeveloperScansScanView resultView) {
-        String errorMessage = "Component " + resultView.getComponentName() +
-        " version " + resultView.getVersionName();  
-        if (StringUtils.isNotBlank(resultView.getExternalId())) {
-            errorMessage += " with ID " + resultView.getExternalId();
-        }
-        errorMessage += " violates policy ";
-        
-        List<DeveloperScansScanItemsViolatingPoliciesView> violatingPolicies = resultView.getViolatingPolicies();
-        
-        for (int i = 0; i < violatingPolicies.size(); i++) {
-            DeveloperScansScanItemsViolatingPoliciesView violation = violatingPolicies.get(i);
-                    
-            errorMessage += violation.getPolicyName();
-            
-            if (i != violatingPolicies.size() -1) {
-                errorMessage += ", ";
-            }
-        }
-        
-        return errorMessage;
-    }
-    
-    private String constructLicenseErrorMessage(DeveloperScansScanView resultView, DeveloperScansScanItemsPolicyViolationLicensesView licensePolicyViolation) {
-        String errorMessage = "Component " + resultView.getComponentName() +
-        " version " + resultView.getVersionName();
-        if (StringUtils.isNotBlank(resultView.getExternalId())) {
-            errorMessage += " with ID " + resultView.getExternalId();
-        }
-        errorMessage += " violates policy ";
-        
-        List<DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView> violatingPolicies = licensePolicyViolation.getViolatingPolicies();
-        
-        for (int i = 0; i < violatingPolicies.size(); i++) {
-            DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView violation = violatingPolicies.get(i);
-                    
-            errorMessage += violation.getPolicyName();
-            
-            if (i != violatingPolicies.size() -1) {
-                errorMessage += ", ";
-            } else {
-                errorMessage += ": license " + licensePolicyViolation.getName();
-            }
-        }
-        
-        return errorMessage;
-    }
-    
-    private String constructVulnerabilityErrorMessage(DeveloperScansScanView resultView,
-            DeveloperScansScanItemsPolicyViolationVulnerabilitiesView vulnerability) {
-        String errorMessage = "Component " + resultView.getComponentName() +
-        " version " + resultView.getVersionName();
-        if (StringUtils.isNotBlank(resultView.getExternalId())) {
-            errorMessage += " with ID " + resultView.getExternalId();
-        }
-        errorMessage += " violates policy ";
-        
-        List<DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView> violatingPolicies = vulnerability.getViolatingPolicies();
-        
-        for (int i = 0; i < violatingPolicies.size(); i++) {
-            DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView violation = violatingPolicies.get(i);
-            
-            errorMessage += violation.getPolicyName();
-            
-            if (i != violatingPolicies.size() -1) {
-                errorMessage += ", ";
-            } else {
-                errorMessage += ": found vulnerability " + vulnerability.getName();
-            }
-        }
-        
-        errorMessage += " with severity " + vulnerability.getVulnSeverity();
-        errorMessage += " and CVSS score " + vulnerability.getOverallScore();
-        
-        return errorMessage;
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanResultAggregatorTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanResultAggregatorTest.java
@@ -48,17 +48,11 @@ public class RapidScanResultAggregatorTest {
         aggregateResult.logResult(logger);
         RapidScanResultSummary summary = aggregateResult.getSummary();
         assertEquals(1, summary.getPolicyErrorCount());
-        // TODO this is based on the number of warning messages, still not sure what constitutes 
-        // a warning over an error.
-        //assertEquals(1, summary.getPolicyWarningCount());
+        assertEquals(1, summary.getPolicyWarningCount());
         assertEquals(1, summary.getSecurityErrorCount());
-        // TODO this is based on the number of warning messages, still not sure what constitutes 
-        // a warning over an error.
-        //assertEquals(1, summary.getSecurityWarningCount());
+        assertEquals(1, summary.getSecurityWarningCount());
         assertEquals(1, summary.getLicenseErrorCount());
-        // TODO this is based on the number of warning messages, still not sure what constitutes 
-        // a warning over an error.
-        //assertEquals(1, summary.getLicenseWarningCount());
+        assertEquals(1, summary.getLicenseWarningCount());
         assertFalse(logger.getOutputList(LogLevel.INFO).isEmpty());
     }
 
@@ -92,10 +86,17 @@ public class RapidScanResultAggregatorTest {
 
                 DeveloperScansScanItemsViolatingPoliciesView view = new DeveloperScansScanItemsViolatingPoliciesView();
                 view.setPolicyName("component_policy");
-                view.setPolicyName("vulnerability_policy");
-                view.setPolicyName("license_policy");
+                view.setPolicySeverity("CRITICAL");
+                DeveloperScansScanItemsViolatingPoliciesView view2 = new DeveloperScansScanItemsViolatingPoliciesView();
+                view2.setPolicyName("vulnerability_policy");
+                view2.setPolicySeverity("CRITICAL");
+                DeveloperScansScanItemsViolatingPoliciesView view3 = new DeveloperScansScanItemsViolatingPoliciesView();
+                view3.setPolicyName("license_policy");
+                view3.setPolicySeverity("MINOR");
 
                 violatingPolicies.add(view);
+                violatingPolicies.add(view2);
+                violatingPolicies.add(view3);
                 return violatingPolicies;
             }
 
@@ -119,8 +120,14 @@ public class RapidScanResultAggregatorTest {
                         
                         DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView view = new DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView();
                         view.setPolicyName("vulnerability_policy");
+                        view.setPolicySeverity("CRITICAL");
+                        
+                        DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView view2 = new DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView();
+                        view2.setPolicyName("vulnerability_policy_warning");
+                        view2.setPolicySeverity("MINOR");
                  
                         violatingPolicies.add(view);
+                        violatingPolicies.add(view2);
                         return violatingPolicies;
                     }
                 };
@@ -144,8 +151,14 @@ public class RapidScanResultAggregatorTest {
                         
                         DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView view = new DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView(); 
                         view.setPolicyName("license_policy");
+                        view.setPolicySeverity("CRITICAL");
+                        
+                        DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView view2 = new DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView(); 
+                        view2.setPolicyName("license_policy_warning");
+                        view2.setPolicySeverity("MINOR");
                         
                         violatingPolicies.add(view);
+                        violatingPolicies.add(view2);
                         return violatingPolicies;
                     }
                 };


### PR DESCRIPTION
This work constructs error and warning messages for non-persistent signature scans using the v5 developer-scans BlackDuck endpoint.