### PR TITLE
Dev/jpp/master/idetect 3234. - detect.target.type=IMAGE should not run sig scan if image is not available

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -26,6 +26,8 @@ public enum ExitCodeType {
 
     FAILURE_ACCURACY_NOT_MET(15, "Detect was unable to meet the required accuracy."),
 
+    FAILURE_IMAGE_NOT_AVAILABLE(20, "Image scan attempted but no return data available."),
+
     FAILURE_GENERAL_ERROR(99, "Detect encountered a known error, details of the error are provided."),
     FAILURE_UNKNOWN_ERROR(100, "Detect encountered an unknown error.");
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
@@ -60,7 +60,9 @@ public class DetectRun {
             UniversalStepRunner stepRunner = new UniversalStepRunner(operationRunner, stepHelper); //Product independent tools
             UniversalToolsResult universalToolsResult = stepRunner.runUniversalTools();
 
-            // test for some image scan results and throw exception if not found.
+            // test to ensure image scan results are available (i.e. image scan success) throws an
+            // exception if results components are empty and/or not found.  This will never throw an
+            // exception for any other scan type
             imageScanCanScanFurther(universalToolsResult, bootSingletons);
 
             // combine: processProjectInformation() -> ProjectResult (nameversion, bdio)


### PR DESCRIPTION
# Description

This fix will prevent a signature scan from running in the current working directory when an image scan fails, such as when the image does not exist.   

# Github Issues

(Optional) Please link to any applicable github issues.
