### PR TITLE
rapid scan fix component count

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
@@ -11,7 +11,6 @@ import com.synopsys.integration.blackduck.api.generated.component.DeveloperScans
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView;
-import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsViolatingPoliciesView;
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 
 public class RapidScanComponentGroupDetail {

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsComponentViolatingPoliciesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesView;
@@ -85,24 +86,19 @@ public class RapidScanComponentGroupDetail {
     // While it may be possible to reduce the overall message generation code in this class by pushing 
     // some common pieces into a parent class or interface, it is likely not worth altering the libraries 
     // as this may be temporary code.
-    public void addComponentMessages(DeveloperScansScanView resultView) {
+    public void addComponentMessages(DeveloperScansScanView resultView, DeveloperScansScanItemsComponentViolatingPoliciesView componentPolicyViolation) {
         String baseMessage = getBaseMessage(resultView);
-
-        List<DeveloperScansScanItemsViolatingPoliciesView> violatingPolicies = resultView.getViolatingPolicies();
 
         String errorMessage = "", warningMessage = "";
 
-        for (int i = 0; i < violatingPolicies.size(); i++) {
-            DeveloperScansScanItemsViolatingPoliciesView violation = violatingPolicies.get(i);
-
-            if (violation.getPolicySeverity().equals("CRITICAL") || violation.getPolicySeverity().equals("BLOCKER")) {
+            if (componentPolicyViolation.getPolicySeverity().equals("CRITICAL") || componentPolicyViolation.getPolicySeverity().equals("BLOCKER")) {
                 if (errorMessage.equals("")) {
                     errorMessage = baseMessage;
                 } else {
                     errorMessage += ", ";
                 }
                 
-                errorMessage += violation.getPolicyName();
+                errorMessage += componentPolicyViolation.getPolicyName();
             } else {
                 if (warningMessage.equals("")) {
                     warningMessage = baseMessage;
@@ -110,9 +106,9 @@ public class RapidScanComponentGroupDetail {
                     warningMessage += ", ";
                 }
                 
-                warningMessage += violation.getPolicyName();
+                warningMessage += componentPolicyViolation.getPolicyName();
             }
-        }
+            
         addMessages(errorMessage, warningMessage);
     }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanResultAggregator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanResultAggregator.java
@@ -97,11 +97,6 @@ public class RapidScanResultAggregator {
                     .map(DeveloperScansScanItemsComponentViolatingPoliciesView::getPolicyName)
                     .collect(Collectors.toSet());
 
-            // TODO theory that we don't need to remove these as they are presented at a high 
-            // summary looking level in the JSON.
-//            policyNames.removeAll(vulnerabilityPolicyNames);
-//            policyNames.removeAll(licensePolicyNames);
-
             componentGroupDetail.addPolicies(componentPolicyNames);
             securityGroupDetail.addPolicies(vulnerabilityPolicyNames);
             licenseGroupDetail.addPolicies(licensePolicyNames);

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanResultAggregator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/aggregate/RapidScanResultAggregator.java
@@ -16,7 +16,6 @@ import com.synopsys.integration.blackduck.api.generated.component.DeveloperScans
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView;
-import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsViolatingPoliciesView;
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 
 public class RapidScanResultAggregator {
@@ -68,12 +67,7 @@ public class RapidScanResultAggregator {
             RapidScanComponentGroupDetail componentGroupDetail = componentDetail.getComponentDetails();
             RapidScanComponentGroupDetail securityGroupDetail = componentDetail.getSecurityDetails();
             RapidScanComponentGroupDetail licenseGroupDetail = componentDetail.getLicenseDetails();
-            
-            // Get the overall list of policy violations
-            List<DeveloperScansScanItemsViolatingPoliciesView> violatingPolicies = resultView.getViolatingPolicies();
-            Set<String> policyNames = violatingPolicies.stream()
-                    .map(DeveloperScansScanItemsViolatingPoliciesView::getPolicyName).collect(Collectors.toSet());
-            
+                  
             List<DeveloperScansScanItemsComponentViolatingPoliciesView> componentViolations = 
                     resultView.getComponentViolatingPolicies();
             List<DeveloperScansScanItemsPolicyViolationVulnerabilitiesView> vulnerabilityViolations = resultView

--- a/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanResultAggregatorTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanResultAggregatorTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsComponentViolatingPoliciesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView;
 import com.synopsys.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesView;
@@ -78,6 +79,23 @@ public class RapidScanResultAggregatorTest {
             @Override
             public String getComponentIdentifier() {
                 return "component_1:component_version_1";
+            }
+            
+            @Override
+            public List<DeveloperScansScanItemsComponentViolatingPoliciesView> getComponentViolatingPolicies() {
+                List<DeveloperScansScanItemsComponentViolatingPoliciesView> componentViolatingPolicies = new ArrayList<>();
+                
+                DeveloperScansScanItemsComponentViolatingPoliciesView componentViolatingPolicy = new DeveloperScansScanItemsComponentViolatingPoliciesView();
+                componentViolatingPolicy.setPolicyName("component_policy");
+                componentViolatingPolicy.setPolicySeverity("CRITICAL");
+                
+                DeveloperScansScanItemsComponentViolatingPoliciesView componentViolatingPolicy2 = new DeveloperScansScanItemsComponentViolatingPoliciesView();
+                componentViolatingPolicy2.setPolicyName("component_policy_warning");
+                componentViolatingPolicy2.setPolicySeverity("MINOR");
+                
+                componentViolatingPolicies.add(componentViolatingPolicy);
+                componentViolatingPolicies.add(componentViolatingPolicy2);
+                return componentViolatingPolicies;
             }
 
             @Override


### PR DESCRIPTION
The v5 rapid scans are using the total count of components to report component violations. This is not correct. There is another field for component violations that we should be using instead. Components might appear in the list due to license or vulnerability policy violations and not component violations.