### PR TITLE
better run multiple np scans

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -41,56 +41,59 @@ public class RapidModeStepRunner {
         this.gson = gson;
     }
 
-    public void runOnline(BlackDuckRunData blackDuckRunData, NameVersion projectVersion, BdioResult bdioResult, DockerTargetData dockerTargetData) throws OperationException {
+    public void runOnline(BlackDuckRunData blackDuckRunData, NameVersion projectVersion, BdioResult bdioResult,
+            DockerTargetData dockerTargetData) throws OperationException {
         operationRunner.phoneHome(blackDuckRunData);
         Optional<File> rapidScanConfig = operationRunner.findRapidScanConfig();
         rapidScanConfig.ifPresent(config -> logger.info("Found rapid scan config file: {}", config));
-        
+
         String blackDuckUrl = blackDuckRunData.getBlackDuckServerConfig().getBlackDuckUrl().toString();
+        List<HttpUrl> parsedUrls = new ArrayList<>();
 
         stepHelper.runToolIfIncluded(DetectTool.DETECTOR, "Detectors", () -> {
-            runScanForResults(bdioResult, rapidScanConfig, blackDuckRunData, projectVersion);
+            parsedUrls.addAll(runScanForResults(bdioResult, rapidScanConfig, blackDuckRunData, projectVersion));
         });
 
         stepHelper.runToolIfIncluded(DetectTool.DOCKER, "Docker", () -> {
-            runScanForResults(bdioResult, rapidScanConfig, blackDuckRunData, projectVersion);
+            parsedUrls.addAll(runScanForResults(bdioResult, rapidScanConfig, blackDuckRunData, projectVersion));
         });
 
         stepHelper.runToolIfIncluded(DetectTool.SIGNATURE_SCAN, "Signature Scanner", () -> {
             logger.debug("Rapid scan signature scan detected.");
-            
+
             SignatureScanStepRunner signatureScanStepRunner = new SignatureScanStepRunner(operationRunner);
-            SignatureScanOuputResult signatureScanOutputResult = signatureScanStepRunner.runRapidSignatureScannerOnline(
-                    blackDuckRunData,
-                    projectVersion,
-                    dockerTargetData
-                );
-            
-            List<HttpUrl> parsedUrls = parseScanUrls(signatureScanOutputResult, blackDuckUrl);
-            
-            List<DeveloperScansScanView> rapidResults = operationRunner.waitForRapidResults(blackDuckRunData, parsedUrls);
-            
-            File jsonFile = operationRunner.generateRapidJsonFile(projectVersion, rapidResults);
-            RapidScanResultSummary summary = operationRunner.logRapidReport(rapidResults);
-            operationRunner.publishRapidResults(jsonFile, summary);
-            
+            SignatureScanOuputResult signatureScanOutputResult = signatureScanStepRunner
+                    .runRapidSignatureScannerOnline(blackDuckRunData, projectVersion, dockerTargetData);
+
+            parsedUrls.addAll(parseScanUrls(signatureScanOutputResult, blackDuckUrl));
         });
+
+        // TODO check if any scans done
+        if (!parsedUrls.isEmpty()) {
+            List<DeveloperScansScanView> rapidResults = operationRunner.waitForRapidResults(blackDuckRunData,
+                    parsedUrls);
+
+            if (rapidResults != null && !rapidResults.isEmpty()) {
+                File jsonFile = operationRunner.generateRapidJsonFile(projectVersion, rapidResults);
+                RapidScanResultSummary summary = operationRunner.logRapidReport(rapidResults);
+                operationRunner.publishRapidResults(jsonFile, summary);
+            }
+        }
     }
 
-   private void runScanForResults(BdioResult bdioResult, Optional<File> rapidScanConfig, BlackDuckRunData blackDuckRunData, NameVersion projectVersion ) throws OperationException {
-       if (bdioResult.isNotEmpty()) {
-           List<HttpUrl> rapidScanUrls = operationRunner.performRapidUpload(blackDuckRunData, bdioResult,
-                   rapidScanConfig.orElse(null));
-           List<DeveloperScansScanView> rapidResults = operationRunner.waitForRapidResults(blackDuckRunData,
-                   rapidScanUrls);
+    private List<HttpUrl> runScanForResults(BdioResult bdioResult, Optional<File> rapidScanConfig,
+            BlackDuckRunData blackDuckRunData, NameVersion projectVersion) throws OperationException {
+        List<HttpUrl> rapidScanUrls = new ArrayList<>();
 
-           File jsonFile = operationRunner.generateRapidJsonFile(projectVersion, rapidResults);
-           RapidScanResultSummary summary = operationRunner.logRapidReport(rapidResults);
-           operationRunner.publishRapidResults(jsonFile, summary);
-       } else {
-           logger.debug("No BDIO results to upload. Skipping.");
-       }
-   }
+        if (bdioResult.isNotEmpty()) {
+            rapidScanUrls.addAll(operationRunner.performRapidUpload(blackDuckRunData, bdioResult,
+                    rapidScanConfig.orElse(null)));
+        } else {
+            logger.debug("No BDIO results to upload. Skipping.");
+        }
+
+        return rapidScanUrls;
+    }
 
     /**
      * The signature scanner only returns a high level success or failure to us. Details are in the

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -68,7 +68,7 @@ public class RapidModeStepRunner {
             parsedUrls.addAll(parseScanUrls(signatureScanOutputResult, blackDuckUrl));
         });
 
-        // TODO check if any scans done
+        //check if any scans were done and report results
         if (!parsedUrls.isEmpty()) {
             List<DeveloperScansScanView> rapidResults = operationRunner.waitForRapidResults(blackDuckRunData,
                     parsedUrls);


### PR DESCRIPTION
This work allows for running both ephemeral package manager and ephemeral signature scans in a single invocation. The results are combined in a single report although duplicates are not removed. Polling for results is only done after both scans are launched.
