### PR TITLE
allow docker scans if only image is specified

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/util/filter/DetectToolFilter.java
+++ b/src/main/java/com/synopsys/integration/detect/util/filter/DetectToolFilter.java
@@ -66,8 +66,8 @@ public class DetectToolFilter {
                 if (!allowedEphemeralTools.contains(detectTool)) {
                     return false;
                 }
-            // Otherwise only allow default tools.
-            } else if (!defaultEphemeralTools.contains(detectTool)) {
+            // Otherwise only allow default tools unless we are in docker mode.
+            } else if (!defaultEphemeralTools.contains(detectTool) && !runDecision.isDockerMode()) {
                 return false;
             }
         }


### PR DESCRIPTION
when a user specifies --detect.target.type=IMAGE --detect.blackduck.scan.mode=EPHEMERAL with no detect.tools we should not fail the scan and assume they mean a docker tools scan. 