### PR TITLE
Dev/jpp/rapid signature scan stabilization/fix up output scanmode reporting

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -205,7 +205,8 @@ public class DetectConfigurationFactory {
 
     public RapidScanOptions createRapidScanOptions() {
         RapidCompareMode rapidCompareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
-        return new RapidScanOptions(rapidCompareMode);
+        BlackduckScanMode scanMode= detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
+        return new RapidScanOptions(rapidCompareMode, scanMode);
     }
 
     public BlackduckScanMode createScanMode() {

--- a/src/main/java/com/synopsys/integration/detect/configuration/enumeration/BlackduckScanMode.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/enumeration/BlackduckScanMode.java
@@ -5,12 +5,12 @@ public enum BlackduckScanMode {
     EPHEMERAL ("Ephemeral"),
     INTELLIGENT ("Intelligent");
 
-    private final String lcName;
+    private final String displayName;
     BlackduckScanMode(String name) {
-        this.lcName = name;
+        this.displayName = name;
     }
     
     public String displayName() {
-        return this.lcName;
+        return this.displayName;
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/configuration/enumeration/BlackduckScanMode.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/enumeration/BlackduckScanMode.java
@@ -1,7 +1,16 @@
 package com.synopsys.integration.detect.configuration.enumeration;
 
 public enum BlackduckScanMode {
-    RAPID,
-    EPHEMERAL,
-    INTELLIGENT
+    RAPID ("Rapid"),
+    EPHEMERAL ("Ephemeral"),
+    INTELLIGENT ("Intelligent");
+
+    private final String lcName;
+    BlackduckScanMode(String name) {
+        this.lcName = name;
+    }
+    
+    public String displayName() {
+        return this.lcName;
+    }
 }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -184,12 +184,12 @@ public class DetectBoot {
                 detectConfigurationFactory.createScanMode()
             );
             
-            String rapidTypeOfScanModeProperty = "Rapid";
+            String nonpersistentScanModeProperty = "Rapid";
             if (blackDuckDecision.scanMode().equals(BlackduckScanMode.EPHEMERAL)) {
-                rapidTypeOfScanModeProperty = "Ephemeral";
+                nonpersistentScanModeProperty = "Ephemeral";
             }
             // this will be used in the non persistent reporting classes, where scan mode type results are printed out...
-            System.setProperty("com.synopsys.nonpersistent.scan.mode.string", rapidTypeOfScanModeProperty);
+            System.setProperty("com.synopsys.nonpersistent.scan.mode.string", nonpersistentScanModeProperty);
 
             RunDecision runDecision = new RunDecision(detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE); //TODO: Move to proper decision home. -jp
             DetectToolFilter detectToolFilter = detectConfigurationFactory.createToolFilter(runDecision, blackDuckDecision);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -183,13 +183,11 @@ public class DetectBoot {
                 detectConfigurationFactory.createBlackDuckConnectionDetails(),
                 detectConfigurationFactory.createScanMode()
             );
-            
-            String nonpersistentScanModeProperty = "Rapid";
-            if (blackDuckDecision.scanMode().equals(BlackduckScanMode.EPHEMERAL)) {
-                nonpersistentScanModeProperty = "Ephemeral";
-            }
+
+            String scanPropertyDisplayName = blackDuckDecision.scanMode().displayName();
             // this will be used in the non persistent reporting classes, where scan mode type results are printed out...
-            System.setProperty("com.synopsys.nonpersistent.scan.mode.string", nonpersistentScanModeProperty);
+            // if it's an intelligent scan, the code that uses this string does not get called.
+            System.setProperty("com.synopsys.nonpersistent.scan.mode.string", scanPropertyDisplayName);
 
             RunDecision runDecision = new RunDecision(detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE); //TODO: Move to proper decision home. -jp
             DetectToolFilter detectToolFilter = detectConfigurationFactory.createToolFilter(runDecision, blackDuckDecision);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -25,6 +25,7 @@ import com.synopsys.integration.detect.configuration.DetectPropertyConfiguration
 import com.synopsys.integration.detect.configuration.DetectPropertyUtil;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
 import com.synopsys.integration.detect.configuration.DetectableOptionFactory;
+import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.DetectGroup;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTargetType;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
@@ -182,6 +183,14 @@ public class DetectBoot {
                 detectConfigurationFactory.createBlackDuckConnectionDetails(),
                 detectConfigurationFactory.createScanMode()
             );
+            
+            String rapidTypeOfScanModeProperty = "Rapid";
+            if (blackDuckDecision.scanMode().equals(BlackduckScanMode.EPHEMERAL)) {
+                rapidTypeOfScanModeProperty = "Ephemeral";
+            }
+            // this will be used in the non persistent reporting classes, where scan mode type results are printed out...
+            System.setProperty("com.synopsys.nonpersistent.scan.mode.string", rapidTypeOfScanModeProperty);
+
             RunDecision runDecision = new RunDecision(detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE); //TODO: Move to proper decision home. -jp
             DetectToolFilter detectToolFilter = detectConfigurationFactory.createToolFilter(runDecision, blackDuckDecision);
             oneRequiresTheOther(

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -184,11 +184,6 @@ public class DetectBoot {
                 detectConfigurationFactory.createScanMode()
             );
 
-            String scanPropertyDisplayName = blackDuckDecision.scanMode().displayName();
-            // this will be used in the non persistent reporting classes, where scan mode type results are printed out...
-            // if it's an intelligent scan, the code that uses this string does not get called.
-            System.setProperty("com.synopsys.nonpersistent.scan.mode.string", scanPropertyDisplayName);
-
             RunDecision runDecision = new RunDecision(detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE); //TODO: Move to proper decision home. -jp
             DetectToolFilter detectToolFilter = detectConfigurationFactory.createToolFilter(runDecision, blackDuckDecision);
             oneRequiresTheOther(

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -25,7 +25,6 @@ import com.synopsys.integration.detect.configuration.DetectPropertyConfiguration
 import com.synopsys.integration.detect.configuration.DetectPropertyUtil;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
 import com.synopsys.integration.detect.configuration.DetectableOptionFactory;
-import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.DetectGroup;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTargetType;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
@@ -71,7 +71,7 @@ public class DetectRun {
                 BlackDuckRunData blackDuckRunData = productRunData.getBlackDuckRunData();
                 if (blackDuckRunData.isNonPersistent() && blackDuckRunData.isOnline()) {
                     RapidModeStepRunner rapidModeSteps = new RapidModeStepRunner(operationRunner, stepHelper, bootSingletons.getGson());
-                    rapidModeSteps.runOnline(blackDuckRunData, nameVersion, bdio, universalToolsResult.getDockerTargetData());
+                    rapidModeSteps.runOnline(blackDuckRunData, nameVersion, bdio, universalToolsResult.getDockerTargetData(), bootSingletons.getDetectConfigurationFactory().createScanMode());
                 } else if (blackDuckRunData.isNonPersistent()) {
                     logger.info("Rapid Scan is offline, nothing to do.");
                 } else if (blackDuckRunData.isOnline()) {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
@@ -71,7 +71,7 @@ public class DetectRun {
                 BlackDuckRunData blackDuckRunData = productRunData.getBlackDuckRunData();
                 if (blackDuckRunData.isNonPersistent() && blackDuckRunData.isOnline()) {
                     RapidModeStepRunner rapidModeSteps = new RapidModeStepRunner(operationRunner, stepHelper, bootSingletons.getGson());
-                    rapidModeSteps.runOnline(blackDuckRunData, nameVersion, bdio, universalToolsResult.getDockerTargetData(), bootSingletons.getDetectConfigurationFactory().createScanMode());
+                    rapidModeSteps.runOnline(blackDuckRunData, nameVersion, bdio, universalToolsResult.getDockerTargetData());
                 } else if (blackDuckRunData.isNonPersistent()) {
                     logger.info("Rapid Scan is offline, nothing to do.");
                 } else if (blackDuckRunData.isOnline()) {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ScanCommandOutput;
+import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detect.lifecycle.OperationException;
 import com.synopsys.integration.detect.lifecycle.run.data.BlackDuckRunData;
@@ -42,7 +43,7 @@ public class RapidModeStepRunner {
     }
 
     public void runOnline(BlackDuckRunData blackDuckRunData, NameVersion projectVersion, BdioResult bdioResult,
-            DockerTargetData dockerTargetData) throws OperationException {
+            DockerTargetData dockerTargetData, BlackduckScanMode mode) throws OperationException {
         operationRunner.phoneHome(blackDuckRunData);
         Optional<File> rapidScanConfig = operationRunner.findRapidScanConfig();
         rapidScanConfig.ifPresent(config -> logger.info("Found rapid scan config file: {}", config));
@@ -67,12 +68,12 @@ public class RapidModeStepRunner {
         });
 
         // Get info about any scans that were done
-        List<DeveloperScansScanView> rapidResults = operationRunner.waitForRapidResults(blackDuckRunData, parsedUrls);
+        List<DeveloperScansScanView> rapidResults = operationRunner.waitForRapidResults(blackDuckRunData, parsedUrls, mode);
 
         // Generate a report, even an empty one if no scans were done as that is what previous detect versions did.
         File jsonFile = operationRunner.generateRapidJsonFile(projectVersion, rapidResults);
-        RapidScanResultSummary summary = operationRunner.logRapidReport(rapidResults);
-        operationRunner.publishRapidResults(jsonFile, summary);
+        RapidScanResultSummary summary = operationRunner.logRapidReport(rapidResults, mode);
+        operationRunner.publishRapidResults(jsonFile, summary, mode);
     }
 
     /**

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -43,7 +43,7 @@ public class RapidModeStepRunner {
     }
 
     public void runOnline(BlackDuckRunData blackDuckRunData, NameVersion projectVersion, BdioResult bdioResult,
-            DockerTargetData dockerTargetData, BlackduckScanMode mode) throws OperationException {
+            DockerTargetData dockerTargetData) throws OperationException {
         operationRunner.phoneHome(blackDuckRunData);
         Optional<File> rapidScanConfig = operationRunner.findRapidScanConfig();
         rapidScanConfig.ifPresent(config -> logger.info("Found rapid scan config file: {}", config));
@@ -68,6 +68,7 @@ public class RapidModeStepRunner {
         });
 
         // Get info about any scans that were done
+        BlackduckScanMode mode = blackDuckRunData.getScanMode();
         List<DeveloperScansScanView> rapidResults = operationRunner.waitForRapidResults(blackDuckRunData, parsedUrls, mode);
 
         // Generate a report, even an empty one if no scans were done as that is what previous detect versions did.

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperation.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
+import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 import com.synopsys.integration.detect.lifecycle.shutdown.ExitCodePublisher;
 import com.synopsys.integration.detect.workflow.blackduck.developer.aggregate.RapidScanAggregateResult;
@@ -19,15 +20,17 @@ public class RapidModeLogReportOperation {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final ExitCodePublisher exitCodePublisher;
     private final RapidScanResultAggregator rapidScanResultAggregator;
+    private String scanMode;
 
-    public RapidModeLogReportOperation(ExitCodePublisher exitCodePublisher, RapidScanResultAggregator rapidScanResultAggregator) {
+    public RapidModeLogReportOperation(ExitCodePublisher exitCodePublisher, RapidScanResultAggregator rapidScanResultAggregator, BlackduckScanMode mode) {
         this.exitCodePublisher = exitCodePublisher;
         this.rapidScanResultAggregator = rapidScanResultAggregator;
+        this.scanMode = mode.displayName();
     }
 
     public RapidScanResultSummary perform(List<DeveloperScansScanView> results) throws DetectUserFriendlyException {
-        RapidScanAggregateResult aggregateResult = rapidScanResultAggregator.aggregateData(results);
-        logger.info(String.format("%s:", RapidScanDetectResult.NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING));
+         RapidScanAggregateResult aggregateResult = rapidScanResultAggregator.aggregateData(results);
+        logger.info(String.format("%s:", scanMode + RapidScanDetectResult.NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING));
         aggregateResult.logResult(new Slf4jIntLogger(logger));
         RapidScanResultSummary summary = aggregateResult.getSummary();
         if (summary.hasErrors()) {

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperation.java
@@ -27,7 +27,7 @@ public class RapidModeLogReportOperation {
 
     public RapidScanResultSummary perform(List<DeveloperScansScanView> results) throws DetectUserFriendlyException {
         RapidScanAggregateResult aggregateResult = rapidScanResultAggregator.aggregateData(results);
-        logger.info(String.format("%s:", RapidScanDetectResult.RAPID_SCAN_RESULT_DETAILS_HEADING));
+        logger.info(String.format("%s:", RapidScanDetectResult.NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING));
         aggregateResult.logResult(new Slf4jIntLogger(logger));
         RapidScanResultSummary summary = aggregateResult.getSummary();
         if (summary.hasErrors()) {

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeUploadOperation.java
@@ -25,7 +25,7 @@ public class RapidModeUploadOperation {
 
     public List<HttpUrl> run(BdioResult bdioResult, RapidScanOptions rapidScanOptions, @Nullable File rapidScanConfig)
         throws IntegrationException, IOException {
-        String scanModeString = System.getProperty("com.synopsys.nonpersistent.scan.mode.string");
+        String scanModeString = rapidScanOptions.getScanMode().displayName();
         logger.info("Begin " + scanModeString + " Mode Scan");
         UploadBatch uploadBatch = new UploadBatch();
         for (UploadTarget uploadTarget : bdioResult.getUploadTargets()) {

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeUploadOperation.java
@@ -25,7 +25,8 @@ public class RapidModeUploadOperation {
 
     public List<HttpUrl> run(BdioResult bdioResult, RapidScanOptions rapidScanOptions, @Nullable File rapidScanConfig)
         throws IntegrationException, IOException {
-        logger.info("Begin Rapid Mode Scan");
+        String scanModeString = System.getProperty("com.synopsys.nonpersistent.scan.mode.string");
+        logger.info("Begin " + scanModeString + " Mode Scan");
         UploadBatch uploadBatch = new UploadBatch();
         for (UploadTarget uploadTarget : bdioResult.getUploadTargets()) {
             logger.debug(String.format("Uploading %s", uploadTarget.getUploadFile().getName()));

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeWaitOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeWaitOperation.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
+import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.workflow.blackduck.developer.blackduck.DetectRapidScanWaitJob;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.Slf4jIntLogger;
@@ -26,11 +27,11 @@ public class RapidModeWaitOperation {
         this.blackDuckApiClient = blackDuckApiClient;
     }
 
-    public List<DeveloperScansScanView> waitForScans(List<HttpUrl> uploadedScans, long timeoutInSeconds, int waitIntervalInSeconds)
+    public List<DeveloperScansScanView> waitForScans(List<HttpUrl> uploadedScans, long timeoutInSeconds, int waitIntervalInSeconds, BlackduckScanMode mode)
         throws IntegrationException, InterruptedException {
         WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createProgressive(timeoutInSeconds, 60);
         ResilientJobConfig waitJobConfig = new ResilientJobConfig(new Slf4jIntLogger(logger), System.currentTimeMillis(), waitIntervalTracker);
-        DetectRapidScanWaitJob waitJob = new DetectRapidScanWaitJob(blackDuckApiClient, uploadedScans);
+        DetectRapidScanWaitJob waitJob = new DetectRapidScanWaitJob(blackDuckApiClient, uploadedScans, mode);
         ResilientJobExecutor jobExecutor = new ResilientJobExecutor(waitJobConfig);
         return jobExecutor.executeJob(waitJob);
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
@@ -3,19 +3,22 @@ package com.synopsys.integration.detect.workflow.blackduck.developer;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.workflow.blackduck.developer.aggregate.RapidScanDetailGroup;
 import com.synopsys.integration.detect.workflow.blackduck.developer.aggregate.RapidScanResultSummary;
 import com.synopsys.integration.detect.workflow.result.DetectResult;
 
 public class RapidScanDetectResult implements DetectResult {
-    public static final String NONPERSISTENT_SCAN_RESULT_HEADING = System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scan Result";
-    public static final String NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING = System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scan Result Details";
+    public static final String NONPERSISTENT_SCAN_RESULT_HEADING = " Scan Result";
+    public static final String NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING = " Scan Result Details";
     private final String jsonFilePath;
     private final List<String> subMessages;
+    public static String scanMode;
 
-    public RapidScanDetectResult(String jsonFilePath, RapidScanResultSummary resultSummary) {
+    public RapidScanDetectResult(String jsonFilePath, RapidScanResultSummary resultSummary, BlackduckScanMode mode) {
         this.jsonFilePath = jsonFilePath;
         this.subMessages = createResultMessages(resultSummary);
+        scanMode = mode.displayName();
     }
 
     @Override
@@ -25,7 +28,7 @@ public class RapidScanDetectResult implements DetectResult {
 
     @Override
     public String getResultMessage() {
-        return String.format("%s: (for more detail look in the log for %s)", NONPERSISTENT_SCAN_RESULT_HEADING, NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING);
+        return String.format("%s: (for more detail look in the log for %s)", scanMode + NONPERSISTENT_SCAN_RESULT_HEADING, scanMode + NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING);
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
@@ -8,8 +8,8 @@ import com.synopsys.integration.detect.workflow.blackduck.developer.aggregate.Ra
 import com.synopsys.integration.detect.workflow.result.DetectResult;
 
 public class RapidScanDetectResult implements DetectResult {
-    public static final String RAPID_SCAN_RESULT_HEADING = System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scan Result";
-    public static final String RAPID_SCAN_RESULT_DETAILS_HEADING = System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scan Result Details";
+    public static final String NONPERSISTENT_SCAN_RESULT_HEADING = System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scan Result";
+    public static final String NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING = System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scan Result Details";
     private final String jsonFilePath;
     private final List<String> subMessages;
 
@@ -25,7 +25,7 @@ public class RapidScanDetectResult implements DetectResult {
 
     @Override
     public String getResultMessage() {
-        return String.format("%s: (for more detail look in the log for %s)", RAPID_SCAN_RESULT_HEADING, RAPID_SCAN_RESULT_DETAILS_HEADING);
+        return String.format("%s: (for more detail look in the log for %s)", NONPERSISTENT_SCAN_RESULT_HEADING, NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING);
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
@@ -8,8 +8,8 @@ import com.synopsys.integration.detect.workflow.blackduck.developer.aggregate.Ra
 import com.synopsys.integration.detect.workflow.result.DetectResult;
 
 public class RapidScanDetectResult implements DetectResult {
-    public static final String RAPID_SCAN_RESULT_HEADING = "Rapid Scan Result";
-    public static final String RAPID_SCAN_RESULT_DETAILS_HEADING = "Rapid Scan Result Details";
+    public static final String RAPID_SCAN_RESULT_HEADING = System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scan Result";
+    public static final String RAPID_SCAN_RESULT_DETAILS_HEADING = System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scan Result Details";
     private final String jsonFilePath;
     private final List<String> subMessages;
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanOptions.java
@@ -1,15 +1,22 @@
 package com.synopsys.integration.detect.workflow.blackduck.developer;
 
+import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.RapidCompareMode;
 
 public class RapidScanOptions {
     private final RapidCompareMode compareMode;
+    private final BlackduckScanMode scanMode;
 
-    public RapidScanOptions(RapidCompareMode compareMode) {
+    public RapidScanOptions(RapidCompareMode compareMode, BlackduckScanMode scanMode) {
         this.compareMode = compareMode;
+        this.scanMode = scanMode;
     }
 
     public RapidCompareMode getCompareMode() {
         return compareMode;
+    }
+
+    public BlackduckScanMode getScanMode() {
+        return scanMode;
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanService.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanService.java
@@ -54,7 +54,8 @@ public class DetectRapidScanService {
 
         for (UploadTarget uploadTarget : uploadBatch.getUploadTargets()) {
             HttpUrl url = bdio2FileUploadService.uploadFile(directoryManager.getRapidOutputDirectory(), uploadTarget, rapidScanOptions, rapidScanConfig);
-            logger.info("Uploaded Rapid Scan: {}", url);
+            String scanModeString = System.getProperty("com.synopsys.nonpersistent.scan.mode.string");
+            logger.info("Uploaded " + scanModeString + " Scan: {}", url);
             allScanUrls.add(url);
         }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanService.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanService.java
@@ -54,7 +54,7 @@ public class DetectRapidScanService {
 
         for (UploadTarget uploadTarget : uploadBatch.getUploadTargets()) {
             HttpUrl url = bdio2FileUploadService.uploadFile(directoryManager.getRapidOutputDirectory(), uploadTarget, rapidScanOptions, rapidScanConfig);
-            String scanModeString = System.getProperty("com.synopsys.nonpersistent.scan.mode.string");
+            String scanModeString = rapidScanOptions.getScanMode().displayName();
             logger.info("Uploaded " + scanModeString + " Scan: {}", url);
             allScanUrls.add(url);
         }

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanWaitJob.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanWaitJob.java
@@ -23,7 +23,7 @@ public class DetectRapidScanWaitJob implements ResilientJob<List<DeveloperScansS
     private final List<HttpUrl> remainingUrls;
     private final List<HttpUrl> completedUrls;
 
-    private static final String JOB_NAME = "Waiting for Rapid Scans";
+    private static final String JOB_NAME = "Waiting for " + System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scans";
 
     private boolean complete;
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanWaitJob.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanWaitJob.java
@@ -11,6 +11,7 @@ import com.synopsys.integration.blackduck.exception.BlackDuckIntegrationExceptio
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.request.BlackDuckMultipleRequest;
 import com.synopsys.integration.blackduck.service.request.BlackDuckResponseRequest;
+import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.exception.IntegrationTimeoutException;
 import com.synopsys.integration.rest.HttpUrl;
@@ -23,15 +24,17 @@ public class DetectRapidScanWaitJob implements ResilientJob<List<DeveloperScansS
     private final List<HttpUrl> remainingUrls;
     private final List<HttpUrl> completedUrls;
 
-    private static final String JOB_NAME = "Waiting for " + System.getProperty("com.synopsys.nonpersistent.scan.mode.string") + " Scans";
+    //This can't be static because the job name could contain the word "Rapid" OR "Ephemeral" etc.
+    private final String JOB_NAME;
 
     private boolean complete;
 
-    public DetectRapidScanWaitJob(BlackDuckApiClient blackDuckApiClient, List<HttpUrl> resultUrl) {
+    public DetectRapidScanWaitJob(BlackDuckApiClient blackDuckApiClient, List<HttpUrl> resultUrl, BlackduckScanMode mode) {
         this.blackDuckApiClient = blackDuckApiClient;
         this.remainingUrls = new ArrayList<>();
         remainingUrls.addAll(resultUrl);
         this.completedUrls = new ArrayList<>(remainingUrls.size());
+        JOB_NAME = "Waiting for " + mode.displayName() + " Scans";
     }
 
     @Override

--- a/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperationTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperationTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mockito;
 
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
+import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 import com.synopsys.integration.detect.lifecycle.shutdown.ExitCodePublisher;
 import com.synopsys.integration.detect.workflow.blackduck.developer.aggregate.RapidScanAggregateResult;
@@ -24,7 +25,7 @@ public class RapidModeLogReportOperationTest {
     void testPublishesPolicyViolation() throws DetectUserFriendlyException {
         ExitCodePublisher exitCodePublisher = Mockito.mock(ExitCodePublisher.class);
         RapidScanResultAggregator rapidScanResultAggregator = Mockito.mock(RapidScanResultAggregator.class);
-        RapidModeLogReportOperation op = new RapidModeLogReportOperation(exitCodePublisher, rapidScanResultAggregator);
+        RapidModeLogReportOperation op = new RapidModeLogReportOperation(exitCodePublisher, rapidScanResultAggregator, BlackduckScanMode.RAPID);
 
         List<DeveloperScansScanView> results = new LinkedList<>();
         DeveloperScansScanView resultView = Mockito.mock(DeveloperScansScanView.class);


### PR DESCRIPTION
# Description

This change allows non-persistent scan type output to properly and correctly report the non-persistent scan sub-type eg. Rapid or Ephemeral.  Change addressed the issue of the detect output reporoting using the word "Rapid" when writing to the terminal for scan results, or when initiating the scan. 

# Github Issues

(Optional) Please link to any applicable github issues.
