### PR TITLE
IDETECT-3524 Ephemeral scans with detect.docker.image does not run DO…

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -176,6 +176,23 @@ public class DetectBoot {
         logger.info("");
 
         ProductRunData productRunData;
+
+        // store the result of hasImageOrTar... we will need this in more than one place.
+        boolean hasImageOrTar = false;
+        DetectableOptionFactory detectableOptionFactory;
+        try {
+            ProxyInfo detectableProxyInfo = detectConfigurationFactory.createBlackDuckProxyInfo();
+            detectableOptionFactory = new DetectableOptionFactory(detectConfiguration, diagnosticSystem, detectableProxyInfo);
+            hasImageOrTar = detectableOptionFactory.createDockerDetectableOptions().hasDockerImageOrTar();
+            oneRequiresTheOther(
+                detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE,
+                hasImageOrTar /*detectableOptionFactory.createDockerDetectableOptions().hasDockerImageOrTar()*/,
+                "Detect target type is set to IMAGE, but no docker image was specified."
+            );
+        } catch (DetectUserFriendlyException e) {
+            return Optional.of(DetectBootResult.exception(e, propertyConfiguration, directoryManager, diagnosticSystem));
+        }
+
         try {
             BlackduckScanMode blackduckScanMode = detectConfigurationFactory.createScanMode();
             ProductDecider productDecider = new ProductDecider();
@@ -185,7 +202,8 @@ public class DetectBoot {
                 detectConfigurationFactory.createHasSignatureScan()
             );
 
-            RunDecision runDecision = new RunDecision(detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE); //TODO: Move to proper decision home. -jp
+            // in order to know if docker is needed we have to have either detect.target.type=IMAGE or detect.docker.image
+            RunDecision runDecision = new RunDecision(detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE || hasImageOrTar); //TODO: Move to proper decision home. -jp
             DetectToolFilter detectToolFilter = detectConfigurationFactory.createToolFilter(runDecision, blackDuckDecision);
             oneRequiresTheOther(
                 detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE,
@@ -204,19 +222,6 @@ public class DetectBoot {
         if (productRunData == null) {
             logger.info("No products to run, Detect is complete.");
             return Optional.of(DetectBootResult.exit(propertyConfiguration, directoryManager, diagnosticSystem));
-        }
-
-        DetectableOptionFactory detectableOptionFactory;
-        try {
-            ProxyInfo detectableProxyInfo = detectConfigurationFactory.createBlackDuckProxyInfo();
-            detectableOptionFactory = new DetectableOptionFactory(detectConfiguration, diagnosticSystem, detectableProxyInfo);
-            oneRequiresTheOther(
-                detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE,
-                detectableOptionFactory.createDockerDetectableOptions().hasDockerImageOrTar(),
-                "Detect target type is set to IMAGE, but no docker image was specified."
-            );
-        } catch (DetectUserFriendlyException e) {
-            return Optional.of(DetectBootResult.exception(e, propertyConfiguration, directoryManager, diagnosticSystem));
         }
 
         BootSingletons bootSingletons = detectBootFactory

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -186,7 +186,7 @@ public class DetectBoot {
             hasImageOrTar = detectableOptionFactory.createDockerDetectableOptions().hasDockerImageOrTar();
             oneRequiresTheOther(
                 detectConfigurationFactory.createDetectTarget() == DetectTargetType.IMAGE,
-                hasImageOrTar /*detectableOptionFactory.createDockerDetectableOptions().hasDockerImageOrTar()*/,
+                hasImageOrTar,
                 "Detect target type is set to IMAGE, but no docker image was specified."
             );
         } catch (DetectUserFriendlyException e) {


### PR DESCRIPTION
…CKER | jppetrakis

# Description

Docker image specified w/o using target.type etc. did not run docker scan for Ephemeral.  I.e. ONLY Ephemeral and detect.docker.image were specified.  Evaluation of the detect.docker.image a bit earlier in the method allows for usage of filter system to properly include the docker scan under this circumstance.

# Github Issues

(Optional) Please link to any applicable github issues.
