### PR TITLE
IDETECT-3523 - Ephemeral scans - missing sig scan status from output …

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
@@ -52,7 +52,13 @@ public class SignatureScanStepRunner {
             List<SignatureScanPath> scanPaths = operationRunner.createScanPaths(projectNameVersion, dockerTargetData);
             ScanBatch scanBatch = operationRunner.createScanBatchOnline(scanPaths, projectNameVersion, dockerTargetData, blackDuckRunData);
 
-            return operationRunner.signatureScan(scanBatch, scanBatchRunner);
+            SignatureScanOuputResult scanResult =  operationRunner.signatureScan(scanBatch, scanBatchRunner);
+
+            // publish report/scan results to status file
+            List<SignatureScannerReport> reports = operationRunner.createSignatureScanReport(scanPaths, scanResult.getScanBatchOutput().getOutputs());
+            operationRunner.publishSignatureScanReport(reports);
+
+            return scanResult;
         }
 
     public void runSignatureScannerOffline(NameVersion projectNameVersion, DockerTargetData dockerTargetData) throws DetectUserFriendlyException, OperationException {


### PR DESCRIPTION
…and status.json | jppetrakis

# Description

The exit status of the signature scan was not being placed into the local status.json file.  This change publishes the exit status etc. into the json file. 

# Github Issues

(Optional) Please link to any applicable github issues.
