### PR TITLE
IDETECT-3528 - regression fix to run DETECTORS when DOCKER is excluded and an image is specified

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.2.0-SIGQA9'
+version = '8.2.0-SIGQA10-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.2.0-SIGQA9-SNAPSHOT'
+version = '8.2.0-SIGQA9'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/synopsys/integration/detect/util/filter/DetectToolFilter.java
+++ b/src/main/java/com/synopsys/integration/detect/util/filter/DetectToolFilter.java
@@ -53,21 +53,19 @@ public class DetectToolFilter {
         if (detectTool == DetectTool.IAC_SCAN) {
             return iacEnabled;
         }
-        if (detectTool == DetectTool.DETECTOR && runDecision.isDockerMode()) {
-            return false;
-        }
+
         if (blackDuckDecision.scanMode() == BlackduckScanMode.RAPID && !rapidTools.contains(detectTool)) {
             return false;
         }
         if (blackDuckDecision.scanMode() == BlackduckScanMode.EPHEMERAL) {
             // If the user specifically asked for something, check that it is an allowed
-            // tool.
-            if (excludedIncludedFilter.includeSpecified()) {
+            // tool or we are in docker mode..
+            if (excludedIncludedFilter.includeSpecified() || runDecision.isDockerMode()) {
                 if (!allowedEphemeralTools.contains(detectTool)) {
                     return false;
                 }
-            // Otherwise only allow default tools unless we are in docker mode.
-            } else if (!defaultEphemeralTools.contains(detectTool) && !runDecision.isDockerMode()) {
+            // Otherwise only allow default tools.
+            } else if (!defaultEphemeralTools.contains(detectTool) ) {
                 return false;
             }
         }


### PR DESCRIPTION
# Description

Update to fix inadvertent exclusion of the DETECTORS tool when docker is excluded.

# Github Issues

(Optional) Please link to any applicable github issues.
