### PR TITLE
options for reduced persistence

### DIFF
--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 8.3.0
+
+### New features
+
+* Added support for Reduced Persistence Signature Scanning. This feature allows users to specify if unmatched files should be persisted or discarded. Not storing data for unmatched files decreases scan time and database size.
+
 ## Version 8.2.0
 
 ### New features

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,2 @@
-gradle.ext.blackDuckCommonVersion='66.0.1'
+gradle.ext.blackDuckCommonVersion='66.0.3-SNAPSHOT'
 gradle.ext.springBootVersion='2.6.6'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,2 @@
-gradle.ext.blackDuckCommonVersion='66.0.3-SNAPSHOT'
+gradle.ext.blackDuckCommonVersion='66.0.3'
 gradle.ext.springBootVersion='2.6.6'

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -22,12 +22,14 @@ import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectClone
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionDistributionType;
 import com.synopsys.integration.blackduck.api.manual.temporary.enumeration.ProjectVersionPhaseType;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.IndividualFileMatching;
+import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllEnumList;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllNoneEnumCollection;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllNoneEnumList;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.NoneEnumList;
+import com.synopsys.integration.configuration.property.types.enumextended.ExtendedEnumProperty;
 import com.synopsys.integration.configuration.property.types.enumextended.ExtendedEnumValue;
 import com.synopsys.integration.detect.configuration.connection.BlackDuckConnectionDetails;
 import com.synopsys.integration.detect.configuration.connection.ConnectionDetails;
@@ -46,6 +48,7 @@ import com.synopsys.integration.detect.tool.detector.executable.DetectExecutable
 import com.synopsys.integration.detect.tool.iac.IacScanOptions;
 import com.synopsys.integration.detect.tool.signaturescanner.BlackDuckSignatureScannerOptions;
 import com.synopsys.integration.detect.tool.signaturescanner.enums.ExtendedIndividualFileMatchingMode;
+import com.synopsys.integration.detect.tool.signaturescanner.enums.ExtendedReducedPersistanceMode;
 import com.synopsys.integration.detect.tool.signaturescanner.enums.ExtendedSnippetMode;
 import com.synopsys.integration.detect.util.filter.DetectToolFilter;
 import com.synopsys.integration.detect.util.finder.DetectDirectoryFileFilter;
@@ -116,6 +119,17 @@ public class DetectConfigurationFactory {
             return individualFileMatching.getBaseValue().get();
         }
 
+        return null;
+    }
+    
+    @Nullable
+    private ReducedPersistence findReducedPersistence() {
+        ExtendedEnumValue<ExtendedReducedPersistanceMode, ReducedPersistence> reducedPersistence = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SIGNATURE_SCANNER_REDUCED_PERSISTENCE);
+        
+        if (reducedPersistence.getBaseValue().isPresent()) {
+            return reducedPersistence.getBaseValue().get();
+        }
+        
         return null;
     }
 
@@ -371,6 +385,7 @@ public class DetectConfigurationFactory {
         Integer maxDepth = detectConfiguration.getValue(DetectProperties.DETECT_EXCLUDED_DIRECTORIES_SEARCH_DEPTH);
         Boolean treatSkippedScansAsSuccess = detectConfiguration.getValue(DetectProperties.DETECT_FORCE_SUCCESS_ON_SKIP);
         Boolean isEphemeral = BlackduckScanMode.EPHEMERAL.equals(detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE));
+        
 
         return new BlackDuckSignatureScannerOptions(
             signatureScannerPaths,
@@ -388,7 +403,8 @@ public class DetectConfigurationFactory {
             copyrightSearch,
             followSymLinks,
             treatSkippedScansAsSuccess,
-            isEphemeral
+            isEphemeral,
+            findReducedPersistence()
         );
     }
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -461,7 +461,7 @@ public class DetectProperties {
     public static final ExtendedEnumProperty<ExtendedReducedPersistanceMode, ReducedPersistence> DETECT_BLACKDUCK_SIGNATURE_SCANNER_REDUCED_PERSISTENCE =
             ExtendedEnumProperty.newBuilder(
                     "detect.blackduck.signature.scanner.reduced.persistence",
-                    ExtendedEnumValue.ofExtendedValue(ExtendedReducedPersistanceMode.NONE),
+                    ExtendedEnumValue.ofExtendedValue(ExtendedReducedPersistanceMode.DEFAULT),
                     ExtendedReducedPersistanceMode.class,
                     ReducedPersistence.class
                 )

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -15,6 +15,7 @@ import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectClone
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionDistributionType;
 import com.synopsys.integration.blackduck.api.manual.temporary.enumeration.ProjectVersionPhaseType;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.IndividualFileMatching;
+import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.synopsys.integration.configuration.property.Properties;
 import com.synopsys.integration.configuration.property.Property;
@@ -48,6 +49,7 @@ import com.synopsys.integration.detect.configuration.enumeration.DetectTargetTyp
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detect.configuration.enumeration.RapidCompareMode;
 import com.synopsys.integration.detect.tool.signaturescanner.enums.ExtendedIndividualFileMatchingMode;
+import com.synopsys.integration.detect.tool.signaturescanner.enums.ExtendedReducedPersistanceMode;
 import com.synopsys.integration.detect.tool.signaturescanner.enums.ExtendedSnippetMode;
 import com.synopsys.integration.detectable.detectables.bazel.WorkspaceRule;
 import com.synopsys.integration.detectable.detectables.bitbake.BitbakeDependencyType;
@@ -455,6 +457,19 @@ public class DetectProperties {
                 "Use this value to enable the various snippet scanning modes. For a full explanation, please refer to the 'Running a component scan using the Signature Scanner command line' section in your Black Duck server's online help. Corresponding Signature Scanner CLI Arguments: --snippet-matching, --snippet-matching-only, --full-snippet-scan.")
             .setGroups(DetectGroup.SIGNATURE_SCANNER, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN)
             .build();
+    
+    public static final ExtendedEnumProperty<ExtendedReducedPersistanceMode, ReducedPersistence> DETECT_BLACKDUCK_SIGNATURE_SCANNER_REDUCED_PERSISTENCE =
+            ExtendedEnumProperty.newBuilder(
+                    "detect.blackduck.signature.scanner.reduced.persistence",
+                    ExtendedEnumValue.ofExtendedValue(ExtendedReducedPersistanceMode.NONE),
+                    ExtendedReducedPersistanceMode.class,
+                    ReducedPersistence.class
+                )
+                .setInfo("Reduced Persistence", DetectPropertyFromVersion.VERSION_8_3_0)
+                .setHelp(
+                    "Use this value to control how unmatched files from signature scans are stored. For a full explanation, please refer to the 'REPLACE ME' section in your Black Duck server's online help. Corresponding Signature Scanner CLI Arguments: --retain-unmatched-files, --discard-unmatched-files.")
+                .setGroups(DetectGroup.SIGNATURE_SCANNER, DetectGroup.GLOBAL)
+                .build();
 
     public static final BooleanProperty DETECT_BLACKDUCK_SIGNATURE_SCANNER_UPLOAD_SOURCE_MODE =
         BooleanProperty.newBuilder("detect.blackduck.signature.scanner.upload.source.mode", false)

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectPropertyFromVersion.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectPropertyFromVersion.java
@@ -38,7 +38,9 @@ public enum DetectPropertyFromVersion implements PropertyVersion {
     VERSION_7_13_0("7.13.0"),
     VERSION_7_14_0("7.14.0"),
     VERSION_8_0_0("8.0.0"),
-    VERSION_8_1_0("8.1.0");
+    VERSION_8_1_0("8.1.0"), 
+    VERSION_8_2_0("8.2.0"),
+    VERSION_8_3_0("8.3.0");
 
     private final String version;
 

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.IndividualFileMatching;
+import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 
 public class BlackDuckSignatureScannerOptions {
@@ -21,6 +22,9 @@ public class BlackDuckSignatureScannerOptions {
 
     @Nullable //Just to note that if you do not want snippet matching, this should be null.
     private final SnippetMatching snippetMatching;
+    
+    @Nullable //Just to note that if you want server defaults this should be null.
+    private final ReducedPersistence reducedPersistence;
 
     private final boolean uploadSource;
     @Nullable
@@ -50,7 +54,8 @@ public class BlackDuckSignatureScannerOptions {
         Boolean copyrightSearch,
         Boolean followSymLinks,
         Boolean treatSkippedScansAsSuccess,
-        Boolean isEphemeral
+        Boolean isEphemeral, 
+        ReducedPersistence reducedPersistence
     ) {
 
         this.signatureScannerPaths = signatureScannerPaths;
@@ -69,6 +74,7 @@ public class BlackDuckSignatureScannerOptions {
         this.followSymLinks = followSymLinks;
         this.treatSkippedScansAsSuccess = treatSkippedScansAsSuccess;
         this.isEphemeral = isEphemeral;
+        this.reducedPersistence = reducedPersistence;
     }
 
     public List<Path> getSignatureScannerPaths() {
@@ -133,5 +139,9 @@ public class BlackDuckSignatureScannerOptions {
 
     public Boolean getIsEphemeral() {
         return isEphemeral;
+    }
+    
+    public Optional<ReducedPersistence> getReducedPersistence() {
+        return Optional.ofNullable(reducedPersistence);
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/enums/ExtendedReducedPersistanceMode.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/enums/ExtendedReducedPersistanceMode.java
@@ -1,0 +1,5 @@
+package com.synopsys.integration.detect.tool.signaturescanner.enums;
+
+public enum ExtendedReducedPersistanceMode {
+    NONE
+}

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/enums/ExtendedReducedPersistanceMode.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/enums/ExtendedReducedPersistanceMode.java
@@ -1,5 +1,5 @@
 package com.synopsys.integration.detect.tool.signaturescanner.enums;
 
 public enum ExtendedReducedPersistanceMode {
-    NONE
+    DEFAULT
 }

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
@@ -74,6 +74,9 @@ public class CreateScanBatchOperation {
 
         signatureScannerOptions.getIndividualFileMatching()
             .ifPresent(scanJobBuilder::individualFileMatching);
+        
+        signatureScannerOptions.getReducedPersistence()
+            .ifPresent(scanJobBuilder::reducedPersistence);
 
         File sourcePath = directoryManager.getSourceDirectory();
 


### PR DESCRIPTION
This adds support for reduced persistence signature scans. These scans no longer store data for unmatched files.