### PR TITLE
IDETECT-3548 go list -m -f {{if (.Main)}}{{.Path}}{{end}} all fails f…

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCliExtractor.java
@@ -58,9 +58,10 @@ public class GoModCliExtractor {
     }
 
     public Extraction extract(File directory, ExecutableTarget goExe) throws ExecutableFailedException, JsonSyntaxException, DetectableException {
+        GoVersion goVersion = goVersion(directory, goExe);
         List<GoListModule> goListModules = listModules(directory, goExe);
-        List<GoListAllData> goListAllModules = listAllModules(directory, goExe);
-        List<GoGraphRelationship> goGraphRelationships = listGraphRelationships(directory, goExe);
+        List<GoListAllData> goListAllModules = listAllModules(directory, goExe, goVersion);
+        List<GoGraphRelationship> goGraphRelationships = listGraphRelationships(directory, goExe, goVersion);
         Set<String> excludedModules = listExcludedModules(directory, goExe);
 
         GoRelationshipManager goRelationshipManager = new GoRelationshipManager(goGraphRelationships, excludedModules);
@@ -78,21 +79,20 @@ public class GoModCliExtractor {
         return goListParser.parseGoListModuleJsonOutput(listOutput);
     }
 
-    private List<GoListAllData> listAllModules(File directory, ExecutableTarget goExe) throws ExecutableFailedException, JsonSyntaxException, DetectableException {
-        GoVersion goVersion = goVersion(directory, goExe);
+    private List<GoListAllData> listAllModules(File directory, ExecutableTarget goExe, GoVersion goVersion) throws ExecutableFailedException, JsonSyntaxException, DetectableException {
         List<String> listAllOutput = goModCommandRunner.runGoListAll(directory, goExe, goVersion);
         return goListParser.parseGoListAllJsonOutput(listAllOutput);
     }
 
-    private List<GoGraphRelationship> listGraphRelationships(File directory, ExecutableTarget goExe) throws ExecutableFailedException {
+    private List<GoGraphRelationship> listGraphRelationships(File directory, ExecutableTarget goExe, GoVersion goVersion) throws ExecutableFailedException {
         List<String> modGraphOutput = goModCommandRunner.runGoModGraph(directory, goExe);
 
         // Get the actual main module that produced this graph
-        String mainMod = goModCommandRunner.runGoModGetMainModule(directory, goExe);
+        String mainMod = goModCommandRunner.runGoModGetMainModule(directory, goExe, goVersion);
 
         // Get the list of TRUE direct dependencies, then use the main mod name and
         // this list to create a TRUE dependency graph from the requirement graph
-        List<String> directs = goModCommandRunner.runGoModDirectDeps(directory, goExe);
+        List<String> directs = goModCommandRunner.runGoModDirectDeps(directory, goExe, goVersion);
         List<String> whyModuleList = goModCommandRunner.runGoModWhy(directory, goExe, false);
         
         GoModuleDependencyHelper goModDependencyHelper = new GoModuleDependencyHelper();

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCommandRunner.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCommandRunner.java
@@ -80,16 +80,31 @@ public class GoModCommandRunner {
             .getStandardOutputAsList();
     }
 
-    public List<String> runGoModDirectDeps(File directory, ExecutableTarget goExe) throws ExecutableFailedException {
+    public List<String> runGoModDirectDeps(File directory, ExecutableTarget goExe, GoVersion goVersion) throws ExecutableFailedException {
         //This'll give all direct dependencies for the main module.
-        List<String> commands = new LinkedList<>(Arrays.asList(LIST_COMMAND, MODULE_OUTPUT_FLAG, FORMAT_FLAG, FORMAT_DIRECTS, MODULE_NAME));
+        List<String> commands = new LinkedList<>();
+        commands.add(LIST_COMMAND);
+        if (goVersion.getMajorVersion() > 1 || goVersion.getMinorVersion() >= 14) {
+            // Providing a readonly flag prevents the command from modifying customer's source.
+            // this flag not supported prior to go 1.14.
+            commands.add(LIST_READONLY_FLAG);
+        }
+        
+        commands.addAll(Arrays.asList(MODULE_OUTPUT_FLAG, FORMAT_FLAG, FORMAT_DIRECTS, MODULE_NAME));
         return executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(directory, goExe, commands))
                 .getStandardOutputAsList();
     }
 
-    public String runGoModGetMainModule(File directory, ExecutableTarget goExe) throws ExecutableFailedException {
+    public String runGoModGetMainModule(File directory, ExecutableTarget goExe, GoVersion goVersion) throws ExecutableFailedException {
         //This gives the value of the main module name.
-        List<String> commands = new LinkedList<>(Arrays.asList(LIST_COMMAND, MODULE_OUTPUT_FLAG, FORMAT_FLAG, FORMAT_FOR_MAIN, MODULE_NAME));
+        List<String> commands = new LinkedList<>();
+        commands.add(LIST_COMMAND);
+        if (goVersion.getMajorVersion() > 1 || goVersion.getMinorVersion() >= 14) {
+            // Providing a readonly flag prevents the command from modifying customer's source.
+            // this flag not supported prior to go 1.14
+            commands.add(LIST_READONLY_FLAG);
+        }
+        commands.addAll(Arrays.asList(MODULE_OUTPUT_FLAG, FORMAT_FLAG, FORMAT_FOR_MAIN, MODULE_NAME));
         return executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(directory, goExe, commands))
                 .getStandardOutputAsList().get(0);
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCommandRunner.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/GoModCommandRunner.java
@@ -44,14 +44,21 @@ public class GoModCommandRunner {
             .getStandardOutputAsList();
     }
 
+    private void getGoListPreamble(List<String> commandList, GoVersion goVersion) {
+        // Providing a readonly flag prevents the command from modifying customer's source.
+        // this flag not supported prior to go 1.14.
+        commandList.add(LIST_COMMAND);
+        if (goVersion.getMajorVersion() > 1 || goVersion.getMinorVersion() >= 14) {
+            // Providing a readonly flag prevents the command from modifying customer's source.
+            commandList.add(LIST_READONLY_FLAG);
+        }
+    }
+
     // TODO: Utilize the fields "Main": true, and "Indirect": true, fields from the JSON output to avoid running go list twice. Before switching to json output we needed to run twice. JM-01/2022
     public List<String> runGoListAll(File directory, ExecutableTarget goExe, GoVersion goVersion) throws ExecutableFailedException {
         List<String> goListCommand = new LinkedList<>();
-        goListCommand.add(LIST_COMMAND);
-        if (goVersion.getMajorVersion() > 1 || goVersion.getMinorVersion() >= 14) {
-            // Providing a readonly flag prevents the command from modifying customer's source.
-            goListCommand.add(LIST_READONLY_FLAG);
-        }
+        getGoListPreamble(goListCommand, goVersion); // modify go list for version > 1.14
+
         goListCommand.addAll(Arrays.asList(MODULE_OUTPUT_FLAG, JSON_OUTPUT_FLAG, MODULE_NAME));
 
         return executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(directory, goExe, goListCommand))
@@ -82,30 +89,22 @@ public class GoModCommandRunner {
 
     public List<String> runGoModDirectDeps(File directory, ExecutableTarget goExe, GoVersion goVersion) throws ExecutableFailedException {
         //This'll give all direct dependencies for the main module.
-        List<String> commands = new LinkedList<>();
-        commands.add(LIST_COMMAND);
-        if (goVersion.getMajorVersion() > 1 || goVersion.getMinorVersion() >= 14) {
-            // Providing a readonly flag prevents the command from modifying customer's source.
-            // this flag not supported prior to go 1.14.
-            commands.add(LIST_READONLY_FLAG);
-        }
+        List<String> goListCommand = new LinkedList<>();
+        getGoListPreamble(goListCommand, goVersion); // modify go list for version > 1.14
+
         
-        commands.addAll(Arrays.asList(MODULE_OUTPUT_FLAG, FORMAT_FLAG, FORMAT_DIRECTS, MODULE_NAME));
-        return executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(directory, goExe, commands))
+        goListCommand.addAll(Arrays.asList(MODULE_OUTPUT_FLAG, FORMAT_FLAG, FORMAT_DIRECTS, MODULE_NAME));
+        return executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(directory, goExe, goListCommand))
                 .getStandardOutputAsList();
     }
 
     public String runGoModGetMainModule(File directory, ExecutableTarget goExe, GoVersion goVersion) throws ExecutableFailedException {
         //This gives the value of the main module name.
-        List<String> commands = new LinkedList<>();
-        commands.add(LIST_COMMAND);
-        if (goVersion.getMajorVersion() > 1 || goVersion.getMinorVersion() >= 14) {
-            // Providing a readonly flag prevents the command from modifying customer's source.
-            // this flag not supported prior to go 1.14
-            commands.add(LIST_READONLY_FLAG);
-        }
-        commands.addAll(Arrays.asList(MODULE_OUTPUT_FLAG, FORMAT_FLAG, FORMAT_FOR_MAIN, MODULE_NAME));
-        return executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(directory, goExe, commands))
+        List<String> goListCommand = new LinkedList<>();
+        getGoListPreamble(goListCommand, goVersion); // modify go list for version > 1.14
+
+        goListCommand.addAll(Arrays.asList(MODULE_OUTPUT_FLAG, FORMAT_FLAG, FORMAT_FOR_MAIN, MODULE_NAME));
+        return executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(directory, goExe, goListCommand))
                 .getStandardOutputAsList().get(0);
     }
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableTest.java
@@ -51,10 +51,10 @@ public class GoModDetectableTest extends DetectableFunctionalTest {
         addExecutableOutput(goModGraphOutput, "go", "mod", "graph");
 
         ExecutableOutput goListMainOutput = createStandardOutputFromResource("/go/go-mod-get-main.xout");
-        addExecutableOutput(goListMainOutput, "go", "list", "-m", "-f", "{{if (.Main)}}{{.Path}}{{end}}", "all");
+        addExecutableOutput(goListMainOutput, "go", "list", "-mod=readonly", "-m", "-f", "{{if (.Main)}}{{.Path}}{{end}}", "all");
 
         ExecutableOutput goListDirectMods = createStandardOutputFromResource("/go/go-mod-list-directs.xout");
-        addExecutableOutput(goListDirectMods, "go", "list", "-m", "-f", "{{if not (or .Indirect .Main)}}{{.Path}}@{{.Version}}{{end}}", "all");
+        addExecutableOutput(goListDirectMods, "go", "list", "-mod=readonly", "-m", "-f", "{{if not (or .Indirect .Main)}}{{.Path}}@{{.Version}}{{end}}", "all");
 
         ExecutableOutput goModWhyNvOutput = createStandardOutput("/go/gomodwhy.xout");
         addExecutableOutput(goModWhyNvOutput, "go", "mod", "why", "-m", "all");

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableUnusedTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableUnusedTest.java
@@ -78,10 +78,10 @@ public class GoModDetectableUnusedTest extends DetectableFunctionalTest {
 
 
         ExecutableOutput goListMainOutput = createStandardOutputFromResource("/go/go-mod-get-main.xout");
-        addExecutableOutput(goListMainOutput, "go", "list", "-m", "-f", "{{if (.Main)}}{{.Path}}{{end}}", "all");
+        addExecutableOutput(goListMainOutput, "go", "list", "-mod=readonly", "-m", "-f", "{{if (.Main)}}{{.Path}}{{end}}", "all");
 
         ExecutableOutput goListDirectMods = createStandardOutputFromResource("/go/go-mod-list-directs.xout");
-        addExecutableOutput(goListDirectMods, "go", "list", "-m", "-f", "{{if not (or .Indirect .Main)}}{{.Path}}@{{.Version}}{{end}}", "all");
+        addExecutableOutput(goListDirectMods, "go", "list", "-mod=readonly", "-m", "-f", "{{if not (or .Indirect .Main)}}{{.Path}}@{{.Version}}{{end}}", "all");
 
     }
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableVendoredTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/go/functional/GoModDetectableVendoredTest.java
@@ -33,10 +33,10 @@ public class GoModDetectableVendoredTest extends DetectableFunctionalTest {
         addExecutableOutput(goListOutput, "go", "list", "-m", "-json");
 
         ExecutableOutput goListMainOutput = createStandardOutputFromResource("/go/go-mod-get-main.xout");
-        addExecutableOutput(goListMainOutput, "go", "list", "-m", "-f", "{{if (.Main)}}{{.Path}}{{end}}", "all");
+        addExecutableOutput(goListMainOutput, "go", "list", "-mod=readonly", "-m", "-f", "{{if (.Main)}}{{.Path}}{{end}}", "all");
 
         ExecutableOutput goListDirectMods = createStandardOutputFromResource("/go/go-mod-list-directs.xout");
-        addExecutableOutput(goListDirectMods, "go", "list", "-m", "-f", "{{if not (or .Indirect .Main)}}{{.Path}}@{{.Version}}{{end}}", "all");
+        addExecutableOutput(goListDirectMods, "go", "list", "-mod=readonly", "-m", "-f", "{{if not (or .Indirect .Main)}}{{.Path}}@{{.Version}}{{end}}", "all");
 
         ExecutableOutput goVersionOutput = createStandardOutput(
             "go version go1.16.5 darwin/amd64"

--- a/src/test/java/com/synopsys/integration/detect/battery/detector/GoBattery.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/detector/GoBattery.java
@@ -32,7 +32,7 @@ public class GoBattery {
     @Test
     void mod() {
         DetectorBatteryTestRunner test = new DetectorBatteryTestRunner("go-mod");
-        test.executableFromResourceFiles(DetectProperties.DETECT_GO_PATH, "go-list.xout", "go-version.xout", "go-list-u-json.xout", "go-mod-graph.xout", "go-mod-get-main.xout", "go-mod-list-directs.xout", "go-mod-why.xout", "go-mod-why.xout");
+        test.executableFromResourceFiles(DetectProperties.DETECT_GO_PATH, "go-version.xout", "go-list.xout", "go-list-u-json.xout", "go-mod-graph.xout", "go-mod-get-main.xout", "go-mod-list-directs.xout", "go-mod-why.xout", "go-mod-why.xout");
         test.sourceDirectoryNamed("source");
         test.sourceFileFromResource("go.mod");
         test.property(DetectProperties.DETECT_GO_MOD_DEPENDENCY_TYPES_EXCLUDED, GoModDependencyType.UNUSED.name());


### PR DESCRIPTION
…or one repo | jppetrakis

# Description

Added the key/value "-mod=readonly".  As testing showed, this wasn't a problem for go 1.13.  The need for mod=readonly came in with go 1.14 and an original "go list..." instance took this into account, based on the go version.  Evidently using mod=readonly appears only needed for modules with a "vendor" subdirectory with vendor modules contained therein.  An empty vendor folder won't cause an error.  Inclusion of mod=readonly does not appear to be an issue for this latter case as well.

# Github Issues

(Optional) Please link to any applicable github issues.
