### PR TITLE
style(help): add the missing detector search rule details to the help.json file

### DIFF
--- a/detector/src/main/java/com/synopsys/integration/detector/rule/DetectableDefinition.java
+++ b/detector/src/main/java/com/synopsys/integration/detector/rule/DetectableDefinition.java
@@ -52,4 +52,9 @@ public class DetectableDefinition {
     public DetectableAccuracyType getAccuracyType() {
         return accuracyType;
     }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
 }

--- a/src/main/java/com/synopsys/integration/detect/configuration/help/json/HelpJsonManager.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/help/json/HelpJsonManager.java
@@ -66,7 +66,11 @@ public class HelpJsonManager {
         searchRule.setMaxDepth(entryPoint.getSearchRule().getMaxDepth());
         searchRule.setNestable(entryPoint.getSearchRule().isNestable());
         searchRule.setYieldsTo(entryPoint.getSearchRule().getYieldsTo().stream().map(Object::toString).collect(Collectors.toList()));
-        //TODO(detectors): Should we capture the more complex nesting rules?
+
+        searchRule.setNotNestableBeneath(entryPoint.getSearchRule().getNotNestableBeneath().stream().map(Object::toString).collect(Collectors.toList()));
+        searchRule.setNotNestableBeneathDetectables(entryPoint.getSearchRule().getNotNestableBeneathDetectables().stream().map(Object::toString).collect(Collectors.toList()));
+
+        entryPointData.setSearchRule(searchRule);
 
         return entryPointData;
     }

--- a/src/main/java/com/synopsys/integration/detect/configuration/help/json/model/HelpJsonSearchRule.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/help/json/model/HelpJsonSearchRule.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 public class HelpJsonSearchRule {
     private List<String> yieldsTo = new ArrayList<>();
+    private List<String> notNestableBeneath = new ArrayList<>();
+    private List<String> notNestableBeneathDetectables = new ArrayList<>();
     private Integer maxDepth = 0;
     private Boolean nestable = false;
 
@@ -32,4 +34,18 @@ public class HelpJsonSearchRule {
         this.yieldsTo = yieldsTo;
     }
 
+    public void setNotNestableBeneath(final List<String> notNestableBeneath) {
+        this.notNestableBeneath = notNestableBeneath;
+    }
+    public List<String> getNotNestableBeneath() {
+        return notNestableBeneath;
+    }
+
+    public void setNotNestableBeneathDetectables(final List<String> notNestableBeneathDetectables) {
+        this.notNestableBeneathDetectables = notNestableBeneathDetectables;
+    }
+
+    public List<String> getNotNestableBeneathDetectables() {
+        return notNestableBeneathDetectables;
+    }
 }


### PR DESCRIPTION
Adds the missing details to the help.json file, in case they are useful for support. (Does not affect the documentation.) 

Background: Data from the help.json file (that detect generates when given either of the following arguments: -hjson or --helpjson) are used to populate the Detectors table on https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=components/detectors.html&_LANG=enus which is designed to help doc readers understand Detect's detector search rules.

This table does not quite tell the full detector search story; it lacks details that are sometimes required to fully understand Detect's behavior. (These details were left out of the documentation intentionally; including them would create a less readable table.) This incompleteness means developers might be called upon to explain subtle aspects of behavior explained by the missing details, because today they are only revealed by reading the (DetectorRuleFactory) code.

(A question about detector search was raised in #blackduck-detect on Nov 7; in that case a staff engineer was able to provide a satisfactory response even without complete visibility into the detector search rules involved.)

The intent of this change is to make these additional subtle details available to support when they need them, to make their job easier and to spare developers from having to provide those details when they are important. The change adds the missing details to the help.json file. It does not affect the documentation because these additional fields are ignored by the documentation generating code. But they are available to support if/when they need them (they can just run Detect with -hjson and read the JSON file it generates).

This completes a TODO that Jordan had left for us.