### PR TITLE
BDRELENG-3074: Use release version as branch to prevent overwrite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,6 +288,11 @@ task submitToPlatform1 (type: Exec, dependsOn: [buildPlatform1]){
       branch=branch.replaceFirst('origin/', '')
     }
 
+    boolean isRelease = System.getenv('RUN_RELEASE') ? System.getenv('RUN_RELEASE').toBoolean() : false
+    if (isRelease){
+        branch="update.${version}"
+    }
+
     executable 'bash'
     environment("RELEASE_VERSION", "${version}")
     environment("BRANCH", branch)

--- a/platform-1/hardening_manifest.yaml.template
+++ b/platform-1/hardening_manifest.yaml.template
@@ -8,7 +8,7 @@ name: "synopsys/blackduck/blackduck-client"
 # The most specific version should be the first tag and will be shown
 # on ironbank.dsop.io
 tags:
-- "RELEASE_VERSION"
+- "TARGET_IMAGE_TAG"
 
 # Build args passed to Dockerfile ARGs
 args:
@@ -26,7 +26,7 @@ labels:
   org.opencontainers.image.url: "blackducksoftware/blackduck-client"
   ## Name of the distributing entity, organization or individual
   org.opencontainers.image.vendor: "Synopsysi, Inc."
-  org.opencontainers.image.version: "RELEASE_VERSION"
+  org.opencontainers.image.version: "TARGET_IMAGE_TAG"
   ## Keywords to help with search (ex. "cicd,gitops,golang")
   mil.dso.ironbank.image.keywords: "SCA"
   ## This value can be "opensource" or "commercial"

--- a/platform-1/submit.sh
+++ b/platform-1/submit.sh
@@ -16,7 +16,7 @@ docker tag ${INTERNAL_DOCKER_REGISTRY}/${TARGET_REPO}/${TARGET_IMAGE}:${TARGET_I
 # upload to artifactory
 zip_sha=$(echo $(sha256sum synopsys-detect-${RELEASE_VERSION}-air-gap.zip) | cut -d' ' -f 1)
 
-sed -e "s/RELEASE_VERSION/${RELEASE_VERSION}/g" -e "s/UBI_VERSION/${UBI_VERSION}/g" -e "s/ZIP_SHA256_VALUE/${zip_sha}/" hardening_manifest.yaml.template > hardening_manifest.yaml
+sed -e "s/TARGET_IMAGE_TAG/${TARGET_IMAGE_TAG}/g" -e "s/RELEASE_VERSION/${RELEASE_VERSION}/g" -e "s/UBI_VERSION/${UBI_VERSION}/g" -e "s/ZIP_SHA256_VALUE/${zip_sha}/g" hardening_manifest.yaml.template > hardening_manifest.yaml
 
 curl -X PUT -u ${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD} ${ARTIFACTORY_HOST}/blackduck-repo1.dso.mil-generic/${TARGET_IMAGE}/synopsys-detect-${RELEASE_VERSION}-air-gap.zip -T synopsys-detect-${RELEASE_VERSION}-air-gap.zip
 


### PR DESCRIPTION
# Description

These are all platform1-related changes:

1. When a release pipeline is run used the release version as the branch for platform1
2. bug fix: The template contains the wrong reference.  


# Github Issues

(Optional) Please link to any applicable github issues.
