### PR TITLE
IDETECT-3552 - go_mod pg project - missing a component | fix wrong ma…

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/parse/GoModuleDependencyHelper.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/parse/GoModuleDependencyHelper.java
@@ -43,11 +43,15 @@ public class GoModuleDependencyHelper {
                     containsDirect = true;
                 }
             }
-            if (!containsDirect) {// anything that falls in here isn't a direct dependency of main
-                grphLine = grphLine.replace(main, "xxxxxx");
-            }
+            
+            // splitting here allows matching with less effort
             String[] splitLine = grphLine.split(" ");
-            if (splitLine[0].equals("xxxxxx")) {
+            boolean needsRedux = false;
+            if (!containsDirect && splitLine[0].equals(main)) {// anything that falls in here isn't a direct dependency of main
+                needsRedux = true;
+            }
+
+            if (needsRedux) {
                 // Redo the line to establish the direct reference module to this *indirect* module
                 grphLine = this.getProperParentage(grphLine, splitLine, whyMap, directs);
             }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/process/WhyListStructureTransform.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/process/WhyListStructureTransform.java
@@ -24,6 +24,9 @@ public class WhyListStructureTransform {
         // tells us that we're hitting a new hierarchy chain so we'll use that
         // to enter the item into the map, and start a new list for the next module.
         for (String whyModuleLine : whyList) {
+            if (whyModuleLine.length() <= 0) {
+                continue; // DONT include blank lines from the output in the list!
+            }
             if (whyModuleLine.startsWith("#")) {
                 if (!key.equals("")) {
                     moduleToHierarchyList.put(key, shortList);


### PR DESCRIPTION
…tch due to list construction | jppetrakis

# Description

Fixed main module matching so that an accidental rename is unlikely.  Eliminated empty strings in ancestry list. 

# Github Issues

(Optional) Please link to any applicable github issues.
