### PR TITLE
BDRELENG-3150: Branch name should allign with next release for repo1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,6 +292,10 @@ task submitToPlatform1 (type: Exec, dependsOn: [buildPlatform1]){
     if (isRelease){
         branch="update.${version}"
     }
+    else{
+      def new_version = version.split('-')[0]
+      branch="update.${new_version}"
+    }
 
     executable 'bash'
     environment("RELEASE_VERSION", "${version}")


### PR DESCRIPTION
# Description

Bug Fix: Branch name shouldn't be master when pushing to repo1. 

# Github Issues

(Optional) Please link to any applicable github issues.
