### PR TITLE
IDETECT-3384 - Moved intermediate WARN log statements to DEBUG level to be consistent

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -76,7 +76,7 @@ public class NpmLockfileGraphTransformer {
             if (resolved != null) {
                 dependencyGraph.addChildToRoot(resolved);
             } else {
-                logger.warn("No dependency found for package: {}", dependency.getName());
+                logger.debug("No resolved dependency found for dependency package: {}", dependency.getName());
             }
         }
     }
@@ -93,7 +93,7 @@ public class NpmLockfileGraphTransformer {
                 logger.trace(String.format("Found package: %s with version: %s", resolved.getName(), resolved.getVersion()));
                 dependencyGraph.addChildWithParent(resolved, npmDependency);
             } else {
-                logger.warn("No dependency found for package: {}", required.getName());
+                logger.debug("No resolved dependency found for required package: {}", required.getName());
             }
         });
 
@@ -129,7 +129,7 @@ public class NpmLockfileGraphTransformer {
         for (NpmDependency current : dependencies) {
             if (current.getName().equals(name)) {
                 return current;
-            }
+            } 
         }
         return null;
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -129,7 +129,7 @@ public class NpmLockfileGraphTransformer {
         for (NpmDependency current : dependencies) {
             if (current.getName().equals(name)) {
                 return current;
-            } 
+            }
         }
         return null;
     }


### PR DESCRIPTION
# Description

Moved intermediate WARN log statements to DEBUG level to be consistent with the rest of the DEBUG logs in the class. These warnings are intermediate  and do not reflect the inclusion of the components in the output BDIO.

# Github Issues

[IDETECT-3384](https://jira-sig.internal.synopsys.com/browse/IDETECT-3384)
