### PR TITLE
Update gradle.md

### DIFF
--- a/documentation/src/main/markdown/packagemgrs/gradle.md
+++ b/documentation/src/main/markdown/packagemgrs/gradle.md
@@ -40,4 +40,6 @@ The init-detect.gradle script configures each project with the custom 'gatherDep
 
 The buildless gradle detector uses Project Inspector to find dependencies.
 
-It currently only supports "build.gradle" and does not support Kotlin build files.
+It currently supports "build.gradle" and does not support Kotlin build files.
+
+Project Inspector does not support dependancy exclusions in buildless mode.


### PR DESCRIPTION
Added note about lack of PI dependency exclusion support in buildless mode.
Covers the very high level original ask, but does not close: https://jira-sig.internal.synopsys.com/browse/IDETECT-3278
