### PR TITLE
Fix detect dependency - upgrade snakeyaml from v1.31 to v1.33

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ dependencies {
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
     implementation "org.springframework.boot:spring-boot"
-    implementation 'org.yaml:snakeyaml:1.31'
+    implementation 'org.yaml:snakeyaml:1.33'
     implementation 'org.zeroturnaround:zt-zip:1.13'
     implementation 'org.apache.pdfbox:pdfbox:2.0.25'
 


### PR DESCRIPTION
# Description

Upgrade plugin snakeyaml to mitigate high security risk: BDSA-2022-3447

# Github Issues

(Optional) Please link to any applicable github issues.
