### PR TITLE
restore generating code location report

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -144,7 +144,11 @@ public class IntelligentModeStepRunner {
         });
 
         stepHelper.runAsGroup("Wait for Results", OperationType.INTERNAL, () -> {
-            if (operationRunner.createBlackDuckPostOptions().shouldWaitForResults()) {                
+            if (operationRunner.createBlackDuckPostOptions().shouldWaitForResults()) {  
+                // Calculate code locations. We do this even if we don't wait based on code locations
+                // as we want to report code location data in various reports.
+                CodeLocationResults codeLocationResults = calculateCodeLocations(codeLocationAccumulator);
+                
                 // Waiting at the scan level is more reliable, do that if the BD server is new enough.
                 if (blackDuckRunData.shouldWaitAtScanLevel()) {
                     pollForBomScanCompletion(blackDuckRunData, projectVersion, scanIdsToWaitFor);
@@ -153,7 +157,6 @@ public class IntelligentModeStepRunner {
                 // If the BD server is older, or we can't detect its version, or if we have scans that we are 
                 // not yet able to obtain the scanID for, use the original notification based waiting.
                 if (!blackDuckRunData.shouldWaitAtScanLevel() || mustWaitAtBomSummaryLevel.get()) {
-                    CodeLocationResults codeLocationResults = calculateCodeLocations(codeLocationAccumulator);
                     waitForCodeLocations(codeLocationResults.getCodeLocationWaitData(), projectNameVersion, blackDuckRunData);
                 }
             }


### PR DESCRIPTION
To keep the status.json consistent with previous versions, we should generate code location report information even if we don't wait on code locations.