### PR TITLE
build: added comment to shared-version.properties about updating create-gradle-airgap-script.ftl

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,3 @@
+// ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
 gradle.ext.blackDuckCommonVersion='66.1.2'
 gradle.ext.springBootVersion='2.6.6'


### PR DESCRIPTION
I mentioned a much better / long term fix in today's comment in [IDETECT-3588](https://jira-sig.internal.synopsys.com/browse/IDETECT-3588), but figured we should do this at a bare minimum in the meantime.
