### PR TITLE
Dev/jpp/master/idetect 3512

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -25,12 +25,10 @@ import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
-import com.synopsys.integration.configuration.property.types.enumallnone.enumeration.AllNoneEnum;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllEnumList;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllNoneEnumCollection;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllNoneEnumList;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.NoneEnumList;
-import com.synopsys.integration.configuration.property.types.enumextended.ExtendedEnumProperty;
 import com.synopsys.integration.configuration.property.types.enumextended.ExtendedEnumValue;
 import com.synopsys.integration.detect.configuration.connection.BlackDuckConnectionDetails;
 import com.synopsys.integration.detect.configuration.connection.ConnectionDetails;
@@ -329,9 +327,6 @@ public class DetectConfigurationFactory {
         if (!hasAll) { 
             cloneCategories = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).representedValues();
         }
-
-        List<ProjectCloneCategoriesType> l1 = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).toPresentValues();
-        List<ExtendedEnumValue<AllNoneEnum, ProjectCloneCategoriesType>> l2 = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).toProvidedValues();
 
         Boolean projectLevelAdjustments = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_LEVEL_ADJUSTMENTS);
         Boolean forceProjectVersionUpdate = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_VERSION_UPDATE);

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -25,6 +25,7 @@ import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
+import com.synopsys.integration.configuration.property.types.enumallnone.enumeration.AllNoneEnum;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllEnumList;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllNoneEnumCollection;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllNoneEnumList;
@@ -319,7 +320,19 @@ public class DetectConfigurationFactory {
         Integer projectTier = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_TIER);
         String projectDescription = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_DESCRIPTION);
         String projectVersionNotes = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NOTES);
-        List<ProjectCloneCategoriesType> cloneCategories = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).representedValues();
+
+        // We check if "ALL" is being specified (the default).  Black Duck will assume "all" if we don't send
+        // anything or we send null.  Leaving cloneCategroies as null will be used to avoid setting cloneCategories in
+        // the ProjectSyncModel,  i.e. the field won't even be created.
+        List<ProjectCloneCategoriesType> cloneCategories = null;
+        boolean hasAll = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).containsAll();
+        if (!hasAll) { 
+            cloneCategories = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).representedValues();
+        }
+
+        List<ProjectCloneCategoriesType> l1 = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).toPresentValues();
+        List<ExtendedEnumValue<AllNoneEnum, ProjectCloneCategoriesType>> l2 = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).toProvidedValues();
+
         Boolean projectLevelAdjustments = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_LEVEL_ADJUSTMENTS);
         Boolean forceProjectVersionUpdate = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_VERSION_UPDATE);
         String projectVersionNickname = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NICKNAME);

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/project/SyncProjectOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/project/SyncProjectOperation.java
@@ -77,7 +77,9 @@ public class SyncProjectOperation {
         }
 
         List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
-        projectSyncModel.setCloneCategories(cloneCategories);
+        if (null != cloneCategories) {
+            projectSyncModel.setCloneCategories(cloneCategories);
+        }
 
         String nickname = projectSyncOptions.getProjectVersionNickname();
         if (StringUtils.isNotBlank(nickname)) {


### PR DESCRIPTION
Fix:
For detect.project.clone.categories=ALL, use Black Duck's default for that field ("all") instead of passing the full list of known values.

Set clonedCategories list to null when "ALL" parameterization is used, then based on this, avoid adding the field to the ProjectSyncModel object.


[IDETECT-3512](https://jira-sig.internal.synopsys.com/browse/IDETECT-3512)
For detect.project.clone.categories=ALL, use Black Duck's default for that field ("all") instead of passing the full list of known values
