### PR TITLE
IDETECT-3501 force BDIO generation in offline mode

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -190,15 +190,20 @@ public class DetectConfigurationFactory {
 
     public BlackDuckConnectionDetails createBlackDuckConnectionDetails() throws DetectUserFriendlyException {
         Boolean offline = detectConfiguration.getValue(DetectProperties.BLACKDUCK_OFFLINE_MODE);
+        Boolean forceBdio = forceBdio();
         String blackduckUrl = detectConfiguration.getNullableValue(DetectProperties.BLACKDUCK_URL);
         Set<String> allBlackDuckKeys = BlackDuckServerConfig.newApiTokenBuilder().getPropertyKeys().stream()
             .filter(it -> !(it.toLowerCase().contains("proxy")))
             .collect(Collectors.toSet());
         Map<String, String> blackDuckProperties = detectConfiguration.getRaw(allBlackDuckKeys);
 
-        return new BlackDuckConnectionDetails(offline, blackduckUrl, blackDuckProperties, findParallelProcessors(), createConnectionDetails());
+        return new BlackDuckConnectionDetails(offline, blackduckUrl, blackDuckProperties, findParallelProcessors(), createConnectionDetails(), forceBdio);
     }
     //#endregion
+    
+    public Boolean forceBdio() {
+        return detectConfiguration.getValue(DetectProperties.BLACKDUCK_OFFLINE_MODE_FORCE_BDIO);
+    }
 
     public PhoneHomeOptions createPhoneHomeOptions() {
         Map<String, String> phoneHomePassthrough = detectConfiguration.getRaw(DetectProperties.PHONEHOME_PASSTHROUGH);

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1733,7 +1733,7 @@ public class DetectProperties {
     
     public static final BooleanProperty BLACKDUCK_OFFLINE_MODE_FORCE_BDIO =
         BooleanProperty.newBuilder("blackduck.offline.mode.force.bdio", false)
-            .setInfo("Offline Mode", DetectPropertyFromVersion.VERSION_4_2_0)
+            .setInfo("Offline Mode", DetectPropertyFromVersion.VERSION_8_5_0)
             .setHelp(
                 "This property will force Detect in offline mode to generate a BDIO even if no code locations were identified.")
             .setGroups(DetectGroup.BLACKDUCK_SERVER, DetectGroup.BLACKDUCK, DetectGroup.OFFLINE, DetectGroup.DEFAULT)

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1730,6 +1730,14 @@ public class DetectProperties {
             )
             .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
             .build();
+    
+    public static final BooleanProperty BLACKDUCK_OFFLINE_MODE_FORCE_BDIO =
+        BooleanProperty.newBuilder("blackduck.offline.mode.force.bdio", false)
+            .setInfo("Offline Mode", DetectPropertyFromVersion.VERSION_4_2_0)
+            .setHelp(
+                "This property will force Detect in offline mode to generate a BDIO even if no code locations were identified.")
+            .setGroups(DetectGroup.BLACKDUCK_SERVER, DetectGroup.BLACKDUCK, DetectGroup.OFFLINE, DetectGroup.DEFAULT)
+            .build();
 
     //#endregion Active Properties
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectPropertyFromVersion.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectPropertyFromVersion.java
@@ -40,7 +40,8 @@ public enum DetectPropertyFromVersion implements PropertyVersion {
     VERSION_8_0_0("8.0.0"),
     VERSION_8_1_0("8.1.0"), 
     VERSION_8_2_0("8.2.0"),
-    VERSION_8_3_0("8.3.0");
+    VERSION_8_3_0("8.3.0"),
+    VERSION_8_5_0("8.5.0");
 
     private final String version;
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/connection/BlackDuckConnectionDetails.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/connection/BlackDuckConnectionDetails.java
@@ -13,19 +13,22 @@ public class BlackDuckConnectionDetails {
     private final Map<String, String> blackduckProperties;
     private final Integer parallelProcessors;
     private final ConnectionDetails connectionDetails;
+    private final Boolean forceBdio;
 
     public BlackDuckConnectionDetails(
         Boolean offline,
         @Nullable String blackDuckUrl,
         Map<String, String> blackduckProperties,
         Integer parallelProcessors,
-        ConnectionDetails connectionDetails
+        ConnectionDetails connectionDetails,
+        Boolean forceBdio
     ) {
         this.offline = offline;
         this.blackDuckUrl = blackDuckUrl;
         this.blackduckProperties = blackduckProperties;
         this.parallelProcessors = parallelProcessors;
         this.connectionDetails = connectionDetails;
+        this.forceBdio = forceBdio;
     }
 
     @NotNull
@@ -51,5 +54,10 @@ public class BlackDuckConnectionDetails {
     @NotNull
     public ConnectionDetails getConnectionDetails() {
         return connectionDetails;
+    }
+    
+    @NotNull
+    public Boolean getForceBdio() {
+        return forceBdio;
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/interactive/InteractiveModeDecisionTree.java
+++ b/src/main/java/com/synopsys/integration/detect/interactive/InteractiveModeDecisionTree.java
@@ -1,6 +1,7 @@
 package com.synopsys.integration.detect.interactive;
 
 import static com.synopsys.integration.detect.configuration.DetectProperties.BLACKDUCK_OFFLINE_MODE;
+import static com.synopsys.integration.detect.configuration.DetectProperties.BLACKDUCK_OFFLINE_MODE_FORCE_BDIO;
 import static com.synopsys.integration.detect.configuration.DetectProperties.DETECT_PROJECT_NAME;
 import static com.synopsys.integration.detect.configuration.DetectProperties.DETECT_PROJECT_VERSION_NAME;
 import static com.synopsys.integration.detect.configuration.DetectProperties.DETECT_TOOLS_EXCLUDED;
@@ -19,6 +20,7 @@ public class InteractiveModeDecisionTree implements DecisionTree {
     public static final String SHOULD_SAVE_TO_PROFILE = "Would you like save these settings to a profile?";
     public static final String SET_PROFILE_NAME = "What is the profile name?";
     public static final String SHOULD_CONNECT_TO_BLACKDUCK = "Would you like to connect to a Black Duck server?";
+    public static final String SHOULD_FORCE_BDIO_CREATION = "Would you like to mandate BDIO generation even if no code locations are identified?";
     public static final String SHOULD_SET_PROJECT_NAME_VERSION = "Would you like to provide a project name and version to use?";
     public static final String SET_PROJECT_NAME = "What is the project name?";
     public static final String SET_PROJECT_VERSION = "What is the project version?";
@@ -58,6 +60,8 @@ public class InteractiveModeDecisionTree implements DecisionTree {
             }
         } else {
             propertySourceBuilder.setProperty(BLACKDUCK_OFFLINE_MODE, Boolean.TRUE.toString());
+            Boolean forceBdioCreation = writer.askYesOrNo(SHOULD_FORCE_BDIO_CREATION);
+            propertySourceBuilder.setProperty(BLACKDUCK_OFFLINE_MODE_FORCE_BDIO, forceBdioCreation.toString());
         }
 
         Boolean scan = writer.askYesOrNo(SHOULD_RUN_SIGNATURE_SCAN);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
@@ -69,7 +69,8 @@ public class DetectRun {
             NameVersion nameVersion = stepRunner.determineProjectInformation(universalToolsResult);
             operationRunner.publishProjectNameVersionChosen(nameVersion);
             BdioResult bdio;
-            if (!universalToolsResult.getDetectCodeLocations().isEmpty()) {
+            if (!universalToolsResult.getDetectCodeLocations().isEmpty() 
+                    || (productRunData.shouldUseBlackDuckProduct() && !productRunData.getBlackDuckRunData().isOnline())) {
                 bdio = stepRunner.generateBdio(universalToolsResult, nameVersion);
             } else {
                 bdio = BdioResult.none();

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
@@ -69,8 +69,9 @@ public class DetectRun {
             NameVersion nameVersion = stepRunner.determineProjectInformation(universalToolsResult);
             operationRunner.publishProjectNameVersionChosen(nameVersion);
             BdioResult bdio;
+            Boolean forceBdio = bootSingletons.getDetectConfigurationFactory().forceBdio();
             if (!universalToolsResult.getDetectCodeLocations().isEmpty() 
-                    || (productRunData.shouldUseBlackDuckProduct() && !productRunData.getBlackDuckRunData().isOnline())) {
+                    || (productRunData.shouldUseBlackDuckProduct() && !productRunData.getBlackDuckRunData().isOnline() && forceBdio)) {
                 bdio = stepRunner.generateBdio(universalToolsResult, nameVersion);
             } else {
                 bdio = BdioResult.none();

--- a/src/test/java/com/synopsys/integration/detect/boot/ProductDeciderTest.java
+++ b/src/test/java/com/synopsys/integration/detect/boot/ProductDeciderTest.java
@@ -129,6 +129,6 @@ class ProductDeciderTest {
     }
 
     private BlackDuckConnectionDetails blackDuckConnectionDetails(boolean offline, String blackduckUrl) {
-        return new BlackDuckConnectionDetails(offline, blackduckUrl, null, null, null);
+        return new BlackDuckConnectionDetails(offline, blackduckUrl, null, null, null, false);
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/interactive/InteractiveModeDecisionTreeEndToEndTest.java
+++ b/src/test/java/com/synopsys/integration/detect/interactive/InteractiveModeDecisionTreeEndToEndTest.java
@@ -70,7 +70,8 @@ public class InteractiveModeDecisionTreeEndToEndTest {
             ),
             Bds.mapOf(
                 Pair.of(DetectProperties.DETECT_TOOLS_EXCLUDED, DetectTool.SIGNATURE_SCAN.toString()),
-                Pair.of(DetectProperties.BLACKDUCK_OFFLINE_MODE, Boolean.TRUE.toString())
+                Pair.of(DetectProperties.BLACKDUCK_OFFLINE_MODE, Boolean.TRUE.toString()),
+                Pair.of(DetectProperties.BLACKDUCK_OFFLINE_MODE_FORCE_BDIO, Boolean.FALSE.toString())
             )
         );
     }


### PR DESCRIPTION
# Description

IDETECT-3501 force BDIO generation in offline mode if optional property is set --blackduck.offline.mode.force.bdio=true

# Github Issues
[IDETECT-3501](https://jira-sig.internal.synopsys.com/browse/IDETECT-3501)
