### PR TITLE
IDETECT-3501 - Forced BDIO generation is not allowed if Detect has a …

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
@@ -71,7 +71,7 @@ public class DetectRun {
             BdioResult bdio;
             Boolean forceBdio = bootSingletons.getDetectConfigurationFactory().forceBdio();
             if (!universalToolsResult.getDetectCodeLocations().isEmpty() 
-                    || (productRunData.shouldUseBlackDuckProduct() && !productRunData.getBlackDuckRunData().isOnline() && forceBdio)) {
+                    || (productRunData.shouldUseBlackDuckProduct() && !productRunData.getBlackDuckRunData().isOnline() && forceBdio && !universalToolsResult.didAnyFail() && exitCodeManager.getWinningExitCode().isSuccess())) {
                 bdio = stepRunner.generateBdio(universalToolsResult, nameVersion);
             } else {
                 bdio = BdioResult.none();


### PR DESCRIPTION
# Description

Forced BDIO generation is not allowed if Detect has a final failure exit code.

# Github Issues

[IDETECT-3501](https://jira-sig.internal.synopsys.com/browse/IDETECT-3501)
