### PR TITLE
Update integration-common library version from 26.0.2 to 26.0.4

### DIFF
--- a/src/main/resources/create-gradle-airgap-script.ftl
+++ b/src/main/resources/create-gradle-airgap-script.ftl
@@ -9,7 +9,7 @@ configurations {
 }
 
 dependencies {
-    airGap 'com.synopsys.integration:integration-common:26.0.2'
+    airGap 'com.synopsys.integration:integration-common:26.0.4'
     airGap 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
 }
 


### PR DESCRIPTION
**Background:**
The "gradle.ext.blackDuckCommonVersion" is specified in shared-version.properties. Currently, when we update Detect's blackDuckCommonVersion, we also need to update the integration-common version, which is encoded in "src/main/resources/create-gradle-airgap-script.ftl" to fix the issue mentioned in [IDETECT-3588](https://jira-sig.internal.synopsys.com/browse/IDETECT-3588). This is a quick fix. 
Long term fix is tracked with the JIRA issue [IDETECT-3619](https://jira-sig.internal.synopsys.com/browse/IDETECT-3619).

**Fix:**
Update the version of the integration-common library in the "src/main/resources/create-gradle-airgap-script.ftl" script from 26.0.2 to 26.0.4

