### PR TITLE
fix(integration-common): Update version to 26.0.4

### DIFF
--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -33,7 +33,7 @@ initscript {
             }
         }
 <#else>
-        classpath 'com.synopsys.integration:integration-common:24.2.1'
+        classpath 'com.synopsys.integration:integration-common:26.0.4'
 </#if>
     }
 }


### PR DESCRIPTION
**JIRA Issues**
[IDETECT-3637](https://jira-sig.internal.synopsys.com/browse/IDETECT-3637)

IDETECT-3637 bug was discovered during investigation of [IDETECT-3588](https://jira-sig.internal.synopsys.com/browse/IDETECT-3588)

**Description**
Updated integration common hardcoded version to 26.0.4 in Gradle init script to ensure Apache Commons Text 1.9.0 is no longer used by Detect.

**BD Test URL** (Running Detect on the Detect project to validate): 
https://us1a-int-hub02.nprd.sig.synopsys.com/api/projects/0ce3b6d3-f583-40bb-bd60-53ae953a237a/versions/8ebe6cb4-d4a9-40a6-88de-98a57d309b6e/components




