### PR TITLE
style(help): Update release notes for Docker Inspector upgrade

### DIFF
--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -15,6 +15,7 @@ Note: this improvement requires [blackduck_product_name] 2023.1.2 or later.
 ### Dependency update
 
 * Upgraded Apache Commons Text to version 1.10.0.
+* Upgraded Docker Inspector to version 10.0.1.
 
 ## Version 8.5.0
 


### PR DESCRIPTION
**JIRA Issue**
[IDETECT-3588](https://jira-sig.internal.synopsys.com/browse/IDETECT-3588)

**Description**
Docker Inspector version 10.0.1 was released on Feb 03, 2023 and Detect (by default) invokes the latest released version of Docker Inspector.