### PR TITLE
build(air gap): Stop producing air gap zip artifact with old naming pattern. (Resolves IDETECT-2933.)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,16 +214,11 @@ task publishAirGapZipWithoutDocker() {
 
     doLast {
         def airGapZipName = "${project.name}-${version}-air-gap-no-docker.zip"
-        def airGapZipNameLegacy = "${project.name}-${version}-air-gap-gradle-nuget.zip"
         //MUST remain for down-stream projects until late 2022
         def airGapZipLocation = createAirGapZipWithoutDocker.ext.airGapPath
         exec {
             commandLine 'curl', '--insecure', '-u', "${project.ext.artifactoryDeployerUsername}:${project.ext.artifactoryDeployerPassword}", '-X', 'PUT',
                     "${project.ext.deployArtifactoryUrl}/${project.ext.artifactoryRepo}/com/synopsys/integration/${project.name}/${version}/${airGapZipName}", '-T', "${airGapZipLocation}", '-f'
-        }
-        exec {
-            commandLine 'curl', '--insecure', '-u', "${project.ext.artifactoryDeployerUsername}:${project.ext.artifactoryDeployerPassword}", '-X', 'PUT',
-                    "${project.ext.deployArtifactoryUrl}/${project.ext.artifactoryRepo}/com/synopsys/integration/${project.name}/${version}/${airGapZipNameLegacy}", '-T', "${airGapZipLocation}", '-f'
         }
     }
 }

--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -2,9 +2,9 @@
 
 ## Version 8.7.0
 
-### Resolved issues
+### Changed features
 
-* (IDETECT-2933) Detect's generated air gap zip is uploaded to Artifactory under the name "synopsys-detect-<version>-air-gap-no-docker.zip". Older naming patterns for this file are no longer supported. 
+* (IDETECT-2933) [solution_name]'s generated air gap zip is uploaded to Artifactory under the name "synopsys-detect-<version>-air-gap-no-docker.zip". Older naming patterns for this file are no longer supported. 
 
 ## Version 8.6.0
 

--- a/documentation/src/main/markdown/releasenotes.md
+++ b/documentation/src/main/markdown/releasenotes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 8.7.0
+
+### Resolved issues
+
+* (IDETECT-2933) Detect's generated air gap zip is uploaded to Artifactory under the name "synopsys-detect-<version>-air-gap-no-docker.zip". Older naming patterns for this file are no longer supported. 
+
 ## Version 8.6.0
 
 ### Changed features


### PR DESCRIPTION
# Description

For a limited time, the air gap zip artifact was being uploaded with both new and legacy naming patterns for backwards compatibility sake. The time is up and we no longer need to do this. 

# Github Issues

Resolves [IDETECT-2933](https://jira-sig.internal.synopsys.com/browse/IDETECT-2933)
