### PR TITLE
remove looking for error in info log

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/workflow/status/DetectStatusLoggerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/status/DetectStatusLoggerTest.java
@@ -60,8 +60,6 @@ public class DetectStatusLoggerTest {
         ArrayList<Status> statusSummaries = new ArrayList<>();
         Status status = new Status("description 1", StatusType.SUCCESS);
         statusSummaries.add(status);
-        status = new Status("description 2", StatusType.FAILURE);
-        statusSummaries.add(status);
         return statusSummaries;
     }
 

--- a/src/test/resources/workflow/status/expectedStatusLoggerOutput.txt
+++ b/src/test/resources/workflow/status/expectedStatusLoggerOutput.txt
@@ -46,7 +46,6 @@ report_1: ./report/1/report_file
 ======== Detect Status ========
 
 description 1: SUCCESS
-description 2: FAILURE
 Overall Status: SUCCESS - Detect exited successfully.
 
 ===============================


### PR DESCRIPTION
Some logging messages have changed to error so tests should no longer look for them in the error log