### PR TITLE
Dev/jpp/8.7.z/idetect 3695

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanRequestBuilder.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanRequestBuilder.java
@@ -9,7 +9,8 @@ import com.synopsys.integration.blackduck.service.request.BlackDuckResponseReque
 import com.synopsys.integration.rest.HttpUrl;
 
 public class DetectRapidScanRequestBuilder {
-    public static final String CURRENT_MEDIA_TYPE = "application/vnd.blackducksoftware.scan-5+json";
+    // change to v6 for full-result usage.  v5 currently appears to return malformed json.
+    public static final String CURRENT_MEDIA_TYPE = "application/vnd.blackducksoftware.scan-6+json";
     private final BlackDuckRequestBuilder blackDuckRequestBuilder;
 
     public DetectRapidScanRequestBuilder() {


### PR DESCRIPTION
Attempt to use policy override causes Gson/Json parse error.  Evidently version of full-result api used resulted in malformed Json array which caused the failure.  Using more recent version for the full-result pull returns proper json construct.
