### PR TITLE
upgraded vulnerable libraries(jackson-databind, apache pdfbox etc.)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ subprojects {
 allprojects {
     dependencies {
         implementation "com.google.guava:guava:31.1-jre"
-        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2'
+        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
 
         implementation 'org.freemarker:freemarker:2.3.31'
         implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
@@ -103,7 +103,7 @@ dependencies {
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
     implementation "org.springframework.boot:spring-boot"
-    implementation 'org.yaml:snakeyaml:2.0'
+    implementation 'org.yaml:snakeyaml:1.33'
     implementation 'org.zeroturnaround:zt-zip:1.13'
     implementation 'org.apache.pdfbox:pdfbox:2.0.27'
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,10 @@ subprojects {
 allprojects {
     dependencies {
         implementation "com.google.guava:guava:31.1-jre"
-        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
+        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2'
 
         implementation 'org.freemarker:freemarker:2.3.31'
-        implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.13'
+        implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
 
         testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
         testImplementation 'org.mockito:mockito-core:2.+'
@@ -103,9 +103,9 @@ dependencies {
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
     implementation "org.springframework.boot:spring-boot"
-    implementation 'org.yaml:snakeyaml:1.33'
+    implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.zeroturnaround:zt-zip:1.13'
-    implementation 'org.apache.pdfbox:pdfbox:2.0.25'
+    implementation 'org.apache.pdfbox:pdfbox:2.0.27'
 
     // spring-boot-starter-test *can* provide these, but we choose to be more explicit about the dependencies we ACTUALLY use
     testImplementation 'org.assertj:assertj-core:3.13.2'
@@ -115,7 +115,7 @@ dependencies {
     testImplementation project(':configuration').sourceSets.test.output
     testImplementation project(':common-test')
     testImplementation 'com.github.docker-java:docker-java-core:3.2.7'
-    testImplementation 'com.github.docker-java:docker-java-transport-httpclient5:3.2.7'
+    testImplementation 'com.github.docker-java:docker-java-transport-httpclient5:3.3.0'
 }
 
 springBoot { mainClass = 'com.synopsys.integration.detect.Application' }


### PR DESCRIPTION

# Description
This branch resolves the vulnerabilities mentioned in [IDETECT-3647](https://jira-sig.internal.synopsys.com/browse/IDETECT-3647). 

Vulnerabilities that can be solved with the existing Java version have been upgraded. You can find my investigation regarding IDETECT-3647 & IDETECT-3682 in [**here**](https://sig-confluence.internal.synopsys.com/pages/viewpage.action?pageId=852761876)

Despite the version upgrade of **Apache Commons Codec**, there seems to be a vulnerability that persists. The CVE-2020-15250 is not pertinent to this application. As these vulnerabilities are for those described in [here](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250).
# Github Issues

(Optional) Please link to any applicable github issues.
