### PR TITLE
upgraded to spring-boot version to 2.7.9.

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
 gradle.ext.blackDuckCommonVersion='66.1.4'
-gradle.ext.springBootVersion='2.6.6'
+gradle.ext.springBootVersion='2.7.9'


### PR DESCRIPTION
# Description

Previously detect had **spring-boot** and **spring core framework** version **2.6.6** & **5.3.18** respectively. And **5.3.18** has some serious security issues. Details can be found **[here](https://sig-confluence.internal.synopsys.com/pages/viewpage.action?pageId=852761876)**.

After upgrading to spring-boot 2.7.9, now the core version of spring is 5.3.25. **For the time being,** the aforementioned vulnerabilities are resolved. 

As we are still running detect in Java 11, this is the highest version of spring boot we can migrate to.

# Github Issues

(Optional) Please link to any applicable github issues.
