### PR TITLE
IDETECT 3706 exit if bdba fails

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/bdba/BdbaRapidScanWaitJob.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdba/BdbaRapidScanWaitJob.java
@@ -1,22 +1,9 @@
-/*
- * Copyright (C) 2023 Synopsys Inc.
- * http://www.synopsys.com/
- * All rights reserved.
- *
- * This software is the confidential and proprietary information of
- * Synopsys ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Synopsys.
- */
 package com.synopsys.integration.detect.workflow.bdba;
 
 import java.util.UUID;
 
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.exception.IntegrationException;
@@ -60,7 +47,7 @@ public class BdbaRapidScanWaitJob implements ResilientJob<BdbaStatusScanView>{
              String json = response.getContentString();
              BdbaStatusScanView initialResponse = gson.fromJson(json, BdbaStatusScanView.class);
 
-             if (!initialResponse.getStatus().equals(IN_PROGRESS)) {
+             if (!initialResponse.getStatus().toLowerCase().equals(IN_PROGRESS)) {
                  complete = true;
                  scanStatus = initialResponse;
              }

--- a/src/main/java/com/synopsys/integration/detect/workflow/bdba/BdbaRapidScanWaitJob.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/bdba/BdbaRapidScanWaitJob.java
@@ -36,6 +36,7 @@ public class BdbaRapidScanWaitJob implements ResilientJob<BdbaStatusScanView>{
     
     private boolean complete;
     private static final String JOB_NAME = "BDBA Stateless Scan Wait Job ";
+    private static final String IN_PROGRESS = "inprogress";
 
     public BdbaRapidScanWaitJob(IntHttpClient httpClient, UUID scanId, Gson gson, String bdbaBaseUrl) {
         this.httpClient = httpClient;
@@ -59,7 +60,7 @@ public class BdbaRapidScanWaitJob implements ResilientJob<BdbaStatusScanView>{
              String json = response.getContentString();
              BdbaStatusScanView initialResponse = gson.fromJson(json, BdbaStatusScanView.class);
 
-             if (initialResponse.getStatus().equals("ready")) {
+             if (!initialResponse.getStatus().equals(IN_PROGRESS)) {
                  complete = true;
                  scanStatus = initialResponse;
              }


### PR DESCRIPTION
We won't always get a ready state from BDBA although the scan might still be done (due to failures). Only poll if the scan comes back as in progress.