### PR TITLE
IDETECT-3344 Configurable Polling Interval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ docker-test/
 *.hprof
 *.bak
 *.gradle
+
+download/

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1055,7 +1055,7 @@ public class OperationRunner {
         );
     }
 
-    public File getScanCliOutputLogFile() {
+    private File getScanCliOutputLogFile() {
         File blackDuckScanOutputDirectory = this.fileFinder.findFile(directoryManager.getScanOutputDirectory(), "BlackDuckScanOutput");
         if (blackDuckScanOutputDirectory != null) {
             File scanIdDirectory = this.fileFinder.findFile(blackDuckScanOutputDirectory, "*");
@@ -1069,7 +1069,7 @@ public class OperationRunner {
         return null;
     }
 
-    public int countSignatureScannerBdioChunks() {
+    private int countSignatureScannerBdioChunks() {
         try {
             File scanCliOutputLogFile = getScanCliOutputLogFile();
             if (scanCliOutputLogFile == null) {
@@ -1098,13 +1098,15 @@ public class OperationRunner {
         }
     }
 
-    public int countDetectBdioEntryFiles() {
+    private int countDetectBdioEntryFiles() {
         try {
             File bdioFile = this.fileFinder.findFile(directoryManager.getBdioOutputDirectory(), "*.bdio");
+            if (bdioFile == null) {
+                return 0;
+            }
             Bdio2ContentExtractor bdio2Extractor = new Bdio2ContentExtractor();
             return bdio2Extractor.extractContent(bdioFile).size() - 1;
         } catch (IntegrationException e) {
-            logger.error(e.getMessage());
             return 0;
         }
     }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -957,7 +957,7 @@ public class OperationRunner {
         );
     }
 
-    public int countBdioEntryFiles() throws IntegrationException {
+    private int countBdioEntryFiles() throws IntegrationException {
         File bdioFile = this.fileFinder.findFile(directoryManager.getBdioOutputDirectory(), "*.bdio");
         Bdio2ContentExtractor bdio2Extractor = new Bdio2ContentExtractor();
         return bdio2Extractor.extractContent(bdioFile).size() - 1; // excludes bdio header file

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -975,8 +975,8 @@ public class OperationRunner {
             BufferedReader reader = new BufferedReader(new FileReader(scanCliOutputLogFile));
 
             Pattern pattern = Pattern.compile("scanNodeList\\.size\\(\\)=(\\d+).*scanLeafList\\.size\\(\\)=(\\d+)");
-            int scanNodeCount = 0;
-            int scanLeafCount = 0;
+            long scanNodeCount = 0;
+            long scanLeafCount = 0;
 
             String line = reader.readLine();
             while (line != null) {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -965,17 +965,17 @@ public class OperationRunner {
 
     private int calculateMaxWaitInSeconds() throws IntegrationException {
         // Max polling interval time will be the (N+1)th Fibonacci number in seconds, where N is the number of BDIO chunks (entry files)
-        int bdioChunks = countBdioEntryFiles();
+        int bdioEntriesCount = countBdioEntryFiles();
         int maxWaitInSeconds = 1;
-        if (bdioChunks > fibonacciSequence.length - 1) {
+        if (bdioEntriesCount > fibonacciSequence.length - 1) {
             maxWaitInSeconds = fibonacciSequence[fibonacciSequence.length - 1];
-        } else if (bdioChunks > 0) {
-            maxWaitInSeconds = fibonacciSequence[bdioChunks];
+        } else if (bdioEntriesCount > 0) {
+            maxWaitInSeconds = fibonacciSequence[bdioEntriesCount];
         }
         return maxWaitInSeconds;
     }
 
-    public BomStatusScanView waitForBomScanCompletion(BlackDuckRunData blackDuckRunData, HttpUrl scanUrl) throws OperationException, IntegrationException {
+    public BomStatusScanView waitForBomScanCompletion(BlackDuckRunData blackDuckRunData, HttpUrl scanUrl) throws OperationException {
         return auditLog.namedInternal("Wait for scan to potentially be included in BOM", () -> {
             BlackDuckServicesFactory blackDuckServicesFactory = blackDuckRunData.getBlackDuckServicesFactory();
             return new BomScanWaitOperation(blackDuckServicesFactory.getBlackDuckApiClient()).waitForScan(

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -198,8 +198,8 @@ public class OperationRunner {
     private final ProjectEventPublisher projectEventPublisher;
     private final DetectExecutableRunner executableRunner;
     private final OperationAuditLog auditLog;
-    private static final int[] limitedFibonacciSequence = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55};
-    private static final int defaultMaxWaitInSeconds = 10;
+    private static final int[] LIMITED_FIBONACCI_SEQUENCE = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55};
+    private static final int MAX_WAIT_IN_SECONDS_IF_BDIO_UNAVAILABLE = 5;
 
     //Internal: Operation -> Action
     //Leave OperationSystem, but it becomes 'user facing groups of actions or steps'
@@ -970,16 +970,14 @@ public class OperationRunner {
         }
     }
 
-    public int calculateMaxWaitInSeconds(int bdioEntriesCount) {
-        int fibonacciSequenceIndex = bdioEntriesCount;
-        int fibonacciSequenceLastIndex = limitedFibonacciSequence.length - 1;
-
+    public int calculateMaxWaitInSeconds(int fibonacciSequenceIndex) {
+        int fibonacciSequenceLastIndex = LIMITED_FIBONACCI_SEQUENCE.length - 1;
         if (fibonacciSequenceIndex > fibonacciSequenceLastIndex) {
-            return limitedFibonacciSequence[fibonacciSequenceLastIndex];
+            return LIMITED_FIBONACCI_SEQUENCE[fibonacciSequenceLastIndex];
         } else if (fibonacciSequenceIndex > 0) {
-            return limitedFibonacciSequence[fibonacciSequenceIndex];
+            return LIMITED_FIBONACCI_SEQUENCE[fibonacciSequenceIndex];
         }
-        return defaultMaxWaitInSeconds;
+        return MAX_WAIT_IN_SECONDS_IF_BDIO_UNAVAILABLE;
     }
 
     public BomStatusScanView waitForBomCompletion(BlackDuckRunData blackDuckRunData, HttpUrl scanUrl) throws OperationException {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -198,7 +198,6 @@ public class OperationRunner {
     private final ProjectEventPublisher projectEventPublisher;
     private final DetectExecutableRunner executableRunner;
     private final OperationAuditLog auditLog;
-    private static final int[] fibonacciSequence = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55};
 
     //Internal: Operation -> Action
     //Leave OperationSystem, but it becomes 'user facing groups of actions or steps'
@@ -328,12 +327,13 @@ public class OperationRunner {
     public List<DeveloperScansScanView> waitForFullRapidResults(BlackDuckRunData blackDuckRunData, List<HttpUrl> rapidScans, BlackduckScanMode mode) throws OperationException {
         return auditLog.namedInternal("Rapid Wait", () -> {
             BlackDuckServicesFactory blackDuckServicesFactory = blackDuckRunData.getBlackDuckServicesFactory();
+            int bdioEntriesCount = countBdioEntryFiles();
             return new RapidModeWaitOperation(blackDuckServicesFactory.getBlackDuckApiClient()).waitForFullScans(
                 rapidScans,
                 detectConfigurationFactory.findTimeoutInSeconds(),
                 RapidModeWaitOperation.DEFAULT_WAIT_INTERVAL_IN_SECONDS,
                 mode,
-                calculateMaxWaitInSeconds()
+                calculateMaxWaitInSeconds(bdioEntriesCount)
             );
         });
     }
@@ -957,20 +957,21 @@ public class OperationRunner {
         );
     }
 
-    private int countBdioEntryFiles() throws IntegrationException {
+    public int countBdioEntryFiles() throws IntegrationException {
         File bdioFile = this.fileFinder.findFile(directoryManager.getBdioOutputDirectory(), "*.bdio");
         Bdio2ContentExtractor bdio2Extractor = new Bdio2ContentExtractor();
         return bdio2Extractor.extractContent(bdioFile).size() - 1; // excludes bdio header file
     }
 
-    private int calculateMaxWaitInSeconds() throws IntegrationException {
+    public int calculateMaxWaitInSeconds(int bdioEntriesCount) {
         // Max polling interval time will be the (N+1)th Fibonacci number in seconds, where N is the number of BDIO chunks (entry files)
-        int bdioEntriesCount = countBdioEntryFiles();
         int maxWaitInSeconds = 1;
-        if (bdioEntriesCount > fibonacciSequence.length - 1) {
-            maxWaitInSeconds = fibonacciSequence[fibonacciSequence.length - 1];
+        int[] customFibonacciSequence = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55};
+
+        if (bdioEntriesCount > customFibonacciSequence.length - 1) {
+            maxWaitInSeconds = customFibonacciSequence[customFibonacciSequence.length - 1];
         } else if (bdioEntriesCount > 0) {
-            maxWaitInSeconds = fibonacciSequence[bdioEntriesCount];
+            maxWaitInSeconds = customFibonacciSequence[bdioEntriesCount];
         }
         return maxWaitInSeconds;
     }
@@ -978,10 +979,11 @@ public class OperationRunner {
     public BomStatusScanView waitForBomScanCompletion(BlackDuckRunData blackDuckRunData, HttpUrl scanUrl) throws OperationException {
         return auditLog.namedInternal("Wait for scan to potentially be included in BOM", () -> {
             BlackDuckServicesFactory blackDuckServicesFactory = blackDuckRunData.getBlackDuckServicesFactory();
+            int bdioEntriesCount = countBdioEntryFiles();
             return new BomScanWaitOperation(blackDuckServicesFactory.getBlackDuckApiClient()).waitForScan(
                     scanUrl,
                     detectConfigurationFactory.findTimeoutInSeconds(),
-                    calculateMaxWaitInSeconds()
+                    calculateMaxWaitInSeconds(bdioEntriesCount)
             );
         });
     }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -187,8 +187,7 @@ public class IntelligentModeStepRunner {
             }
             
             HttpUrl scanToSearchFor = new HttpUrl(bomToSearchFor.toString() + "/" + scanId);
-
-            operationRunner.waitForBomScanCompletion(blackDuckRunData, scanToSearchFor);
+            operationRunner.waitForBomCompletion(blackDuckRunData, scanToSearchFor);
         }
     }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/BomScanWaitOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/BomScanWaitOperation.java
@@ -22,8 +22,8 @@ public class BomScanWaitOperation {
         this.blackDuckApiClient = blackDuckApiClient;
     }
 
-    public BomStatusScanView waitForScan(HttpUrl scanUrl, long timeoutInSeconds) throws InterruptedException, IntegrationException {
-        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createProgressive(timeoutInSeconds, 60);
+    public BomStatusScanView waitForScan(HttpUrl scanUrl, long timeoutInSeconds, int maxWaitInSeconds) throws InterruptedException, IntegrationException {
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createProgressive(timeoutInSeconds, maxWaitInSeconds);
         ResilientJobConfig waitJobConfig = new ResilientJobConfig(new Slf4jIntLogger(logger), System.currentTimeMillis(), waitIntervalTracker);
         
         DetectBomScanWaitJob waitJob = new DetectBomScanWaitJob(blackDuckApiClient, scanUrl);

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeWaitOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeWaitOperation.java
@@ -27,9 +27,9 @@ public class RapidModeWaitOperation {
         this.blackDuckApiClient = blackDuckApiClient;
     }
 
-    public List<DeveloperScansScanView> waitForFullScans(List<HttpUrl> uploadedScans, long timeoutInSeconds, int waitIntervalInSeconds, BlackduckScanMode mode)
+    public List<DeveloperScansScanView> waitForFullScans(List<HttpUrl> uploadedScans, long timeoutInSeconds, int waitIntervalInSeconds, BlackduckScanMode mode, int maxWaitInSeconds)
             throws IntegrationException, InterruptedException {
-            WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createProgressive(timeoutInSeconds, 60);
+            WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createProgressive(timeoutInSeconds, maxWaitInSeconds);
             ResilientJobConfig waitJobConfig = new ResilientJobConfig(new Slf4jIntLogger(logger), System.currentTimeMillis(), waitIntervalTracker);
             DetectRapidScanWaitJobFull waitJob = new DetectRapidScanWaitJobFull(blackDuckApiClient, uploadedScans, mode);
             ResilientJobExecutor jobExecutor = new ResilientJobExecutor(waitJobConfig);

--- a/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
@@ -1,0 +1,50 @@
+package com.synopsys.integration.detect.lifecycle.run.operation;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import org.mockito.Mockito;
+
+import com.synopsys.integration.detect.lifecycle.run.DetectFontLoaderFactory;
+import com.synopsys.integration.detect.lifecycle.run.singleton.BootSingletons;
+import com.synopsys.integration.detect.lifecycle.run.singleton.EventSingletons;
+import com.synopsys.integration.detect.lifecycle.run.singleton.UtilitySingletons;
+import com.synopsys.integration.detect.tool.detector.factory.DetectDetectableFactory;
+import com.synopsys.integration.exception.IntegrationException;
+
+public class OperationRunnerTest {
+    private static OperationRunner operationRunner;
+    @BeforeAll
+    public static void setUp() {
+        operationRunner = new OperationRunner(
+            Mockito.mock(DetectDetectableFactory.class),
+            Mockito.mock(DetectFontLoaderFactory.class),
+            Mockito.mock(BootSingletons.class),
+            Mockito.mock(UtilitySingletons.class),
+            Mockito.mock(EventSingletons.class)
+        );
+    }
+
+    @Test
+    public void testCalculateMaxWaitInSeconds() throws IntegrationException {
+        // Lower bound edge cases
+        Assertions.assertEquals(1, operationRunner.calculateMaxWaitInSeconds(0));
+        Assertions.assertEquals(1, operationRunner.calculateMaxWaitInSeconds(-1));
+
+        // Core cases
+        Assertions.assertEquals(1, operationRunner.calculateMaxWaitInSeconds(2));
+        Assertions.assertEquals(2, operationRunner.calculateMaxWaitInSeconds(3));
+        Assertions.assertEquals(3, operationRunner.calculateMaxWaitInSeconds(4));
+        Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(5));
+        Assertions.assertEquals(8, operationRunner.calculateMaxWaitInSeconds(6));
+        Assertions.assertEquals(13, operationRunner.calculateMaxWaitInSeconds(7));
+        Assertions.assertEquals(21, operationRunner.calculateMaxWaitInSeconds(8));
+        Assertions.assertEquals(34, operationRunner.calculateMaxWaitInSeconds(9));
+        Assertions.assertEquals(55, operationRunner.calculateMaxWaitInSeconds(10));
+
+        // Upper bound edge cases
+        Assertions.assertEquals(55, operationRunner.calculateMaxWaitInSeconds(11));
+        Assertions.assertEquals(55, operationRunner.calculateMaxWaitInSeconds(100));
+    }
+}

--- a/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
@@ -29,8 +29,8 @@ public class OperationRunnerTest {
     @Test
     public void testCalculateMaxWaitInSeconds() throws IntegrationException {
         // Lower bound edge cases
-        Assertions.assertEquals(1, operationRunner.calculateMaxWaitInSeconds(0));
-        Assertions.assertEquals(1, operationRunner.calculateMaxWaitInSeconds(-1));
+        Assertions.assertEquals(10, operationRunner.calculateMaxWaitInSeconds(0));
+        Assertions.assertEquals(10, operationRunner.calculateMaxWaitInSeconds(-1));
 
         // Core cases
         Assertions.assertEquals(1, operationRunner.calculateMaxWaitInSeconds(2));

--- a/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
@@ -29,8 +29,8 @@ public class OperationRunnerTest {
     @Test
     public void testCalculateMaxWaitInSeconds() throws IntegrationException {
         // Lower bound edge cases
-        Assertions.assertEquals(10, operationRunner.calculateMaxWaitInSeconds(0));
-        Assertions.assertEquals(10, operationRunner.calculateMaxWaitInSeconds(-1));
+        Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(0));
+        Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(-1));
 
         // Core cases
         Assertions.assertEquals(1, operationRunner.calculateMaxWaitInSeconds(2));


### PR DESCRIPTION
### Background
In Intelligent mode when `--detect.wait.for.results=true`, Detect polls the BOM Status API and the wait time progresses in a fibonacci sequence. This also occurs in Rapid mode by default (i.e. not dependent on `--detect.wait.for.results`). Customers need to wait a lot longer for larger scans as the fibonacci sequence grows exponentially.

### Description
This PR configures the max wait time to be dependent on the number of BDIO chunks. Number of BDIO chunks is derived from Detect's BDIO file or a Signature Scanner BDIO file depending on the detect tools property configuration.

**Approach when Signature Scan is executed and Scan CLI's log file exists**
- Extract the scan node count and scan leaf count from the Scan CLI's output log file.
- Number of BDIO chunks (N) used by signature scanner is calculated as below: (Math.ceil to adjust for a remainder)
  - `int bdioChunksCount = (int) Math.ceil(sumOfScanNodesAndLeaves / 30000D); ` 

**Approach for all other cases**
- Count the number of entry files in Detect's BDIO zip as N

Max wait time is then set as the (N+1)th Fibonacci number in seconds up to a max value of 55.

**Example**
Custom fibonacci sequence used: `{0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55}`
If `--detect.tools=DETECTOR` and the BDIO contains a header file and 3 BDIO entry files, the max wait time is 2 seconds as we look at the (N+1)th i.e. 4th fibonacci number. Hence, polling interval will not exceed 2 seconds in this case.
If `--detect.tools=SIGNATURE_SCAN`, the above formula would apply to count the bdio chunks. So if scanNodeCount = 336 and scanLeafCount = 1655, bdioChunksCount would be equal to 1 which is N.
Max wait time would be 2nd fibonacci number in above sequence that is 1.

### JIRA Issue
[IDETECT-3344](https://jira-sig.internal.synopsys.com/browse/IDETECT-3344)

### Confluence page
[Configurable Polling Interval in Communication](https://sig-confluence.internal.synopsys.com/display/integration/Configurable+Polling+Interval+in+Communication?src=jira)