### PR TITLE
revert snakeyaml and jackson dataformat version upgrade changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ subprojects {
 allprojects {
     dependencies {
         implementation "com.google.guava:guava:31.1-jre"
-        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2'
+        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
 
         implementation 'org.freemarker:freemarker:2.3.31'
         implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
@@ -103,7 +103,7 @@ dependencies {
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
     implementation "org.springframework.boot:spring-boot"
-    implementation 'org.yaml:snakeyaml:2.0'
+    implementation 'org.yaml:snakeyaml:1.33'
     implementation 'org.zeroturnaround:zt-zip:1.13'
     implementation 'org.apache.pdfbox:pdfbox:2.0.27'
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.8.0-SIGQA3'
+version = '8.8.0-SIGQA4-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.8.0-SIGQA3-SNAPSHOT'
+version = '8.8.0-SIGQA3'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.8.0-SIGQA4'
+version = '8.8.0-SIGQA5-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.8.0-SIGQA4-SNAPSHOT'
+version = '8.8.0-SIGQA4'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/main/resources/create-gradle-airgap-script.ftl
+++ b/src/main/resources/create-gradle-airgap-script.ftl
@@ -10,7 +10,7 @@ configurations {
 
 dependencies {
     airGap 'com.synopsys.integration:integration-common:26.0.4'
-    airGap 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    airGap 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
 }
 
 task installDependencies(type: Copy) {


### PR DESCRIPTION
# Description

This PR resolves the snakeyaml compatibility issue mentioned in **IDETECT-3713**, caused by [this PR](https://github.com/blackducksoftware/synopsys-detect/pull/758).

This branch has been tested before and after the revert. Before the revert, these issues with snakeyaml seem to persist. 
However, after the revert Karolyn confirmed that these issues are resolved.
