### PR TITLE
Set min polling interval threshold when bdio chunk count is below 5

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -212,7 +212,7 @@ public class OperationRunner {
     private final DetectExecutableRunner executableRunner;
     private final OperationAuditLog auditLog;
     private static final int[] LIMITED_FIBONACCI_SEQUENCE = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55};
-    private static final int MAX_WAIT_IN_SECONDS_IF_BDIO_UNAVAILABLE = 5;
+    private static final int MIN_POLLING_INTERVAL_THRESHOLD_IN_SECONDS = 5;
 
     //Internal: Operation -> Action
     //Leave OperationSystem, but it becomes 'user facing groups of actions or steps'
@@ -1127,10 +1127,10 @@ public class OperationRunner {
         int fibonacciSequenceLastIndex = LIMITED_FIBONACCI_SEQUENCE.length - 1;
         if (fibonacciSequenceIndex > fibonacciSequenceLastIndex) {
             return LIMITED_FIBONACCI_SEQUENCE[fibonacciSequenceLastIndex];
-        } else if (fibonacciSequenceIndex > 0) {
+        } else if (fibonacciSequenceIndex > 4) {
             return LIMITED_FIBONACCI_SEQUENCE[fibonacciSequenceIndex];
         }
-        return MAX_WAIT_IN_SECONDS_IF_BDIO_UNAVAILABLE;
+        return MIN_POLLING_INTERVAL_THRESHOLD_IN_SECONDS;
     }
 
     public int getFibonacciSequenceIndex() {

--- a/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
@@ -31,11 +31,11 @@ public class OperationRunnerTest {
         // Lower bound edge cases
         Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(0));
         Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(-1));
+        Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(2));
+        Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(3));
+        Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(4));
 
         // Core cases
-        Assertions.assertEquals(1, operationRunner.calculateMaxWaitInSeconds(2));
-        Assertions.assertEquals(2, operationRunner.calculateMaxWaitInSeconds(3));
-        Assertions.assertEquals(3, operationRunner.calculateMaxWaitInSeconds(4));
         Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(5));
         Assertions.assertEquals(8, operationRunner.calculateMaxWaitInSeconds(6));
         Assertions.assertEquals(13, operationRunner.calculateMaxWaitInSeconds(7));


### PR DESCRIPTION
This PR refers to setting a minimum polling interval threshold value of 5 seconds in cases where the BDIO chunk count is below 5.

JIRA Issue
https://jira-sig.internal.synopsys.com/browse/IDETECT-3344

