### PR TITLE
improve close of stream

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidBdbaStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidBdbaStepRunner.java
@@ -1,6 +1,5 @@
 package com.synopsys.integration.detect.lifecycle.run.step;
 
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
@@ -134,7 +133,7 @@ public class RapidBdbaStepRunner {
     }
 
     private void extractBdio(DirectoryManager directoryManager, Response response)
-            throws IntegrationException, IOException, FileNotFoundException {
+            throws IntegrationException, IOException {
         logger.debug("Downloaded BDBA protobuf BDIO. Beginning extraction.");
 
         try (ZipInputStream zis = new ZipInputStream(response.getContent())) {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidBdbaStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidBdbaStepRunner.java
@@ -113,7 +113,7 @@ public class RapidBdbaStepRunner {
         jobExecutor.executeJob(waitJob);
     }
 
-    public void downloadAndExtractBdio(DirectoryManager directoryManager, NameVersion projectVersion) throws IntegrationException, IOException {
+    public void downloadAndExtractBdio(DirectoryManager directoryManager) throws IntegrationException, IOException {
         RequestBuilder createRequestBuilder = httpClient.createRequestBuilder(HttpMethod.GET);
         
         HttpUriRequest request = createRequestBuilder

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -116,7 +116,7 @@ public class RapidModeStepRunner {
         RapidBdbaStepRunner rapidBdbaStepRunner = new RapidBdbaStepRunner(gson, bdbaScanId, blackDuckRunData.getBlackDuckServerConfig().getTimeout());
         rapidBdbaStepRunner.submitScan(isContainerScan, scaasFilePath);
         rapidBdbaStepRunner.pollForResults();
-        rapidBdbaStepRunner.downloadAndExtractBdio(directoryManager, projectVersion);
+        rapidBdbaStepRunner.downloadAndExtractBdio(directoryManager);
 
         UUID bdScanId = operationRunner.initiateStatelessBdbaScan(blackDuckRunData);
         operationRunner.uploadBdioEntries(blackDuckRunData, bdScanId);


### PR DESCRIPTION
These changes are to cleanup some issues sonarcloud scans found with the code. Primarily I'm now closing streams as part of a try block instead of specifically in the code. Changes have been tested locally with the sonar plugin to intelliJ