### PR TITLE
refactor: Remove empty constructor to address code smell reported in Sonar Cloud. (IDETECT-3773)

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/help/yaml/HelpYamlWriter.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/help/yaml/HelpYamlWriter.java
@@ -26,8 +26,6 @@ public class HelpYamlWriter {
         }
     };
 
-    public HelpYamlWriter() {}
-
     public void createHelpYamlDocument(String filename) {
         List<Property> allProperties = DetectProperties.allProperties().getProperties();
 


### PR DESCRIPTION
Removing empty HelpYamlWriter constructor since its explicit declaration is redundant.

The reported issue in Sonar Cloud has been resolved (confirmed locally with the SonarLint IntelliJ plugin).

[IDETECT-3773](https://jira-sig.internal.synopsys.com/browse/IDETECT-3773)
