### PR TITLE
Dev/idetect 3841 proxy fix

### DIFF
--- a/common/src/test/java/com/synopsys/integration/common/test/util/finder/SimpleFileFinderTest.java
+++ b/common/src/test/java/com/synopsys/integration/common/test/util/finder/SimpleFileFinderTest.java
@@ -32,24 +32,13 @@ public class SimpleFileFinderTest {
     }
 
     @AfterEach
-    public void cleanup() {
-        File initialDirectory = initialDirectoryPath.toFile();
+    public void cleanup() throws IOException {
         try {
-            if (initialDirectory.exists() && initialDirectory.canWrite()) {
                 Files.delete(initialDirectoryPath);
-            }
         } catch (DirectoryNotEmptyException e) {
-            if (initialDirectory.isDirectory() && initialDirectory.canRead() && initialDirectory.canWrite()) {
-                try {
-                    FileUtils.deleteDirectory(initialDirectory);
-                } catch (IOException ex) {
-                    ex.printStackTrace();
+            FileUtils.deleteDirectory(initialDirectoryPath.toFile());
                 }
             }
-        } catch (IOException ex) {
-            ex.printStackTrace();
-        }
-    }
 
     @Test
     @DisabledOnOs(WINDOWS)

--- a/common/src/test/java/com/synopsys/integration/common/test/util/finder/SimpleFileFinderTest.java
+++ b/common/src/test/java/com/synopsys/integration/common/test/util/finder/SimpleFileFinderTest.java
@@ -32,11 +32,22 @@ public class SimpleFileFinderTest {
     }
 
     @AfterEach
-    public void cleanup() throws IOException {
+    public void cleanup() {
+        File initialDirectory = initialDirectoryPath.toFile();
         try {
-            Files.delete(initialDirectoryPath);
+            if (initialDirectory.exists() && initialDirectory.canWrite()) {
+                Files.delete(initialDirectoryPath);
+            }
         } catch (DirectoryNotEmptyException e) {
-            FileUtils.deleteDirectory(initialDirectoryPath.toFile());
+            if (initialDirectory.isDirectory() && initialDirectory.canRead() && initialDirectory.canWrite()) {
+                try {
+                    FileUtils.deleteDirectory(initialDirectory);
+                } catch (IOException ex) {
+                    ex.printStackTrace();
+                }
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
         }
     }
 

--- a/common/src/test/java/com/synopsys/integration/common/test/util/finder/SimpleFileFinderTest.java
+++ b/common/src/test/java/com/synopsys/integration/common/test/util/finder/SimpleFileFinderTest.java
@@ -34,11 +34,11 @@ public class SimpleFileFinderTest {
     @AfterEach
     public void cleanup() throws IOException {
         try {
-                Files.delete(initialDirectoryPath);
+            Files.delete(initialDirectoryPath);
         } catch (DirectoryNotEmptyException e) {
             FileUtils.deleteDirectory(initialDirectoryPath.toFile());
-                }
-            }
+        }
+    }
 
     @Test
     @DisabledOnOs(WINDOWS)

--- a/detector/src/test/java/com/synopsys/integration/detector/finder/DirectoryFinderTest.java
+++ b/detector/src/test/java/com/synopsys/integration/detector/finder/DirectoryFinderTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import com.synopsys.integration.common.util.finder.SimpleFileFinder;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class DirectoryFinderTest {
     private static Path initialDirectoryPath;
@@ -35,10 +33,7 @@ public class DirectoryFinderTest {
 
     @AfterAll
     public static void cleanup() throws IOException {
-        File initialDirectory = initialDirectoryPath.toFile();
-        if (initialDirectory.exists() && initialDirectory.canWrite()) {
-            FileUtils.deleteDirectory(initialDirectoryPath.toFile());
-        }
+        FileUtils.deleteDirectory(initialDirectoryPath.toFile());
     }
 
     @Test
@@ -72,12 +67,10 @@ public class DirectoryFinderTest {
                 break;
             }
         }
-        if (simpleTestDir != null) {
-            Set<DirectoryFindResult> subDirResults = simpleTestDir.getChildren();
-            assertEquals(2, subDirResults.size());
-            String subDirContentsName = subDirResults.iterator().next().getDirectory().getName();
-            assertTrue(subDirContentsName.startsWith("subSubDir"));
-        }
+        Set<DirectoryFindResult> subDirResults = simpleTestDir.getChildren();
+        assertEquals(2, subDirResults.size());
+        String subDirContentsName = subDirResults.iterator().next().getDirectory().getName();
+        assertTrue(subDirContentsName.startsWith("subSubDir"));
     }
 
     @Test
@@ -112,27 +105,19 @@ public class DirectoryFinderTest {
                 break;
             }
         }
-        if (symLinkTestDir != null) {
-            Set<DirectoryFindResult> subDirResults = symLinkTestDir.getChildren();
+        Set<DirectoryFindResult> subDirResults = symLinkTestDir.getChildren();
 
-            if (followSymLinks) {
-                assertEquals(2, subDirResults.size());
-            } else {
-                assertEquals(1, subDirResults.size());
-                String subDirContentsName = subDirResults.iterator().next().getDirectory().getName();
-                assertEquals("regularDir", subDirContentsName);
-            }
+        if (followSymLinks) {
+            assertEquals(2, subDirResults.size());
+        } else {
+            assertEquals(1, subDirResults.size());
+            String subDirContentsName = subDirResults.iterator().next().getDirectory().getName();
+            assertEquals("regularDir", subDirContentsName);
         }
-        if (initialDirectory.exists() && initialDirectory.canWrite()) {
-            try {
-                FileUtils.deleteDirectory(initialDirectory);
-            } catch (IOException ex) {
-                ex.printStackTrace();
-            }
-        }
-        
+
+        FileUtils.deleteDirectory(initialDirectory);
     }
-
+        
     @NotNull
     private DirectoryFinderOptions createFinderOptions(boolean followSymLinks) {
         Predicate<File> fileFilter = f -> true;

--- a/detector/src/test/java/com/synopsys/integration/detector/finder/DirectoryFinderTest.java
+++ b/detector/src/test/java/com/synopsys/integration/detector/finder/DirectoryFinderTest.java
@@ -117,7 +117,7 @@ public class DirectoryFinderTest {
 
         FileUtils.deleteDirectory(initialDirectory);
     }
-        
+    
     @NotNull
     private DirectoryFinderOptions createFinderOptions(boolean followSymLinks) {
         Predicate<File> fileFilter = f -> true;

--- a/detector/src/test/java/com/synopsys/integration/detector/finder/DirectoryFinderTest.java
+++ b/detector/src/test/java/com/synopsys/integration/detector/finder/DirectoryFinderTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import com.synopsys.integration.common.util.finder.SimpleFileFinder;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class DirectoryFinderTest {
     private static Path initialDirectoryPath;
@@ -33,7 +35,10 @@ public class DirectoryFinderTest {
 
     @AfterAll
     public static void cleanup() throws IOException {
-        FileUtils.deleteDirectory(initialDirectoryPath.toFile());
+        File initialDirectory = initialDirectoryPath.toFile();
+        if (initialDirectory.exists() && initialDirectory.canWrite()) {
+            FileUtils.deleteDirectory(initialDirectoryPath.toFile());
+        }
     }
 
     @Test
@@ -67,10 +72,12 @@ public class DirectoryFinderTest {
                 break;
             }
         }
-        Set<DirectoryFindResult> subDirResults = simpleTestDir.getChildren();
-        assertEquals(2, subDirResults.size());
-        String subDirContentsName = subDirResults.iterator().next().getDirectory().getName();
-        assertTrue(subDirContentsName.startsWith("subSubDir"));
+        if (simpleTestDir != null) {
+            Set<DirectoryFindResult> subDirResults = simpleTestDir.getChildren();
+            assertEquals(2, subDirResults.size());
+            String subDirContentsName = subDirResults.iterator().next().getDirectory().getName();
+            assertTrue(subDirContentsName.startsWith("subSubDir"));
+        }
     }
 
     @Test
@@ -105,17 +112,25 @@ public class DirectoryFinderTest {
                 break;
             }
         }
-        Set<DirectoryFindResult> subDirResults = symLinkTestDir.getChildren();
+        if (symLinkTestDir != null) {
+            Set<DirectoryFindResult> subDirResults = symLinkTestDir.getChildren();
 
-        if (followSymLinks) {
-            assertEquals(2, subDirResults.size());
-        } else {
-            assertEquals(1, subDirResults.size());
-            String subDirContentsName = subDirResults.iterator().next().getDirectory().getName();
-            assertEquals("regularDir", subDirContentsName);
+            if (followSymLinks) {
+                assertEquals(2, subDirResults.size());
+            } else {
+                assertEquals(1, subDirResults.size());
+                String subDirContentsName = subDirResults.iterator().next().getDirectory().getName();
+                assertEquals("regularDir", subDirContentsName);
+            }
         }
-
-        FileUtils.deleteDirectory(initialDirectory);
+        if (initialDirectory.exists() && initialDirectory.canWrite()) {
+            try {
+                FileUtils.deleteDirectory(initialDirectory);
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+        
     }
 
     @NotNull

--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -54,6 +54,7 @@ import com.synopsys.integration.detect.workflow.report.output.FormattedOutputMan
 import com.synopsys.integration.detect.workflow.status.DetectIssue;
 import com.synopsys.integration.detect.workflow.status.DetectIssueType;
 import com.synopsys.integration.detect.workflow.status.DetectStatusManager;
+import java.io.IOException;
 
 public class Application implements ApplicationRunner {
     private final Logger logger = LoggerFactory.getLogger(Application.class);
@@ -81,8 +82,17 @@ public class Application implements ApplicationRunner {
     public static void main(String[] args) {
         SpringApplicationBuilder builder = new SpringApplicationBuilder(Application.class);
         builder.logStartupInfo(false);
-        ApplicationUpdater updater = new ApplicationUpdater(new ApplicationUpdaterUtility(), args);
-        if (!updater.selfUpdate()) {
+        boolean selfUpdated = false;
+        ApplicationUpdater updater = null;
+        try {
+            updater = new ApplicationUpdater(new ApplicationUpdaterUtility(), args);
+            selfUpdated = updater.selfUpdate();
+        } finally {
+            if (updater != null) {
+                updater.closeUpdater();
+            }
+        }
+        if (!selfUpdated) {
             builder.run(args);
         }
     }

--- a/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
@@ -97,12 +97,12 @@ public class ApplicationUpdater extends URLClassLoader {
     public ApplicationUpdater(ApplicationUpdaterUtility applicationUpdaterUtility, String[] args) {
         super(new URL[] {}, Thread.currentThread().getContextClassLoader());
         // System Environment Properties are checked before application arguments.
+        proxyProperties = new HashMap<>(7);
+        proxyIgnoredHosts = new HashSet<>();
         checkEnvironmentProperties();
         this.args = parseArguments(args);
         this.applicationUpdaterUtility = applicationUpdaterUtility;
         detectInfo = new DetectInfoUtility().createDetectInfo();
-        proxyProperties = new HashMap<>(7);
-        proxyIgnoredHosts = new HashSet<>();
     }
     
     public boolean selfUpdate() {
@@ -264,7 +264,7 @@ public class ApplicationUpdater extends URLClassLoader {
     }
     
     private String[] parseArguments(String[] args) {
-        Map<String, String> tempProxyProperties = new HashMap<>(7);
+        final Map<String, String> tempProxyProperties = new HashMap<>(7);
         final ListIterator<String> it = Arrays.asList(args).listIterator();
         while (it.hasNext()) {
             String argument = it.next();
@@ -304,12 +304,12 @@ public class ApplicationUpdater extends URLClassLoader {
             ListIterator<String> it, 
             String argument, 
             Map<String, String> tempProxyProperties) {
-        String value = findArgumentValue(it, argument);
+        final String value = findArgumentValue(it, argument);
         tempProxyProperties.put(argKey, value);
     }
     
     private String findArgumentValue(ListIterator<String> it, String argument) {
-        int equalsIndex;
+        final int equalsIndex;
         if ((equalsIndex = argument.indexOf("=")) > -1) {
             return argument.substring(equalsIndex + 1, argument.length());
         } else if (it.hasNext()) {
@@ -319,8 +319,8 @@ public class ApplicationUpdater extends URLClassLoader {
     }
     
     private Set<String> findArgumentCommaDelimitedValues(ListIterator<String> it, String argument) {
-        int equalsIndex;
-        String delimitedValues;
+        final int equalsIndex;
+        final String delimitedValues;
         if ((equalsIndex = argument.indexOf("=")) > -1) {
             delimitedValues = argument.substring(equalsIndex + 1, argument.length());
             return Arrays.stream(delimitedValues.split("\\,"))
@@ -406,8 +406,8 @@ public class ApplicationUpdater extends URLClassLoader {
     }
     
     private ProxyInfo prepareProxyInfo() {
-        ProxyInfoBuilder proxyInfoBuilder = new ProxyInfoBuilder();
-        CredentialsBuilder credentialsBuilder = Credentials.newBuilder();
+        final ProxyInfoBuilder proxyInfoBuilder = new ProxyInfoBuilder();
+        final CredentialsBuilder credentialsBuilder = Credentials.newBuilder();
         credentialsBuilder.setUsernameAndPassword(proxyProperties.get(ARG_PROXY_USERNAME), 
                 proxyProperties.get(ARG_PROXY_PASSWORD));
         proxyInfoBuilder.setCredentials(credentialsBuilder.build());
@@ -426,13 +426,13 @@ public class ApplicationUpdater extends URLClassLoader {
         headers.put(DOWNLOAD_VERSION_HEADER, currentVersion);
         final Request request = new Request(downloadUrl, HttpMethod.GET, 
                 null, queryParams, headers, null);
-        ProxyInfo proxyInfo;
-        if (proxyIgnoredHosts.contains(blackduckHost)) {
+        final ProxyInfo proxyInfo;
+        if (proxyIgnoredHosts.contains(blackduckHost) || proxyProperties.isEmpty()) {
             proxyInfo = ProxyInfo.NO_PROXY_INFO;
         } else {
             proxyInfo = prepareProxyInfo();
         }
-        IntHttpClient intHttpClient = applicationUpdaterUtility.getIntHttpClient(trustCertificate, proxyInfo);
+        final IntHttpClient intHttpClient = applicationUpdaterUtility.getIntHttpClient(trustCertificate, proxyInfo);
         try (final Response response = intHttpClient.execute(request)) {
             if (response.isStatusCodeSuccess()) {
                 final String newFileName = response.getHeaderValue(DOWNLOADED_FILE_NAME);

--- a/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
@@ -441,11 +441,13 @@ public class ApplicationUpdater extends URLClassLoader {
                 
                 if (!Files.exists(targetFilePath, LinkOption.NOFOLLOW_LINKS)) {
                     logger.debug("{} Writing to file {}.", LOG_PREFIX, targetFilePath.toAbsolutePath());
-                    try (final ReadableByteChannel readableByteChannel = Channels.newChannel(response.getContent())) {
-                        try (final FileOutputStream fileOutputStream = new FileOutputStream(targetFile)) {
+                    try(final ReadableByteChannel readableByteChannel = Channels.newChannel(response.getContent())) {
+                        try(final FileOutputStream fileOutputStream = new FileOutputStream(targetFile)) {
                             fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
                             logger.debug("{} Successfully wrote response to file {}.", LOG_PREFIX, targetFilePath.toAbsolutePath());
+                            fileOutputStream.close();
                         }
+                        readableByteChannel.close();
                     }
                 }
                 return targetFilePath;

--- a/src/main/java/com/synopsys/integration/detect/ApplicationUpdaterUtility.java
+++ b/src/main/java/com/synopsys/integration/detect/ApplicationUpdaterUtility.java
@@ -8,14 +8,14 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 
 public class ApplicationUpdaterUtility {
     
-    protected IntHttpClient getIntHttpClient() {
+    protected IntHttpClient getIntHttpClient(boolean trustCertificate, ProxyInfo proxyInfo) {
         final SilentIntLogger silentLogger = new SilentIntLogger();
         silentLogger.setLogLevel(LogLevel.WARN);
         return new IntHttpClient(silentLogger,
                 BlackDuckServicesFactory.createDefaultGsonBuilder().setPrettyPrinting().create(),
                 IntHttpClient.DEFAULT_TIMEOUT, 
-                true, 
-                ProxyInfo.NO_PROXY_INFO
+                trustCertificate, 
+                proxyInfo
         );
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/ApplicationUpdaterTest.java
+++ b/src/test/java/com/synopsys/integration/detect/ApplicationUpdaterTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mockito;
 import com.synopsys.integration.detect.configuration.DetectInfo;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.client.IntHttpClient;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.request.Request;
 import com.synopsys.integration.rest.response.Response;
 
@@ -35,10 +36,9 @@ public class ApplicationUpdaterTest {
         Mockito.when(detectInfo.getDetectVersion()).thenReturn("8.9.0");
         ApplicationUpdaterUtility applicationUpdaterUtility = Mockito.mock(ApplicationUpdaterUtility.class);
         ApplicationUpdater applicationUpdater = new ApplicationUpdater(applicationUpdaterUtility, args);
-        Mockito.when(applicationUpdaterUtility.getIntHttpClient()).thenReturn(intHttpClient);
+        Mockito.when(applicationUpdaterUtility.getIntHttpClient(true, ProxyInfo.NO_PROXY_INFO)).thenReturn(intHttpClient);
         
         boolean selfUpdated = applicationUpdater.selfUpdate();
-
         Assertions.assertTrue(selfUpdated);
     }
 }


### PR DESCRIPTION
# Description

Fix to add proxy support and fix for Sonar CF issues.

**The proxy approach is defined below:**

> Load values from HTTPS System environment properties if set. 
>> If not set, load from HTTP System Environment properties if set, with a warning on use of HTTP.
>>>Then, overwrite the proxy values with any input proxy arguments.

**Thus, preference order is:**
1. Argument level
2. HTTPS System Environment
3. HTTP System Environment (with warning log)
4. No proxy.

+ Coverity scan result fix.

# Github Issues

https://jira-sig.internal.synopsys.com/browse/IDETECT-3841
