### PR TITLE
Detect continues to identify certain components in the go.mod file with "// indirect" as direct dependencies.

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/parse/GoModuleDependencyHelper.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/parse/GoModuleDependencyHelper.java
@@ -91,7 +91,7 @@ public class GoModuleDependencyHelper {
         if (trackPath != null && !trackPath.isEmpty()) {
             for (String tp : trackPath) {
                 String parent = directs.stream()
-                        .filter(directMod -> directMod.contains(tp) || tp.contains(directMod.replaceAll("@.*","")))
+                        .filter(directMod -> tp.contains(directMod.replaceAll("@.*","")))
                         .findFirst()
                         .orElse(null);
                 if (parent != null) { // if real direct is found... otherwise do nothing

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/parse/GoModuleDependencyHelper.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/parse/GoModuleDependencyHelper.java
@@ -88,18 +88,16 @@ public class GoModuleDependencyHelper {
         // look up the 'why' results for the module...  This will tell us
         // the direct dependency item that pulled this item into the mix.
         List<String> trackPath = whyMap.get(childModulePath);
-        String parent = "";
         if (trackPath != null && !trackPath.isEmpty()) {
             for (String tp : trackPath) {
-                for (String directMod : directs) {
-                    if (directMod.contains(tp)) {
-                        parent = directMod;
-                        break;
-                    }
+                String parent = directs.stream()
+                        .filter(directMod -> directMod.contains(tp) || tp.contains(directMod.replaceAll("@.*","")))
+                        .findFirst()
+                        .orElse(null);
+                if (parent != null) { // if real direct is found... otherwise do nothing
+                    grphLine = grphLine.replace(splitLine[0], parent);
+                    break;
                 }
-            }
-            if (parent.length() > 0) { // if real direct is found... otherwise do nothing
-                grphLine = grphLine.replace(splitLine[0], parent);
             }
         }
         return grphLine;


### PR DESCRIPTION
# Description

The current implementation of "detect" does not recognize all components marked with "// indirect" in the go.mod file as transitive dependencies, leading to potential issues with dependency management. This commit updates "detect" to correctly identify all such components as transitive dependencies.


## Existing solution

The method `getProperParentage(......){}` looks up the 'why' results for the module in the whyMap and retrieves a list of direct dependency items.

For each item in the trackPath list, the method iterates the list of direct dependencies and checks if the item is contained within the direct dependency. If a match is found, the direct dependency is set as the parent.

If a parent is found, the method replaces the first element of the split line with the parent and returns the updated graph line. Otherwise, it returns the original graph line.


## My change

For each item in the trackPath list, the method iterates the list of direct dependencies and checks **if the item is contained within the direct dependency or if the direct dependency(without version) is contained within the item**. If a match is found, the direct dependency is set as the parent and quits the iteration.


# Github Issues

IDETECT-3776
