### PR TITLE
Wait for BOM if hub returns BUILDING or NOT INCLUDED

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/DetectBomScanWaitJob.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/DetectBomScanWaitJob.java
@@ -27,7 +27,8 @@ public class DetectBomScanWaitJob implements ResilientJob<BomStatusScanView> {
         BomStatusScanView initialResponse = 
                 blackDuckApiClient.getResponse(scanUrl, BomStatusScanView.class);
         
-        if (initialResponse.getStatus() != BomStatusScanStatusType.BUILDING) {
+        if (initialResponse.getStatus() != BomStatusScanStatusType.BUILDING &&
+                initialResponse.getStatus() != BomStatusScanStatusType.NOT_INCLUDED) {
             complete = true;
             scanResponse = initialResponse;
         }


### PR DESCRIPTION
If a customer tells us to wait for a BOM we should do so if hub returns either a NOT INCLUDED (the scan hasn't been considered yet for inclusion in the BOM) or BUILDING (the scan is currently being considered for inclusion in the BOM) statuses. 