### PR TITLE
8.9.0 Release - fix for release-qa job failure on 8.9.z branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.9.0-SIGQA7'
+version = '8.9.0-SIGQA8-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.9.0-SIGQA6-SNAPSHOT'
+version = '8.9.0-SIGQA6'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 group = 'com.synopsys.integration'
-version = '8.9.0-SIGQA6'
+version = '8.9.0-SIGQA7'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/test/java/com/synopsys/integration/detect/ApplicationUpdaterTest.java
+++ b/src/test/java/com/synopsys/integration/detect/ApplicationUpdaterTest.java
@@ -9,7 +9,6 @@ import org.mockito.Mockito;
 public class ApplicationUpdaterTest {
     
     private final String fakeUrl = "https://synopsys.com";
-    private final ApplicationUpdaterUtility utility = new ApplicationUpdaterUtility();
     
     private final String[] successArgs = new String[] {
             "-jar",
@@ -47,12 +46,12 @@ public class ApplicationUpdaterTest {
     
     @Test
     public void testCanSelfUpdate() {
-        Assertions.assertTrue(new ApplicationUpdater(utility, successArgs).canSelfUpdate());
+        Assertions.assertTrue(new ApplicationUpdater(new ApplicationUpdaterUtility(), successArgs).canSelfUpdate());
     }
     
     @Test
     public void testCanSelfUpdateWithoutBdUrl() {
-        Assertions.assertFalse(new ApplicationUpdater(utility, failureArgs).canSelfUpdate());
+        Assertions.assertFalse(new ApplicationUpdater(new ApplicationUpdaterUtility(), failureArgs).canSelfUpdate());
     }
     
     @Test
@@ -115,36 +114,36 @@ public class ApplicationUpdaterTest {
     
     @Test
     public void testProxyFoundThree() {
-        Assertions.assertEquals(ProxyInfo.NO_PROXY_INFO, new ApplicationUpdater(utility, successArgsWithInvalidProxy).getProxyInfo());
+        Assertions.assertEquals(ProxyInfo.NO_PROXY_INFO, new ApplicationUpdater(new ApplicationUpdaterUtility(), successArgsWithInvalidProxy).getProxyInfo());
     }
     
     @Test
     public void testProxyFoundFour() {
-        Assertions.assertNotEquals(ProxyInfo.NO_PROXY_INFO, new ApplicationUpdater(utility, successArgsWithValidProxy).getProxyInfo());
+        Assertions.assertNotEquals(ProxyInfo.NO_PROXY_INFO, new ApplicationUpdater(new ApplicationUpdaterUtility(), successArgsWithValidProxy).getProxyInfo());
     }
     
     @Test
     public void testValidDetectFileName() {
-        Assertions.assertTrue(new ApplicationUpdater(utility, successArgs).isValidDetectFileName("synopsys-detect-8.9.0-SIGQA6-SNAPSHOT.jar"));
+        Assertions.assertTrue(new ApplicationUpdater(new ApplicationUpdaterUtility(), successArgs).isValidDetectFileName("synopsys-detect-8.9.0-SIGQA6-SNAPSHOT.jar"));
     }
     
     @Test
     public void testVersionFromDetectFileName() {
-        Assertions.assertEquals("8.9.0", new ApplicationUpdater(utility, successArgs).getVersionFromDetectFileName("synopsys-detect-8.9.0-SIGQA6-SNAPSHOT.jar"));
+        Assertions.assertEquals("8.9.0", new ApplicationUpdater(new ApplicationUpdaterUtility(), successArgs).getVersionFromDetectFileName("synopsys-detect-8.9.0-SIGQA6-SNAPSHOT.jar"));
     }
     
     @Test
     public void testVersionConvert() {
-        Assertions.assertEquals(new Version(8, 9, 0), new ApplicationUpdater(utility, successArgs).convert("8.9.0"));
+        Assertions.assertEquals(new Version(8, 9, 0), new ApplicationUpdater(new ApplicationUpdaterUtility(), successArgs).convert("8.9.0"));
     }
     
     @Test
     public void testTooOldDownloadVersion() {
-        Assertions.assertTrue(new ApplicationUpdater(utility, successArgs).isDownloadVersionTooOld("8.9.0", "8.8.0"));
+        Assertions.assertTrue(new ApplicationUpdater(new ApplicationUpdaterUtility(), successArgs).isDownloadVersionTooOld("8.9.0", "8.8.0"));
     }
     
     @Test
     public void testNotSoOldDownloadVersion() {
-        Assertions.assertFalse(new ApplicationUpdater(utility, successArgs).isDownloadVersionTooOld("8.10.0", "8.9.0"));
+        Assertions.assertFalse(new ApplicationUpdater(new ApplicationUpdaterUtility(), successArgs).isDownloadVersionTooOld("8.10.0", "8.9.0"));
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/ApplicationUpdaterTest.java
+++ b/src/test/java/com/synopsys/integration/detect/ApplicationUpdaterTest.java
@@ -51,7 +51,9 @@ public class ApplicationUpdaterTest {
     
     @Test
     public void testCanSelfUpdateWithoutBdUrl() {
-        Assertions.assertFalse(new ApplicationUpdater(new ApplicationUpdaterUtility(), failureArgs).canSelfUpdate());
+        ApplicationUpdaterUtility mockedUtility = Mockito.mock(ApplicationUpdaterUtility.class);
+        Mockito.when(mockedUtility.getSysEnvProperty(ApplicationUpdater.SYS_ENV_PROP_BLACKDUCK_URL)).thenReturn(null);
+        Assertions.assertFalse(new ApplicationUpdater(mockedUtility, failureArgs).canSelfUpdate());
     }
     
     @Test


### PR DESCRIPTION
# Description

Fix for release-qa highlighted unit test failure.

# Github Issues

Test failure: https://build-bd.internal.synopsys.com/job/integration-builds-v2/job/generated-builds/job/solutions/job/synopsys-detect/job/release-qa/308/
