### PR TITLE
Reduce runtime complexity of pip-inspector.py dependency scan script

### DIFF
--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -136,8 +136,9 @@ def recursively_resolve_dependencies(package_name, history):
     dependency_node = DependencyNode(package.project_name, package.version)
 
     if package_name.lower() not in history:
+        history.append(package_name.lower())
         for package_dependency in package.requires():
-            child_node = recursively_resolve_dependencies(package_dependency.key, history + [package_name.lower()])
+            child_node = recursively_resolve_dependencies(package_dependency.key, history)
             if child_node is not None:
                 dependency_node.children = dependency_node.children + [child_node]
 


### PR DESCRIPTION
Reduce runtime complexity of recursively_resolve_dependencies function

# Description

The `pip-inspector.py` script execution time is long for dependencies like `cdk-chalice` that depend on `aws-cdk` IaC python libraries, please see [requirements.txt link](https://github.com/alexpulver/cdk-chalice/blob/master/requirements.txt).

If package `history` list is passed by reference instead of being passed by value, `pip-inspector.py` execution time is cut down from approx. 18.5 minutes to less than 1 second (on a powerful workstation) while scanning single [cdk-chalice](https://pypi.org/project/cdk-chalice/) dependency.

Since `pip-inspector.py` is compiled into the executable `*.jar` file (as part of Spring Boot `resources`), the only way to apply the patch locally is to recompile Synopsys detect binaries from scratch using sources available in this repository.

Please consider my kind request to include this patch into the next release.

JIRA Ticket : IDETECT-3888

# Github Issues

## Expected behavior
* pip-inspector.py has acceptable execution time on `aws-cdk` dependencies
## Actual behavior
* pip-inspector.py "hangs" while performing the scan
## Steps to Reproduce
* add single cdk-chalice==0.9.0 dependency to `requirements.txt` file
* start `RAPID` or `INTELLIGENT` scan

## Version
**Project Version:**

* Synopsys detect 8.9.0

**Language Version:**

* Python 3.9.16

**OS:**

* MacOS
* Linux
* Windows (possibly)