### PR TITLE
Container Scanning - Create & include code location name for container scans

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -256,6 +256,10 @@ public class OperationRunner {
         this.auditLog = new OperationAuditLog(utilitySingletons.getOperationWrapper(), operationSystem);
     }
 
+    public CodeLocationNameManager getCodeLocationNameManager() {
+        return codeLocationNameManager;
+    }
+
     public final Optional<DetectableTool> checkForDocker() throws OperationException {//TODO: refactor bazel+docker out of detectable
         return auditLog.namedInternal("Check For Docker", () -> {
             DetectableTool detectableTool = new DetectableTool(detectDetectableFactory::createDockerDetectable,

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -26,6 +26,7 @@ public class ContainerScanStepRunner {
     private final String projectGroupName;
     private final BlackDuckRunData blackDuckRunData;
     private final File binaryRunDirectory;
+    private final File containerImage;
 
     public ContainerScanStepRunner(OperationRunner operationRunner, NameVersion projectNameVersion, BlackDuckRunData blackDuckRunData) {
         this.operationRunner = operationRunner;
@@ -33,6 +34,7 @@ public class ContainerScanStepRunner {
         this.blackDuckRunData = blackDuckRunData;
         binaryRunDirectory = operationRunner.getDirectoryManager().getBinaryOutputDirectory();
         projectGroupName = operationRunner.calculateProjectGroupOptions().getProjectGroup();
+        containerImage = operationRunner.getContainerScanImage();
     }
 
     public UUID invokeContainerScanningWorkflow() throws IntegrationException, IOException {
@@ -43,13 +45,11 @@ public class ContainerScanStepRunner {
     }
 
     private String getContainerScanCodeLocationName() {
-        File containerImage = operationRunner.getContainerScanImage();
         CodeLocationNameManager codeLocationNameManager = operationRunner.getCodeLocationNameManager();
         return codeLocationNameManager.createContainerScanCodeLocationName(containerImage, projectNameVersion.getName(), projectNameVersion.getVersion());
     }
 
     public void initiateScan() throws IOException, IntegrationException {
-
         DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
             UUID.randomUUID().toString(),
             "CONTAINER",
@@ -63,7 +63,6 @@ public class ContainerScanStepRunner {
     }
 
     public void uploadImageToStorageService() throws IntegrationException {
-        File containerImage = operationRunner.getContainerScanImage();
         String storageServiceEndpoint = String.join("", "/api/storage/containers/", scanId.toString());
         String storageServiceArtifactContentType = "application/vnd.blackducksoftware.container-scan-data-1+octet-stream";
         logger.debug("Uploading container image artifact to storage endpoint: {}", storageServiceEndpoint);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import com.synopsys.integration.detect.lifecycle.run.data.BlackDuckRunData;
 import com.synopsys.integration.detect.lifecycle.run.operation.OperationRunner;
 import com.synopsys.integration.detect.util.bdio.protobuf.DetectProtobufBdioHeaderUtil;
+import com.synopsys.integration.detect.workflow.codelocation.CodeLocationNameManager;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.response.Response;
 import com.synopsys.integration.util.NameVersion;
@@ -41,8 +42,20 @@ public class ContainerScanStepRunner {
         return scanId;
     }
 
+    private String getContainerScanCodeLocationName() {
+        File containerImage = operationRunner.getContainerScanImage();
+        CodeLocationNameManager codeLocationNameManager = operationRunner.getCodeLocationNameManager();
+        return codeLocationNameManager.createContainerScanCodeLocationName(containerImage, projectNameVersion.getName(), projectNameVersion.getVersion());
+    }
+
     public void initiateScan() throws IOException, IntegrationException {
-        DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(UUID.randomUUID().toString(), "CONTAINER", projectNameVersion, projectGroupName);
+
+        DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
+            UUID.randomUUID().toString(),
+            "CONTAINER",
+            projectNameVersion,
+            projectGroupName,
+            getContainerScanCodeLocationName());
         File bdioHeaderFile = detectProtobufBdioHeaderUtil.createProtobufBdioHeader(binaryRunDirectory);
         scanId = operationRunner.uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeaderFile);
         String scanIdString = scanId.toString();

--- a/src/main/java/com/synopsys/integration/detect/util/bdio/protobuf/DetectProtobufBdioHeaderUtil.java
+++ b/src/main/java/com/synopsys/integration/detect/util/bdio/protobuf/DetectProtobufBdioHeaderUtil.java
@@ -16,20 +16,22 @@ public class DetectProtobufBdioHeaderUtil {
     private final String scanType;
     private final NameVersion projectNameVersion;
     private final String projectGroupName;
+    private final String codeLocationName;
     private static final String CREATOR_NAME = "SYNOPSYS_DETECT";
 
-    public DetectProtobufBdioHeaderUtil(String scanId, String scanType, NameVersion projectNameVersion, String projectGroupName) {
+    public DetectProtobufBdioHeaderUtil(String scanId, String scanType, NameVersion projectNameVersion, String projectGroupName, String codeLocationName) {
         this.scanId = scanId;
         this.scanType = scanType;
         this.projectNameVersion = projectNameVersion;
         this.projectGroupName = projectGroupName;
+        this.codeLocationName = codeLocationName;
     }
 
     public File createProtobufBdioHeader(File targetDirectory) throws IOException {
         BdioHeader bdioHeader = new BdioHeader(
             scanId,
             scanType,
-            "",
+            codeLocationName,
             projectNameVersion.getName(),
             projectNameVersion.getVersion(),
             "",

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGenerator.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameGenerator.java
@@ -104,6 +104,16 @@ public class CodeLocationNameGenerator {
         return createCodeLocationName(prefix, fileCodeLocationNamePieces, suffix, fileCodeLocationEndPieces);
     }
 
+    public String createContainerScanCodeLocationName(File targetFile, String projectName, String projectVersionName) {
+        String codeLocationTypeString = CodeLocationNameType.CONTAINER.getName();
+
+        String canonicalFileName = DetectFileUtils.tryGetCanonicalName(targetFile);
+        List<String> fileCodeLocationNamePieces = Arrays.asList(canonicalFileName, projectName, projectVersionName);
+        List<String> fileCodeLocationEndPieces = Collections.singletonList(codeLocationTypeString);
+
+        return createCodeLocationName(prefix, fileCodeLocationNamePieces, suffix, fileCodeLocationEndPieces);
+    }
+
     public String createImpactAnalysisCodeLocationName(File sourceDirectory, String projectName, String projectVersionName) {
         String codeLocationTypeString = CodeLocationNameType.IMPACT_ANALYSIS.getName();
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameManager.java
@@ -53,6 +53,17 @@ public class CodeLocationNameManager {
         return scanCodeLocationName;
     }
 
+    public String createContainerScanCodeLocationName(File targetFile, String projectName, String projectVersionName) {
+        String scanCodeLocationName;
+
+        if (codeLocationNameGenerator.useCodeLocationOverride()) {
+            scanCodeLocationName = codeLocationNameGenerator.getNextCodeLocationOverrideNameUnSourced(CodeLocationNameType.CONTAINER);
+        } else {
+            scanCodeLocationName = codeLocationNameGenerator.createContainerScanCodeLocationName(targetFile, projectName, projectVersionName);
+        }
+        return scanCodeLocationName;
+    }
+
     public String createImpactAnalysisCodeLocationName(File sourceDirectory, String projectName, String projectVersionName) {
         String scanCodeLocationName;
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameType.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationNameType.java
@@ -5,6 +5,7 @@ public enum CodeLocationNameType {
     IMPACT_ANALYSIS("impact"),
     SIGNATURE("signature"),
     BINARY("binary"),
+    CONTAINER("container"),
     IAC("iac");
 
     private final String name;


### PR DESCRIPTION
### Description
The `/api/intelligent-persistence-scans` endpoint has a validation for empty code location name.
Hence, sending the protobuf bdio header with an empty string value for the `codeLocationName` field causes a 400 Bad Request response when creating an intelligent persistent scan. 

This PR fixes this issue by creating a code location name for container scan and including this name in the protobuf bdio header.

### JIRA Issue
IDETECT-3890
