### PR TITLE
Container Scanning - Skip container scan initiation early if image file not present or could not be downloaded

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -63,8 +63,8 @@ public class ContainerScanStepRunner {
         File bdioHeaderFile = detectProtobufBdioHeaderUtil.createProtobufBdioHeader(binaryRunDirectory);
         scanId = operationRunner.uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeaderFile);
         if (scanId == null) {
-            logger.debug("Scan ID not received in the response header.");
-            throw new IntegrationException("Scan ID not received in the response header.");
+            logger.warn("Scan ID was not found in the response from the server.");
+            throw new IntegrationException("Scan ID was not found in the response from the server.");
         }
         String scanIdString = scanId.toString();
         logger.debug("Scan initiated with scan service. Scan ID received: {}", scanIdString);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -44,6 +44,10 @@ public class ContainerScanStepRunner {
         return scanId;
     }
 
+    public Boolean shouldRunContainerScan() {
+        return containerImage != null && containerImage.exists();
+    }
+
     private String getContainerScanCodeLocationName() {
         CodeLocationNameManager codeLocationNameManager = operationRunner.getCodeLocationNameManager();
         return codeLocationNameManager.createContainerScanCodeLocationName(containerImage, projectNameVersion.getName(), projectNameVersion.getVersion());
@@ -58,6 +62,10 @@ public class ContainerScanStepRunner {
             getContainerScanCodeLocationName());
         File bdioHeaderFile = detectProtobufBdioHeaderUtil.createProtobufBdioHeader(binaryRunDirectory);
         scanId = operationRunner.uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeaderFile);
+        if (scanId == null) {
+            logger.debug("Scan ID not received in the response header.");
+            throw new IntegrationException("Scan ID not received in the response header.");
+        }
         String scanIdString = scanId.toString();
         logger.debug("Scan initiated with scan service. Scan ID received: {}", scanIdString);
     }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -131,9 +131,16 @@ public class IntelligentModeStepRunner {
         });
 
         stepHelper.runToolIfIncluded(DetectTool.CONTAINER_SCAN, "Container Scanner", () -> {
+            logger.debug("Determining if configuration is valid to run a container scan.");
             ContainerScanStepRunner containerScanStepRunner = new ContainerScanStepRunner(operationRunner, projectNameVersion, blackDuckRunData);
-            UUID scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
-            scanIdsToWaitFor.add(scanId.toString());
+            if (containerScanStepRunner.shouldRunContainerScan()) {
+                logger.debug("Invoking non-SCAaaS stateless container scan.");
+                UUID scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
+                scanIdsToWaitFor.add(scanId.toString());
+            } else {
+                logger.debug("Container image file not provided or could not be downloaded. Container scan will not run.");
+            }
+
         });
 
         stepHelper.runToolIfIncludedWithCallbacks(

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -134,7 +134,7 @@ public class IntelligentModeStepRunner {
             logger.debug("Determining if configuration is valid to run a container scan.");
             ContainerScanStepRunner containerScanStepRunner = new ContainerScanStepRunner(operationRunner, projectNameVersion, blackDuckRunData);
             if (containerScanStepRunner.shouldRunContainerScan()) {
-                logger.debug("Invoking non-SCAaaS stateless container scan.");
+                logger.debug("Invoking stateless container scan.");
                 UUID scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
                 scanIdsToWaitFor.add(scanId.toString());
             } else {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -96,7 +96,7 @@ public class RapidModeStepRunner {
                 logger.debug("Determining if configuration is valid to run a container scan.");
                 ContainerScanStepRunner containerScanStepRunner = new ContainerScanStepRunner(operationRunner, projectVersion, blackDuckRunData);
                 if (containerScanStepRunner.shouldRunContainerScan()) {
-                    logger.debug("Invoking non-SCAaaS stateless container scan.");
+                    logger.debug("Invoking stateless container scan.");
                     UUID scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
                     String statelessScanEndpoint = operationRunner.getScanServicePostEndpoint();
                     HttpUrl scanServiceUrlToPoll = new HttpUrl(blackDuckUrl + statelessScanEndpoint + "/" + scanId.toString());


### PR DESCRIPTION
### Description

Container scan should be skipped early if the container image was not provided via `container.scan.file.path` or if it could not be accessed/downloaded from the URI provided. 

I also added an NPE check in case the scanId was not received from Hub's response header.

Note: If `detect.tools` property is not explicitly specified, Detect includes all the tools by default in the `DetectToolFilter` class ([documentation reference](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=runningdetect%2Fincludingexcluding%2Ftools.html&_LANG=enus&anchor=detect-tools-included)). Hence, container scan does get included in the `DetectToolFilter` even if `detect.tools` is not set by the user. In this case, we want to ensure container scan doesn't get invoked if `container.scan.file.path` is not provided or the image wasn't downloaded. This fix addresses that scenario.

### Jira Issue

Fixes IDETECT-3891
