### PR TITLE
Add -hyaml to command line help page.

### DIFF
--- a/documentation/src/main/markdown/configuring/configfile.md
+++ b/documentation/src/main/markdown/configuring/configfile.md
@@ -29,7 +29,7 @@ file syntax: `propertyName=propertyValue`, one per line.
 
 When setting a property value in a .yml file, do not prefix the property name with hyphens,
 and adhere to YAML syntax for dictionaries: `propertyName: propertyValue`, one per line.
-There is a Detect command line help option, -hyaml, that can be used to generate a template YAML configuration file. 
+There is a [solution_name] command line help option, -hyaml, that can be used to generate a template YAML configuration file. 
 
 ## Running [solution_name] from a directory that contains a file named *config*
 

--- a/documentation/src/main/markdown/gettingstarted/gettinghelp.md
+++ b/documentation/src/main/markdown/gettingstarted/gettinghelp.md
@@ -6,7 +6,8 @@
 | ---- | ------------------- | ----------- | ----------- |
 | Help | --help | -h | Provides basic help information (including how to get more detailed help). |
 | Interactive | --interactive | -i | Guides you through configuring [solution_name]. |
-| Diagnostic | --detect.diagnostic=true | -d | Creates a zip file containing diagnostic information for support. |
+| Diagnostic | --diagnostic | -d | Creates a zip file containing diagnostic information for support. |
+| hyaml | --helpyaml | -hyaml | To generate a configuration file template for setting properties. |
 
 Additional resources are available at [Synopsys Software Integrity Community](https://community.synopsys.com).
 


### PR DESCRIPTION
Added hyaml entry to the command line help page.
Replaced a hard-coded "Detect" with the variable.
Replaced "--detect.diagnostic=true" with the  "--diagnostic" value noted in the DetectArgumentStateParser.java file.

IDETECT-3892