### PR TITLE
Update ubi version for platform1

### DIFF
--- a/platform-1/config.env
+++ b/platform-1/config.env
@@ -2,7 +2,7 @@ export TARGET_REPO=blackducksoftware
 export TARGET_IMAGE=blackduck-client
 export TARGET_VERSION=$RELEASE_VERSION
 
-export UBI_VERSION=8.7
+export UBI_VERSION=8.8
 export IMAGE_SUFFIX=_ubi
 
 export TARGET_IMAGE_TAG=${TARGET_VERSION}${IMAGE_SUFFIX}${UBI_VERSION}


### PR DESCRIPTION
# Description

Upgrade UBI version to 8.8 in Platform1 image, as support for v8.7 has been deprecated
