### PR TITLE
<docs>(8.10 release notes): Add missing dependency updates to release notes for IDETECT-3883

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -13,7 +13,11 @@
 
 ### Dependency updates
 
-* Upgraded Spring Boot to version 2.7.12 to resolve [CVE-2023-20883](https://nvd.nist.gov/vuln/detail/CVE-2023-20883)
+* Upgraded Spring Boot to version 2.7.12 to resolve [CVE-2023-20883](https://nvd.nist.gov/vuln/detail/CVE-2023-20883) 
+* Upgraded jackson-databind to version 2.15.0 to resolve high severity [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003) and high severity [CVE-2022-42004](https://nvd.nist.gov/vuln/detail/CVE-2022-42004)
+* Upgraded jQuery to version 3.6 to resolve medium severity [CVE-2020-11022](https://nvd.nist.gov/vuln/detail/CVE-2020-11022), [CVE-2019-11358](https://nvd.nist.gov/vuln/detail/CVE-2019-11358) and [CVE-2020-11023](https://nvd.nist.gov/vuln/detail/CVE-2020-11023)
+* Upgraded SnakeYAML to version 2.0 to resolve critical severity [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471)
+* Upgraded json-smart to version 2.4.11 to resolve high severity [CVE-2023-1370](https://nvd.nist.gov/vuln/detail/CVE-2023-1370)
 
 ## Version 8.9.0
 


### PR DESCRIPTION
Despite the comment under IDETECT-3883, only spring boot's update was documented in release notes. This PR adds all other dependency updates and resolved vulnerabilities according to IDETECT-3883. 

Original PR for IDETECT-3883: https://github.com/blackducksoftware/synopsys-detect/pull/818/files (which does not include upgrades to snakeyaml, jquery or jackson-databind ....)