### PR TITLE
fix: Remove jackson-databind-2.15.0 dependency from airgap

### DIFF
--- a/src/main/resources/create-gradle-airgap-script.ftl
+++ b/src/main/resources/create-gradle-airgap-script.ftl
@@ -10,7 +10,6 @@ configurations {
 
 dependencies {
     airGap 'com.synopsys.integration:integration-common:26.0.6'
-    airGap 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
 }
 
 task installDependencies(type: Copy) {


### PR DESCRIPTION
### Description

Do not include the jackson-databind-2.15.0 dependency in the air gap mode archive as this causes the below concurrent execution exception.

```shell
java.util.concurrent.ExecutionException: org.gradle.api.GradleException: Failed to create Jar file /Users/karolyn/.gradle/caches/jars-9/e5ee5313e57c78188ad11ea059a07c07/jackson-core-2.15.0.jar
``` 
This is because jackson-core-2.15.0 is already being pulled as a transitive dependency from `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0` in regular Detect (non air gap mode) and in air gap Detect, the current Gradle version (v7.3.1) of Detect again tries to pull it from as a transitive dependency from ` jackson-databind-2.15.0`. (Future versions of Gradle have handled this issue.)

### Jira Issue
IDETECT-3915
