### PR TITLE
Add scanID and scan type to status.json's codelocations array

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -1,5 +1,11 @@
 # Current Release notes
 
+## Version 8.11.0
+
+### New features
+
+* For Stateless and Rapid scans, the scanID and detector tool being run, are now stored in the codeLocations section of the status.json file.
+
 ## Version 8.10.0
 
 ### Changed features

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* For Stateless and Rapid scans, the scanID and detector tool being run, are now stored in the codeLocations section of the status.json file.
+* For Stateless and Rapid scans, the scanId and Detector tool being run, are now stored in the codeLocations section of the status.json file containing the run summary.
 
 ## Version 8.10.0
 

--- a/documentation/src/main/resources/templates/status-file.ftl
+++ b/documentation/src/main/resources/templates/status-file.ftl
@@ -95,6 +95,8 @@ For those detectors that support it (currently, only CLANG), a list of file path
 ````
 {
 "codeLocationName": The name of a code location produced by this run of [solution_name].
+"scanType": The type of scan that was done, DETECTOR, BAZEL, SIGNATURE_SCAN, DOCKER, BINARY_SCAN, or CONTAINER_SCAN.
+"scanId": The UUID for the scan.
 }
 ````
 ## Property Values

--- a/documentation/src/main/resources/templates/status-file.ftl
+++ b/documentation/src/main/resources/templates/status-file.ftl
@@ -95,7 +95,7 @@ For those detectors that support it (currently, only CLANG), a list of file path
 ````
 {
 "codeLocationName": The name of a code location produced by this run of [solution_name].
-"scanType": The type of scan that was done, DETECTOR, BAZEL, SIGNATURE_SCAN, DOCKER, BINARY_SCAN, or CONTAINER_SCAN.
+"scanType": The type of scan that was performed, DETECTOR, BAZEL, SIGNATURE_SCAN, DOCKER, BINARY_SCAN, or CONTAINER_SCAN.
 "scanId": The UUID for the scan.
 }
 ````

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1137,4 +1137,11 @@ public class OperationRunner {
             );
         });
     }
+    
+    public UUID getScanIdFromScanUrl(HttpUrl blackDuckScanUrl) {
+        String url = blackDuckScanUrl.toString();
+        UUID scanId = UUID.fromString(url.substring(url.lastIndexOf("/") + 1));
+        
+        return scanId;
+    }
 }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -163,6 +163,7 @@ import com.synopsys.integration.detect.workflow.project.ProjectNameVersionDecide
 import com.synopsys.integration.detect.workflow.project.ProjectNameVersionOptions;
 import com.synopsys.integration.detect.workflow.result.DetectResult;
 import com.synopsys.integration.detect.workflow.result.ReportDetectResult;
+import com.synopsys.integration.detect.workflow.status.FormattedCodeLocation;
 import com.synopsys.integration.detect.workflow.status.OperationSystem;
 import com.synopsys.integration.detect.workflow.status.Status;
 import com.synopsys.integration.detect.workflow.status.StatusEventPublisher;
@@ -470,10 +471,10 @@ public class OperationRunner {
         return auditLog.namedInternal("Calculate Code Location Wait Data", () -> new CodeLocationWaitCalculator().calculateWaitData(codeLocationCreationDatas));
     }
 
-    public final void publishCodeLocationNames(Set<String> codeLocationNames) throws OperationException {
+    public final void publishCodeLocationData(Set<FormattedCodeLocation> codeLocationData) throws OperationException {
         auditLog.namedInternal(
             "Publish CodeLocationsCompleted Event",
-            () -> codeLocationEventPublisher.publishCodeLocationsCompleted(codeLocationNames)
+            () -> codeLocationEventPublisher.publishCodeLocationsCompleted(codeLocationData)
         );
     }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -36,6 +36,7 @@ import com.synopsys.integration.detect.workflow.report.util.ReportConstants;
 import com.synopsys.integration.detect.workflow.result.BlackDuckBomDetectResult;
 import com.synopsys.integration.detect.workflow.result.DetectResult;
 import com.synopsys.integration.detect.workflow.result.ReportDetectResult;
+import com.synopsys.integration.detect.workflow.status.FormattedCodeLocation;
 import com.synopsys.integration.detect.workflow.status.OperationType;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
@@ -206,8 +207,15 @@ public class IntelligentModeStepRunner {
 
         Set<String> allCodeLocationNames = new HashSet<>(codeLocationAccumulator.getNonWaitableCodeLocations());
         CodeLocationWaitData waitData = operationRunner.calculateCodeLocationWaitData(codeLocationAccumulator.getWaitableCodeLocations());
+        
+        Set<FormattedCodeLocation> allCodeLocationData = new HashSet<>();
+        for (String codeLocationName : waitData.getCodeLocationNames()) {
+            FormattedCodeLocation codeLocation = new FormattedCodeLocation(codeLocationName, null, null);
+            allCodeLocationData.add(codeLocation);
+        }
+        
         allCodeLocationNames.addAll(waitData.getCodeLocationNames());
-        operationRunner.publishCodeLocationNames(allCodeLocationNames);
+        operationRunner.publishCodeLocationData(allCodeLocationData);
         return new CodeLocationResults(allCodeLocationNames, waitData);
     }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -127,7 +127,7 @@ public class RapidModeStepRunner {
         
         for (HttpUrl httpUrl : scanResultUrls) {
             String url = httpUrl.toString();
-            String scanId = url.substring(url.lastIndexOf("/") + 1);
+            UUID scanId = UUID.fromString(url.substring(url.lastIndexOf("/") + 1));
             FormattedCodeLocation codeLocationData = new FormattedCodeLocation(null, scanId, scanType);
             formattedCodeLocations.add(codeLocationData);
         }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -122,14 +122,17 @@ public class RapidModeStepRunner {
      * file in formattedCodeLocations so scanId and type can be reported.
      */
     private void processScanResults(List<HttpUrl> scanResultUrls, List<HttpUrl> parsedUrls,
-            Set<FormattedCodeLocation> formattedCodeLocations, String scanType) {
-        parsedUrls.addAll(scanResultUrls);
-        
+            Set<FormattedCodeLocation> formattedCodeLocations, String scanType) {        
         for (HttpUrl httpUrl : scanResultUrls) {
-            String url = httpUrl.toString();
-            UUID scanId = UUID.fromString(url.substring(url.lastIndexOf("/") + 1));
-            FormattedCodeLocation codeLocationData = new FormattedCodeLocation(null, scanId, scanType);
-            formattedCodeLocations.add(codeLocationData);
+            UUID scanId;
+            try {
+                scanId = operationRunner.getScanIdFromScanUrl(httpUrl);
+                parsedUrls.add(httpUrl);
+                FormattedCodeLocation codeLocationData = new FormattedCodeLocation(null, scanId, scanType);
+                formattedCodeLocations.add(codeLocationData);
+            } catch (IllegalArgumentException e) {
+                logger.info(String.format("Unable to parse scanId from URL %s", httpUrl));
+            }
         }
     }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationEventPublisher.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/codelocation/CodeLocationEventPublisher.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 
 import com.synopsys.integration.detect.workflow.event.Event;
 import com.synopsys.integration.detect.workflow.event.EventSystem;
+import com.synopsys.integration.detect.workflow.status.FormattedCodeLocation;
 
 public class CodeLocationEventPublisher {
     private final EventSystem eventSystem;
@@ -12,8 +13,8 @@ public class CodeLocationEventPublisher {
         this.eventSystem = eventSystem;
     }
 
-    public void publishCodeLocationsCompleted(Collection<String> codeLocationNameCollection) {
-        eventSystem.publishEvent(Event.CodeLocationsCompleted, codeLocationNameCollection);
+    public void publishCodeLocationsCompleted(Collection<FormattedCodeLocation> codeLocationDataCollection) {
+        eventSystem.publishEvent(Event.CodeLocationsCompleted, codeLocationDataCollection);
     }
 
     public void publishDetectCodeLocationNamesCalculated(DetectCodeLocationNamesResult detectCodeLocationNamesResult) {

--- a/src/main/java/com/synopsys/integration/detect/workflow/event/Event.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/event/Event.java
@@ -11,6 +11,7 @@ import com.synopsys.integration.detect.workflow.codelocation.DetectCodeLocationN
 import com.synopsys.integration.detect.workflow.profiling.DetectorTimings;
 import com.synopsys.integration.detect.workflow.result.DetectResult;
 import com.synopsys.integration.detect.workflow.status.DetectIssue;
+import com.synopsys.integration.detect.workflow.status.FormattedCodeLocation;
 import com.synopsys.integration.detect.workflow.status.Operation;
 import com.synopsys.integration.detect.workflow.status.Status;
 import com.synopsys.integration.detect.workflow.status.UnrecognizedPaths;
@@ -23,7 +24,7 @@ public class Event {
     //    public static final EventType<DetectorEvaluation> ExtractionStarted = new EventType<>(DetectorEvaluation.class);
     //    public static final EventType<DetectorEvaluation> ExtractionEnded = new EventType<>(DetectorEvaluation.class);
     public static final EventType<DetectCodeLocationNamesResult> DetectCodeLocationNamesCalculated = new EventType<>(DetectCodeLocationNamesResult.class);
-    public static final EventType<Collection<String>> CodeLocationsCompleted = new EventType(Collection.class);
+    public static final EventType<Collection<FormattedCodeLocation>> CodeLocationsCompleted = new EventType(Collection.class);
     public static final EventType<ExitCodeRequest> ExitCode = new EventType<>(ExitCodeRequest.class);
     public static final EventType<Status> StatusSummary = new EventType<>(Status.class);
     public static final EventType<DetectIssue> Issue = new EventType<>(DetectIssue.class);

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedCodeLocationOutput.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedCodeLocationOutput.java
@@ -1,5 +1,7 @@
 package com.synopsys.integration.detect.workflow.report.output;
 
+import java.util.UUID;
+
 import com.google.gson.annotations.SerializedName;
 import com.synopsys.integration.detect.workflow.status.FormattedCodeLocation;
 
@@ -8,7 +10,7 @@ public class FormattedCodeLocationOutput {
     public String codeLocationName;
     
     @SerializedName("scanId")
-    public String scanId;
+    public UUID scanId;
     
     @SerializedName("scanType")
     public String scanType;

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedCodeLocationOutput.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedCodeLocationOutput.java
@@ -1,13 +1,21 @@
 package com.synopsys.integration.detect.workflow.report.output;
 
 import com.google.gson.annotations.SerializedName;
+import com.synopsys.integration.detect.workflow.status.FormattedCodeLocation;
 
 public class FormattedCodeLocationOutput {
     @SerializedName("codeLocationName")
     public String codeLocationName;
+    
+    @SerializedName("scanId")
+    public String scanId;
+    
+    @SerializedName("scanType")
+    public String scanType;
 
-    FormattedCodeLocationOutput(String name) {
-        this.codeLocationName = name;
+    FormattedCodeLocationOutput(FormattedCodeLocation data) {
+        this.codeLocationName = data.getCodeLocationName();
+        this.scanId = data.getScanId();
+        this.scanType = data.getScanType();
     }
-
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedOutputManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/report/output/FormattedOutputManager.java
@@ -23,6 +23,7 @@ import com.synopsys.integration.detect.workflow.event.Event;
 import com.synopsys.integration.detect.workflow.event.EventSystem;
 import com.synopsys.integration.detect.workflow.result.DetectResult;
 import com.synopsys.integration.detect.workflow.status.DetectIssue;
+import com.synopsys.integration.detect.workflow.status.FormattedCodeLocation;
 import com.synopsys.integration.detect.workflow.status.Operation;
 import com.synopsys.integration.detect.workflow.status.OperationType;
 import com.synopsys.integration.detect.workflow.status.Status;
@@ -35,7 +36,7 @@ import com.synopsys.integration.detector.base.DetectorType;
 import com.synopsys.integration.util.NameVersion;
 
 public class FormattedOutputManager {
-    private final Set<String> codeLocations = new HashSet<>();
+    private final Set<FormattedCodeLocation> codeLocations = new HashSet<>();
     private final List<Status> statusSummaries = new ArrayList<>();
     private final List<DetectResult> detectResults = new ArrayList<>();
     private final List<DetectIssue> detectIssues = new ArrayList<>();

--- a/src/main/java/com/synopsys/integration/detect/workflow/status/FormattedCodeLocation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/FormattedCodeLocation.java
@@ -1,0 +1,29 @@
+package com.synopsys.integration.detect.workflow.status;
+
+/**
+ * This class captures the data needed to populate the codeLocation's array in the status.json 
+ */
+public class FormattedCodeLocation {
+
+    private final String codeLocationName;
+    private final String scanId;
+    private final String scanType;
+    
+    public FormattedCodeLocation(String codeLocationName, String scanId, String scanType) {
+        this.codeLocationName = codeLocationName;
+        this.scanId = scanId;
+        this.scanType = scanType;
+    }
+    
+    public String getCodeLocationName() {
+        return codeLocationName;
+    }
+
+    public String getScanId() {
+        return scanId;
+    }
+
+    public String getScanType() {
+        return scanType;
+    }
+}

--- a/src/main/java/com/synopsys/integration/detect/workflow/status/FormattedCodeLocation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/FormattedCodeLocation.java
@@ -1,15 +1,17 @@
 package com.synopsys.integration.detect.workflow.status;
 
+import java.util.UUID;
+
 /**
  * This class captures the data needed to populate the codeLocation array in the status.json file.
  */
 public class FormattedCodeLocation {
 
     private final String codeLocationName;
-    private final String scanId;
+    private final UUID scanId;
     private final String scanType;
     
-    public FormattedCodeLocation(String codeLocationName, String scanId, String scanType) {
+    public FormattedCodeLocation(String codeLocationName, UUID scanId, String scanType) {
         this.codeLocationName = codeLocationName;
         this.scanId = scanId;
         this.scanType = scanType;
@@ -19,7 +21,7 @@ public class FormattedCodeLocation {
         return codeLocationName;
     }
 
-    public String getScanId() {
+    public UUID getScanId() {
         return scanId;
     }
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/status/FormattedCodeLocation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/status/FormattedCodeLocation.java
@@ -1,7 +1,7 @@
 package com.synopsys.integration.detect.workflow.status;
 
 /**
- * This class captures the data needed to populate the codeLocation's array in the status.json 
+ * This class captures the data needed to populate the codeLocation array in the status.json file.
  */
 public class FormattedCodeLocation {
 

--- a/src/test/java/com/synopsys/integration/detect/workflow/report/FormattedOutputManagerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/report/FormattedOutputManagerTest.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.detect.workflow.report;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ public class FormattedOutputManagerTest {
         
         // Mock a completed scan to report on
         List<FormattedCodeLocation> codeLocationExpected = new ArrayList<>();
-        codeLocationExpected.add(new FormattedCodeLocation(null, "f4ffe78c-9c83-4f45-b66e-d60fd2fcce46", DetectTool.DETECTOR.name()));
+        codeLocationExpected.add(new FormattedCodeLocation(null, UUID.randomUUID(), DetectTool.DETECTOR.name()));
         
         // Publish the event
         eventSystem.publishEvent(Event.CodeLocationsCompleted, codeLocationExpected);

--- a/src/test/java/com/synopsys/integration/detect/workflow/report/FormattedOutputManagerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/report/FormattedOutputManagerTest.java
@@ -1,5 +1,47 @@
-// TODO Jordan deleted this test. It would require a re-write
+package com.synopsys.integration.detect.workflow.report;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detect.configuration.DetectInfo;
+import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
+import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
+import com.synopsys.integration.detect.workflow.event.Event;
+import com.synopsys.integration.detect.workflow.event.EventSystem;
+import com.synopsys.integration.detect.workflow.report.output.FormattedCodeLocationOutput;
+import com.synopsys.integration.detect.workflow.report.output.FormattedOutput;
+import com.synopsys.integration.detect.workflow.report.output.FormattedOutputManager;
+import com.synopsys.integration.detect.workflow.status.FormattedCodeLocation;
+
+public class FormattedOutputManagerTest {
+    @Test
+    public void formattedCodeLocationTest() {
+        // Setup the reporting infrastructure
+        EventSystem eventSystem = new EventSystem();
+        FormattedOutputManager formattedOutputManager = new FormattedOutputManager(eventSystem);
+        
+        // Mock a completed scan to report on
+        List<FormattedCodeLocation> codeLocationExpected = new ArrayList<>();
+        codeLocationExpected.add(new FormattedCodeLocation(null, "f4ffe78c-9c83-4f45-b66e-d60fd2fcce46", DetectTool.DETECTOR.name()));
+        
+        // Publish the event
+        eventSystem.publishEvent(Event.CodeLocationsCompleted, codeLocationExpected);
+        
+        DetectInfo detectInfo = new DetectInfo("", null, "");
+        FormattedOutput formattedOutput = formattedOutputManager.createFormattedOutput(detectInfo, ExitCodeType.SUCCESS);
+        
+        List<FormattedCodeLocationOutput> codeLocationActual = formattedOutput.codeLocations;
+        Assertions.assertEquals(1, codeLocationActual.size());
+        Assertions.assertEquals(codeLocationExpected.get(0).getScanId(), codeLocationActual.get(0).scanId);
+        Assertions.assertEquals(codeLocationExpected.get(0).getScanType(), codeLocationActual.get(0).scanType);
+    }
+}
+
 /*
+// TODO Jordan deleted this test. It would require a re-write
 package com.synopsys.integration.detect.workflow.report;
 
 import java.io.File;


### PR DESCRIPTION
For rapid and stateless scans, this work adds the scanID and scan type to the codeLocations array of the status.json file.