### PR TITLE
bug fix verify return of mkdir

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
@@ -176,8 +176,8 @@ public class ApplicationUpdater extends URLClassLoader {
     private File installOrUpdateScanner(String dirPath) throws IOException, IntegrationException {
         final File installDirectory = new File(dirPath);
         
-        if (!installDirectory.exists()) {
-            installDirectory.mkdir();
+        if (!installDirectory.exists() && !installDirectory.mkdir()) {
+            return null;
         } else if (!checkInstallationDir(installDirectory.toPath())) {
             return null;
         }


### PR DESCRIPTION
# Description

We had a case of mkdir failing as it tried to create a directory but did not have the rights. Our scan crashed with a NullPointerException. So I added a check if mkdir was successful.

# Issues
[might fix this issue](https://community.synopsys.com/s/question/0D5Hr00006WwmEGKAZ/i-am-facing-issue-with-detect890-since-new-version-release-and-i-am-trying-to-execute-it-with-older-detect-version-but-i-am-not-getting-the-exact-property-name-to-set-it-as-a-detect-version-880-can-you-please-help-me-with-this)

IDETECT-3921

