### PR TITLE
Fix codeLocation output to status.json for intelligent scans

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -207,14 +207,14 @@ public class IntelligentModeStepRunner {
 
         Set<String> allCodeLocationNames = new HashSet<>(codeLocationAccumulator.getNonWaitableCodeLocations());
         CodeLocationWaitData waitData = operationRunner.calculateCodeLocationWaitData(codeLocationAccumulator.getWaitableCodeLocations());
+        allCodeLocationNames.addAll(waitData.getCodeLocationNames());
         
         Set<FormattedCodeLocation> allCodeLocationData = new HashSet<>();
-        for (String codeLocationName : waitData.getCodeLocationNames()) {
+        for (String codeLocationName : allCodeLocationNames) {
             FormattedCodeLocation codeLocation = new FormattedCodeLocation(codeLocationName, null, null);
             allCodeLocationData.add(codeLocation);
         }
         
-        allCodeLocationNames.addAll(waitData.getCodeLocationNames());
         operationRunner.publishCodeLocationData(allCodeLocationData);
         return new CodeLocationResults(allCodeLocationNames, waitData);
     }


### PR DESCRIPTION
This is a recent regression as I was attempting to format codeLocation names on only a portion of the code locations reported by Detect. This rearranges the code so that all code locations are gathered before they are formatted for the status.json report.