### PR TITLE
pass no persistence mode flag to the scan CLI when user specifies BOM_COMPARE mode

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -5,6 +5,7 @@
 ### New features
 
 * For Stateless and Rapid scans, the scanId and Detector tool being run, are now stored in the codeLocations section of the status.json file containing the run summary.
+* Stateless Signature and Package Manager scans now support the <code>--detect.blackduck.rapid.compare.mode</code> flag. Values are ALL, BOM_COMPARE, or BOM_COMPARE_STRICT. See the [Stateless Scans page](runningdetect/statelessscan.md) for further details. 
 
 ## Version 8.10.0
 

--- a/documentation/src/main/markdown/runningdetect/rapidscan.md
+++ b/documentation/src/main/markdown/runningdetect/rapidscan.md
@@ -105,6 +105,6 @@ For further remediation and transitive dependency upgrade guidance, please consu
 
 ## Rapid Scan Compare Mode
 
-You can configure Rapid Scan to return only the difference in policy violations between the current scan and previous Rapid Scans using the same configuration. To return only the difference in policy violations, configure detect.blackduck.rapid.compare.mode to BOM_COMPARE or BOM_COMPARE_STRICT.
+You can configure Rapid Scan to return only the difference in policy violations between the current scan and previous Persistent Scans using the same configuration. To return only the difference in policy violations, configure detect.blackduck.rapid.compare.mode to BOM_COMPARE or BOM_COMPARE_STRICT.
 
 Setting the compare mode to ALL evaluates all RAPID or FULL policies. BOM_COMPARE_STRICT only shows policy violations not present in an existing project version BOM. BOM_COMPARE depends on the type of policy rule modes and behaves like ALL if the policy rule is only RAPID and like BOM_COMPARE_STRICT when the policy rule is RAPID and FULL. See the Black Duck documentation for complete details.

--- a/documentation/src/main/markdown/runningdetect/statelessscan.md
+++ b/documentation/src/main/markdown/runningdetect/statelessscan.md
@@ -115,3 +115,8 @@ For further remediation and transitive dependency upgrade guidance, please consu
 <xref href="RiskGuidance.dita" scope="peer">Getting remediation guidance for components with security vulnerabilities.
 <data name="facets" value="pubname=bd-hub"/>
 
+## Stateless Scan Compare Mode
+
+You can configure Stateless Scan to return only the difference in policy violations between the current scan and previous Persistent Scans using the same configuration. To return only the difference in policy violations, configure detect.blackduck.rapid.compare.mode to BOM_COMPARE or BOM_COMPARE_STRICT.
+
+Setting the compare mode to ALL evaluates all RAPID or FULL policies. BOM_COMPARE_STRICT only shows policy violations not present in an existing project version BOM. BOM_COMPARE depends on the type of policy rule modes and behaves like ALL if the policy rule is only RAPID and like BOM_COMPARE_STRICT when the policy rule is RAPID and FULL. See the Black Duck documentation for complete details.

--- a/documentation/src/main/markdown/runningdetect/statelessscan.md
+++ b/documentation/src/main/markdown/runningdetect/statelessscan.md
@@ -117,6 +117,6 @@ For further remediation and transitive dependency upgrade guidance, please consu
 
 ## Stateless Scan Compare Mode
 
-You can configure Stateless Scan to return only the difference in policy violations between the current scan and previous Persistent Scans using the same configuration. To return only the difference in policy violations, configure detect.blackduck.rapid.compare.mode to BOM_COMPARE or BOM_COMPARE_STRICT.
+You can configure Package Manager and Signature Stateless Scans to return only the difference in policy violations between the current scan and previous Persistent Scans using the same configuration. To return only the difference in policy violations, configure detect.blackduck.rapid.compare.mode to BOM_COMPARE or BOM_COMPARE_STRICT.
 
 Setting the compare mode to ALL evaluates all RAPID or FULL policies. BOM_COMPARE_STRICT only shows policy violations not present in an existing project version BOM. BOM_COMPARE depends on the type of policy rule modes and behaves like ALL if the policy rule is only RAPID and like BOM_COMPARE_STRICT when the policy rule is RAPID and FULL. See the Black Duck documentation for complete details.

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.3-SNAPSHOT'
+gradle.ext.blackDuckCommonVersion='66.2.3'
 gradle.ext.springBootVersion='2.7.12'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.1'
+gradle.ext.blackDuckCommonVersion='66.2.3-SNAPSHOT'
 gradle.ext.springBootVersion='2.7.12'

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -29,9 +29,7 @@ import com.synopsys.integration.configuration.property.types.enumallnone.list.Al
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllNoneEnumCollection;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllNoneEnumList;
 import com.synopsys.integration.configuration.property.types.enumallnone.list.NoneEnumList;
-import com.synopsys.integration.configuration.property.types.enumextended.ExtendedEnumProperty;
 import com.synopsys.integration.configuration.property.types.enumextended.ExtendedEnumValue;
-import com.synopsys.integration.configuration.property.types.path.PathValue;
 import com.synopsys.integration.detect.configuration.connection.BlackDuckConnectionDetails;
 import com.synopsys.integration.detect.configuration.connection.ConnectionDetails;
 import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
@@ -392,6 +390,7 @@ public class DetectConfigurationFactory {
         Boolean treatSkippedScansAsSuccess = detectConfiguration.getValue(DetectProperties.DETECT_FORCE_SUCCESS_ON_SKIP);
         Boolean isStateless = BlackduckScanMode.STATELESS.equals(detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE)) ||
                 BlackduckScanMode.EPHEMERAL.equals(detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE));
+        RapidCompareMode compareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
         
 
         return new BlackDuckSignatureScannerOptions(
@@ -411,7 +410,8 @@ public class DetectConfigurationFactory {
             followSymLinks,
             treatSkippedScansAsSuccess,
             isStateless,
-            findReducedPersistence()
+            findReducedPersistence(),
+            compareMode
         );
     }
 

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.IndividualFileMatching;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
+import com.synopsys.integration.detect.configuration.enumeration.RapidCompareMode;
 
 public class BlackDuckSignatureScannerOptions {
     private final List<Path> signatureScannerPaths;
@@ -38,6 +39,7 @@ public class BlackDuckSignatureScannerOptions {
     private final Boolean followSymLinks;
     private final Boolean treatSkippedScansAsSuccess;
     private final Boolean isStateless;
+    private final RapidCompareMode bomCompareMode;
 
     public BlackDuckSignatureScannerOptions(
         List<Path> signatureScannerPaths,
@@ -56,7 +58,8 @@ public class BlackDuckSignatureScannerOptions {
         Boolean followSymLinks,
         Boolean treatSkippedScansAsSuccess,
         Boolean isStateless, 
-        ReducedPersistence reducedPersistence
+        ReducedPersistence reducedPersistence, 
+        RapidCompareMode bomCompareMode
     ) {
 
         this.signatureScannerPaths = signatureScannerPaths;
@@ -76,6 +79,7 @@ public class BlackDuckSignatureScannerOptions {
         this.treatSkippedScansAsSuccess = treatSkippedScansAsSuccess;
         this.isStateless = isStateless;
         this.reducedPersistence = reducedPersistence;
+        this.bomCompareMode = bomCompareMode;
     }
 
     public List<Path> getSignatureScannerPaths() {
@@ -144,5 +148,10 @@ public class BlackDuckSignatureScannerOptions {
     
     public Optional<ReducedPersistence> getReducedPersistence() {
         return Optional.ofNullable(reducedPersistence);
+    }
+
+    // TODO write some tests around this piece
+    public RapidCompareMode getBomCompareMode() {
+        return bomCompareMode;
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
@@ -150,7 +150,6 @@ public class BlackDuckSignatureScannerOptions {
         return Optional.ofNullable(reducedPersistence);
     }
 
-    // TODO write some tests around this piece
     public RapidCompareMode getBomCompareMode() {
         return bomCompareMode;
     }

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
@@ -67,6 +67,8 @@ public class CreateScanBatchOperation {
         signatureScannerOptions.getAdditionalArguments().ifPresent(scanJobBuilder::additionalScanArguments);
         
         scanJobBuilder.rapid(signatureScannerOptions.getIsStateless());
+        
+        scanJobBuilder.bomCompareMode(signatureScannerOptions.getBomCompareMode().toString());
 
         String projectName = projectNameVersion.getName();
         String projectVersionName = projectNameVersion.getVersion();

--- a/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
+++ b/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
@@ -15,6 +15,7 @@ import com.synopsys.integration.common.util.Bdo;
 import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.DefaultDetectorSearchExcludedDirectories;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
+import com.synopsys.integration.detect.configuration.enumeration.RapidCompareMode;
 import com.synopsys.integration.detect.tool.signaturescanner.BlackDuckSignatureScannerOptions;
 import com.synopsys.integration.rest.credentials.Credentials;
 
@@ -87,5 +88,15 @@ public class DetectConfigurationFactoryTests {
         BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = factory.createBlackDuckSignatureScannerOptions();
 
         Assertions.assertTrue(blackDuckSignatureScannerOptions.getIsStateless());
+    }
+    
+    @Test
+    public void testNoPersistenceModeSpecified() {
+        DetectConfigurationFactory factory = factoryOf(
+                Pair.of(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE, RapidCompareMode.BOM_COMPARE_STRICT.toString()));
+        
+        BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = factory.createBlackDuckSignatureScannerOptions();
+
+        Assertions.assertTrue(RapidCompareMode.BOM_COMPARE_STRICT.equals(blackDuckSignatureScannerOptions.getBomCompareMode()));
     }
 }


### PR DESCRIPTION
When a user asks for a BOM COMPARE mode we need to pass that data down to the scan CLI in the form of the new --no-persistent-mode flag. This is a flag on the signature scanner itself and the mechanism is mostly in https://github.com/blackducksoftware/blackduck-common/pull/404

IDETECT-3893