### PR TITLE
Add error message instead of silent failure when installation directory

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
@@ -178,7 +178,7 @@ public class ApplicationUpdater extends URLClassLoader {
         
         if (!installDirectory.exists() && !installDirectory.mkdir()) {
             throw new AccessDeniedException(dirPath, null, 
-                        "No write permissison to create the missing installation directory: "
+                        "No write permission to create the missing installation directory: "
                                 .concat(dirPath));
         } else if (!checkInstallationDir(installDirectory.toPath())) {
             return null;
@@ -311,7 +311,7 @@ public class ApplicationUpdater extends URLClassLoader {
                 return true;
             } else {
                 throw new AccessDeniedException(path.toString(), null, 
-                        "No write permissison to store downloaded Jar in the installation directory: "
+                        "No write permission to store downloaded Jar in the installation directory: "
                                 .concat(path.getFileName().toAbsolutePath().toString()));
             }
         }

--- a/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
@@ -177,7 +177,9 @@ public class ApplicationUpdater extends URLClassLoader {
         final File installDirectory = new File(dirPath);
         
         if (!installDirectory.exists() && !installDirectory.mkdir()) {
-            return null;
+            throw new AccessDeniedException(dirPath, null, 
+                        "No write permisison to create the missing installation directory: "
+                                .concat(dirPath));
         } else if (!checkInstallationDir(installDirectory.toPath())) {
             return null;
         }

--- a/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/synopsys/integration/detect/ApplicationUpdater.java
@@ -178,7 +178,7 @@ public class ApplicationUpdater extends URLClassLoader {
         
         if (!installDirectory.exists() && !installDirectory.mkdir()) {
             throw new AccessDeniedException(dirPath, null, 
-                        "No write permisison to create the missing installation directory: "
+                        "No write permissison to create the missing installation directory: "
                                 .concat(dirPath));
         } else if (!checkInstallationDir(installDirectory.toPath())) {
             return null;
@@ -311,7 +311,7 @@ public class ApplicationUpdater extends URLClassLoader {
                 return true;
             } else {
                 throw new AccessDeniedException(path.toString(), null, 
-                        "No write permisison to store downloaded Jar in the installation directory: "
+                        "No write permissison to store downloaded Jar in the installation directory: "
                                 .concat(path.getFileName().toAbsolutePath().toString()));
             }
         }


### PR DESCRIPTION
# Description

Add error message instead of silent failure when installation directory cannot be created.

# Github Issues

IDETECT-3921
