### PR TITLE
update documentation to replace scan types

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* For Stateless and Rapid scans, the scanId and Detector tool being run, are now stored in the codeLocations section of the status.json file containing the run summary.
+* For Stateless and Rapid scans, the scanId and scan type being run, are now stored in the codeLocations section of the status.json file. For a given scanId, the scan type can be DETECTOR, BINARY_SCAN, SIGNATURE_SCAN, or CONTAINER_SCAN.
 * Stateless Signature and Package Manager scans now support the <code>--detect.blackduck.rapid.compare.mode</code> flag. Values are ALL, BOM_COMPARE, or BOM_COMPARE_STRICT. See the [Stateless Scans page](runningdetect/statelessscan.md) for further details. 
 
 ### Resolved issues

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* For Stateless and Rapid scans, the scanId and scan type being run, are now stored in the codeLocations section of the status.json file. For a given scanId, the scan type can be DETECTOR, BINARY_SCAN, SIGNATURE_SCAN, or CONTAINER_SCAN.
+* For Stateless and Rapid scans, the scanId and scan type being run are now stored in the codeLocations section of the status.json file. For a given scanId, the scan type can be DETECTOR, BINARY_SCAN, SIGNATURE_SCAN, or CONTAINER_SCAN.
 * Stateless Signature and Package Manager scans now support the <code>--detect.blackduck.rapid.compare.mode</code> flag. Values are ALL, BOM_COMPARE, or BOM_COMPARE_STRICT. See the [Stateless Scans page](runningdetect/statelessscan.md) for further details. 
 
 ### Resolved issues

--- a/documentation/src/main/resources/templates/status-file.ftl
+++ b/documentation/src/main/resources/templates/status-file.ftl
@@ -95,7 +95,7 @@ For those detectors that support it (currently, only CLANG), a list of file path
 ````
 {
 "codeLocationName": The name of a code location produced by this run of Synopsys Detect.
-"scanType": The type of scan that was performed, DETECTOR, BAZEL, SIGNATURE_SCAN, DOCKER, BINARY_SCAN, or CONTAINER_SCAN.
+"scanType": The type of scan that was performed, DETECTOR, BINARY_SCAN, SIGNATURE_SCAN, or CONTAINER_SCAN.
 "scanId": The UUID for the scan.
 }
 ````


### PR DESCRIPTION
Need to update the documentation as instead of tools we need to list type since several tools fall into the DETECTOR category. Specifically, docker, bazel, and detector will all show up as the detector type since they generate and upload a BDIO.