### PR TITLE
optimize how detect project clone categories are sent

### DIFF
--- a/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumallnone/list/AllNoneEnumListBase.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumallnone/list/AllNoneEnumListBase.java
@@ -78,16 +78,15 @@ public class AllNoneEnumListBase<E extends Enum<E>, B extends Enum<B>> implement
     }
     
     /**
-     * This returns null if the properties' value is set to all values of the Enum.
+     * This returns null if the properties' value is set to ALL values of the Enum.
+     * It returns an empty array if the value is set to NONE.
      * This indicates all to Black Duck and streamlines things for newer endpoints.
+     * Older endpoints should use representedValues.
      */
     public List<B> representedValuesStreamlined() {
         if (containsNone()) {
-            // NONE is achieved by sending the field but with an empty array value
             return new ArrayList<>();
         } else if (containsAll()) {
-            // ALL is achieved by sending the request with the field set to null.
-            // This is the default if the property is not specified.
             return null;
         } else {
             return toPresentValues();

--- a/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumallnone/list/AllNoneEnumListBase.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumallnone/list/AllNoneEnumListBase.java
@@ -76,6 +76,23 @@ public class AllNoneEnumListBase<E extends Enum<E>, B extends Enum<B>> implement
             return toPresentValues();
         }
     }
+    
+    /**
+     * This returns null if the properties' value is set to all values of the Enum.
+     * This indicates all to Black Duck and streamlines things for newer endpoints.
+     */
+    public List<B> representedValuesStreamlined() {
+        if (containsNone()) {
+            // NONE is achieved by sending the field but with an empty array value
+            return new ArrayList<>();
+        } else if (containsAll()) {
+            // ALL is achieved by sending the request with the field set to null.
+            // This is the default if the property is not specified.
+            return null;
+        } else {
+            return toPresentValues();
+        }
+    }
 
     public Set<B> representedValueSet() {
         return new HashSet<>(representedValues());

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.NotNull;
@@ -323,7 +324,7 @@ public class DetectConfigurationFactory {
         Integer projectTier = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_TIER);
         String projectDescription = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_DESCRIPTION);
         String projectVersionNotes = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NOTES);
-        List<ProjectCloneCategoriesType> cloneCategories = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).representedValues();
+        List<ProjectCloneCategoriesType> cloneCategories = getCloneCategories();
         Boolean projectLevelAdjustments = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_LEVEL_ADJUSTMENTS);
         Boolean forceProjectVersionUpdate = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_VERSION_UPDATE);
         String projectVersionNickname = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NICKNAME);
@@ -339,6 +340,22 @@ public class DetectConfigurationFactory {
             projectVersionNickname,
             projectLevelAdjustments
         );
+    }
+
+    public List<ProjectCloneCategoriesType> getCloneCategories() {
+        AllNoneEnumList<ProjectCloneCategoriesType> value = detectConfiguration
+                .getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES);
+
+        if (value.containsNone()) {
+            // NONE is achieved by sending the field but with an empty array value
+            return new ArrayList<>();
+        } else if (value.containsAll()) {
+            // ALL is achieved by sending the request with project category field missing or set to null
+            // This is the default if the property is not specified.
+            return null;
+        } else {
+            return value.toPresentValues();
+        }
     }
 
     public ProjectVersionLicenseOptions createProjectVersionLicenseOptions() {

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.NotNull;
@@ -324,7 +323,7 @@ public class DetectConfigurationFactory {
         Integer projectTier = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_TIER);
         String projectDescription = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_DESCRIPTION);
         String projectVersionNotes = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NOTES);
-        List<ProjectCloneCategoriesType> cloneCategories = getCloneCategories();
+        List<ProjectCloneCategoriesType> cloneCategories = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).representedValuesStreamlined();
         Boolean projectLevelAdjustments = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_LEVEL_ADJUSTMENTS);
         Boolean forceProjectVersionUpdate = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_VERSION_UPDATE);
         String projectVersionNickname = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NICKNAME);

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -341,22 +341,6 @@ public class DetectConfigurationFactory {
         );
     }
 
-    public List<ProjectCloneCategoriesType> getCloneCategories() {
-        AllNoneEnumList<ProjectCloneCategoriesType> value = detectConfiguration
-                .getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES);
-
-        if (value.containsNone()) {
-            // NONE is achieved by sending the field but with an empty array value
-            return new ArrayList<>();
-        } else if (value.containsAll()) {
-            // ALL is achieved by sending the request with project category field missing or set to null
-            // This is the default if the property is not specified.
-            return null;
-        } else {
-            return value.toPresentValues();
-        }
-    }
-
     public ProjectVersionLicenseOptions createProjectVersionLicenseOptions() {
         String licenseName = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_LICENSE);
         return new ProjectVersionLicenseOptions(licenseName);

--- a/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
+++ b/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.detect.configuration;
 import static com.synopsys.integration.detect.configuration.DetectConfigurationFactoryTestUtils.factoryOf;
 import static com.synopsys.integration.detect.configuration.DetectConfigurationFactoryTestUtils.spyFactoryOf;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectCloneCategoriesType;
 import com.synopsys.integration.common.util.Bdo;
 import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.DefaultDetectorSearchExcludedDirectories;
@@ -98,5 +100,38 @@ public class DetectConfigurationFactoryTests {
         BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = factory.createBlackDuckSignatureScannerOptions();
 
         Assertions.assertTrue(RapidCompareMode.BOM_COMPARE_STRICT.equals(blackDuckSignatureScannerOptions.getBomCompareMode()));
+    }
+    
+    @Test
+    public void testAllCloneCategories() {
+        DetectConfigurationFactory factory = factoryOf(Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, "ALL"));
+        
+        List<ProjectCloneCategoriesType> cloneCategories = factory.getCloneCategories();
+        
+        Assertions.assertTrue(cloneCategories == null);
+    }
+    
+    @Test
+    public void testNoCloneCategories() {
+        DetectConfigurationFactory factory = factoryOf(Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, "NONE"));
+        
+        List<ProjectCloneCategoriesType> cloneCategories = factory.getCloneCategories();
+        
+        Assertions.assertTrue(cloneCategories.isEmpty()); 
+    }
+    
+    @Test
+    public void testSpecificCloneCategories() {
+        DetectConfigurationFactory factory = factoryOf(
+                Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, 
+                        ProjectCloneCategoriesType.CUSTOM_FIELD_DATA.toString() 
+                        + "," 
+                        + ProjectCloneCategoriesType.DEEP_LICENSE.toString()
+                ));
+        
+        List<ProjectCloneCategoriesType> cloneCategories = factory.getCloneCategories();
+        
+        Assertions.assertTrue(cloneCategories.contains(ProjectCloneCategoriesType.CUSTOM_FIELD_DATA));
+        Assertions.assertTrue(cloneCategories.contains(ProjectCloneCategoriesType.DEEP_LICENSE));
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
+++ b/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
@@ -19,6 +19,7 @@ import com.synopsys.integration.detect.configuration.enumeration.DefaultDetector
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detect.configuration.enumeration.RapidCompareMode;
 import com.synopsys.integration.detect.tool.signaturescanner.BlackDuckSignatureScannerOptions;
+import com.synopsys.integration.detect.workflow.blackduck.project.options.ProjectSyncOptions;
 import com.synopsys.integration.rest.credentials.Credentials;
 
 public class DetectConfigurationFactoryTests {
@@ -106,7 +107,9 @@ public class DetectConfigurationFactoryTests {
     public void testAllCloneCategories() {
         DetectConfigurationFactory factory = factoryOf(Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, "ALL"));
         
-        List<ProjectCloneCategoriesType> cloneCategories = factory.getCloneCategories();
+        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions();
+
+        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
         
         Assertions.assertTrue(cloneCategories == null);
     }
@@ -114,8 +117,9 @@ public class DetectConfigurationFactoryTests {
     @Test
     public void testNoCloneCategories() {
         DetectConfigurationFactory factory = factoryOf(Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, "NONE"));
-        
-        List<ProjectCloneCategoriesType> cloneCategories = factory.getCloneCategories();
+        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions();
+
+        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
         
         Assertions.assertTrue(cloneCategories.isEmpty()); 
     }
@@ -129,7 +133,9 @@ public class DetectConfigurationFactoryTests {
                         + ProjectCloneCategoriesType.DEEP_LICENSE.toString()
                 ));
         
-        List<ProjectCloneCategoriesType> cloneCategories = factory.getCloneCategories();
+        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions();
+
+        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
         
         Assertions.assertTrue(cloneCategories.contains(ProjectCloneCategoriesType.CUSTOM_FIELD_DATA));
         Assertions.assertTrue(cloneCategories.contains(ProjectCloneCategoriesType.DEEP_LICENSE));


### PR DESCRIPTION
ALL is achieved by sending the request with project category field missing or set to null, and NONE is achieved by sending the field but with an empty array value.