### PR TITLE
(refactor/console logging)Throw exception and fail Component Location Analysis in all cases whe…

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -189,6 +189,7 @@ import com.synopsys.integration.blackduck.bdio2.util.Bdio2ContentExtractor;
 
 import static com.synopsys.integration.componentlocator.ComponentLocator.SUPPORTED_DETECTORS;
 import static com.synopsys.integration.detect.workflow.componentlocationanalysis.GenerateComponentLocationAnalysisOperation.SUPPORTED_DETECTORS_LOG_MSG;
+import static com.synopsys.integration.detect.workflow.componentlocationanalysis.GenerateComponentLocationAnalysisOperation.OPERATION_NAME;
 public class OperationRunner {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final DetectDetectableFactory detectDetectableFactory;
@@ -467,18 +468,26 @@ public class OperationRunner {
             if (applicableDetectorsIncludeAtLeastOneSupportedDetector(bdio.getApplicableDetectorTypes())) {
                 if (!bdio.getCodeLocationNamesResult().getCodeLocationNames().isEmpty()) {
                     auditLog.namedPublic(
-                            "Generate Component Location Analysis File for All Components",
+                            OPERATION_NAME,
                             () -> new GenerateComponentLocationAnalysisOperation().locateComponentsForOfflineDetectorScan(bdio, directoryManager.getScanOutputDirectory(), directoryManager.getSourceDirectory())
                     );
                 } else {
                     logger.info(ReportConstants.RUN_SEPARATOR);
                     logger.info("Component Location Analysis requires a non-empty BDIO. Skipping location analysis.");
                     logger.info(ReportConstants.RUN_SEPARATOR);
+                    auditLog.namedPublic(
+                            OPERATION_NAME,
+                            () -> new GenerateComponentLocationAnalysisOperation().failComponentLocationAnalysisOperation()
+                    );
                 }
         } else {
                 logger.info(ReportConstants.RUN_SEPARATOR);
                 logger.info(SUPPORTED_DETECTORS_LOG_MSG);
                 logger.info(ReportConstants.RUN_SEPARATOR);
+                auditLog.namedPublic(
+                        OPERATION_NAME,
+                        () -> new GenerateComponentLocationAnalysisOperation().failComponentLocationAnalysisOperation()
+                );
             }
         }
     }
@@ -494,18 +503,26 @@ public class OperationRunner {
             if (applicableDetectorsIncludeAtLeastOneSupportedDetector(bdio.getApplicableDetectorTypes())) {
                 if (!rapidFullResults.isEmpty()) {
                     auditLog.namedPublic(
-                            "Generate Component Location Analysis File for Reported Components",
+                            OPERATION_NAME,
                             () -> (new GenerateComponentLocationAnalysisOperation()).locateComponentsForNonPersistentOnlineDetectorScan(rapidFullResults, directoryManager.getScanOutputDirectory(), directoryManager.getSourceDirectory())
                     );
                 } else {
                     logger.info(ReportConstants.RUN_SEPARATOR);
                     logger.info("Component Location Analysis requires non-empty Rapid Scan results. Skipping location analysis.");
                     logger.info(ReportConstants.RUN_SEPARATOR);
+                    auditLog.namedPublic(
+                            OPERATION_NAME,
+                            () -> new GenerateComponentLocationAnalysisOperation().failComponentLocationAnalysisOperation()
+                    );
                 }
         } else {
                 logger.info(ReportConstants.RUN_SEPARATOR);
                 logger.info(SUPPORTED_DETECTORS_LOG_MSG);
                 logger.info(ReportConstants.RUN_SEPARATOR);
+                auditLog.namedPublic(
+                        OPERATION_NAME,
+                        () -> new GenerateComponentLocationAnalysisOperation().failComponentLocationAnalysisOperation()
+                );
             }
         }
     }
@@ -536,7 +553,7 @@ public class OperationRunner {
     public void attemptToGenerateComponentLocationAnalysisIfEnabled() throws OperationException {
         if (detectConfigurationFactory.isComponentLocationAnalysisEnabled()) {
             auditLog.namedPublic(
-                    "Generate Component Location Analysis File for All Components",
+                    OPERATION_NAME,
                     () -> (new GenerateComponentLocationAnalysisOperation()).locateComponentsForOnlineIntelligentScan()
             );
         }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.synopsys.integration.detect.workflow.componentlocationanalysis.ComponentLocatorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.synopsys.integration.detect.workflow.componentlocationanalysis.ComponentLocatorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
@@ -1,22 +1,17 @@
 package com.synopsys.integration.detect.workflow.componentlocationanalysis;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
-import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 import com.synopsys.integration.detect.workflow.bdio.BdioResult;
 import com.synopsys.integration.componentlocator.ComponentLocator;
 import com.synopsys.integration.componentlocator.beans.Component;
 import com.synopsys.integration.componentlocator.beans.Input;
-import com.synopsys.integration.detect.workflow.file.DetectFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.synopsys.integration.detect.workflow.report.util.ReportConstants;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -74,11 +69,6 @@ public class GenerateComponentLocationAnalysisOperation {
 
     private void runComponentLocator(List<Component> componentsList, File scanOutputFolder, File projectSrcDir) throws ComponentLocatorException {
         Input componentLocatorInput = generateComponentLocatorInput(componentsList, projectSrcDir);
-
-        //
-        serializeInputToJson(scanOutputFolder, componentLocatorInput);
-        //
-
         String outputFilepath = scanOutputFolder + "/" + DETECT_OUTPUT_FILE_NAME;
 
         logger.info(ReportConstants.RUN_SEPARATOR);
@@ -94,18 +84,5 @@ public class GenerateComponentLocationAnalysisOperation {
 
     private Input generateComponentLocatorInput(List<Component> componentsList, File sourceDir) {
         return new Input(sourceDir.getAbsolutePath(), new JsonObject(), componentsList);
-    }
-
-
-    private void serializeInputToJson(File saveInputFileDir, Input libInput) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        String serializedLibInput = gson.toJson(libInput);
-        try {
-            File componentsSourceInputFile =  new File (saveInputFileDir, "components-source.json");
-            DetectFileUtils.writeToFile(componentsSourceInputFile, serializedLibInput);
-        } catch (IOException ex) {
-            logger.info("UH OH SPAGHETTIOO");
-//            throw new DetectUserFriendlyException("Failed to create component location analysis output file", ex, ExitCodeType.FAILURE_UNKNOWN_ERROR);
-        }
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
@@ -1,17 +1,22 @@
 package com.synopsys.integration.detect.workflow.componentlocationanalysis;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
+import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 import com.synopsys.integration.detect.workflow.bdio.BdioResult;
 import com.synopsys.integration.componentlocator.ComponentLocator;
 import com.synopsys.integration.componentlocator.beans.Component;
 import com.synopsys.integration.componentlocator.beans.Input;
+import com.synopsys.integration.detect.workflow.file.DetectFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.synopsys.integration.detect.workflow.report.util.ReportConstants;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -60,7 +65,7 @@ public class GenerateComponentLocationAnalysisOperation {
     }
 
     /**
-     * A ComponentLocatorException shoud be thrown in all cases where the output file is not created so that the
+     * A ComponentLocatorException should be thrown in all cases where the output file is not created so that the
      * appropriate status can be logged for the requested {@link GenerateComponentLocationAnalysisOperation}.
      */
     public void failComponentLocationAnalysisOperation() throws ComponentLocatorException {
@@ -69,6 +74,11 @@ public class GenerateComponentLocationAnalysisOperation {
 
     private void runComponentLocator(List<Component> componentsList, File scanOutputFolder, File projectSrcDir) throws ComponentLocatorException {
         Input componentLocatorInput = generateComponentLocatorInput(componentsList, projectSrcDir);
+
+        //
+        serializeInputToJson(scanOutputFolder, componentLocatorInput);
+        //
+
         String outputFilepath = scanOutputFolder + "/" + DETECT_OUTPUT_FILE_NAME;
 
         logger.info(ReportConstants.RUN_SEPARATOR);
@@ -84,5 +94,18 @@ public class GenerateComponentLocationAnalysisOperation {
 
     private Input generateComponentLocatorInput(List<Component> componentsList, File sourceDir) {
         return new Input(sourceDir.getAbsolutePath(), new JsonObject(), componentsList);
+    }
+
+
+    private void serializeInputToJson(File saveInputFileDir, Input libInput) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String serializedLibInput = gson.toJson(libInput);
+        try {
+            File componentsSourceInputFile =  new File (saveInputFileDir, "components-source.json");
+            DetectFileUtils.writeToFile(componentsSourceInputFile, serializedLibInput);
+        } catch (IOException ex) {
+            logger.info("UH OH SPAGHETTIOO");
+//            throw new DetectUserFriendlyException("Failed to create component location analysis output file", ex, ExitCodeType.FAILURE_UNKNOWN_ERROR);
+        }
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
@@ -19,6 +19,7 @@ import java.util.List;
  * save the resulting output file in the appropriate output subdirectory.
  */
 public class GenerateComponentLocationAnalysisOperation {
+    public static final String OPERATION_NAME = "Generating Component Location Analysis File for All Components";
     public static final String DETECT_OUTPUT_FILE_NAME = "components-with-locations.json";
     public static final String SUPPORTED_DETECTORS_LOG_MSG = "Component Location Analysis supports NPM, Maven, Gradle and NuGet detectors only.";
     private final BdioToComponentListTransformer bdioTransformer = new BdioToComponentListTransformer();
@@ -55,6 +56,14 @@ public class GenerateComponentLocationAnalysisOperation {
     public void locateComponentsForOnlineIntelligentScan() throws ComponentLocatorException {
         logger.info(ReportConstants.RUN_SEPARATOR);
         logger.info("Intelligent Scan mode does not support Component Location Analysis.");
+        failComponentLocationAnalysisOperation();
+    }
+
+    /**
+     * A ComponentLocatorException shoud be thrown in all cases where the output file is not created so that the
+     * appropriate status can be logged for the requested {@link GenerateComponentLocationAnalysisOperation}.
+     */
+    public void failComponentLocationAnalysisOperation() throws ComponentLocatorException {
         throw new ComponentLocatorException("Failed to generate Component Location Analysis file.");
     }
 
@@ -67,7 +76,7 @@ public class GenerateComponentLocationAnalysisOperation {
         if (status != 0) {
             logger.warn("Component Locator execution has failed.");
             logger.info(ReportConstants.RUN_SEPARATOR);
-            throw new ComponentLocatorException("Failed to generate Component Location Analysis file.");
+            failComponentLocationAnalysisOperation();
         }
         logger.info("Component Location Analysis file saved at: {}", outputFilepath);
         logger.info(ReportConstants.RUN_SEPARATOR);

--- a/src/test/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperationIT.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperationIT.java
@@ -27,7 +27,7 @@ public class GenerateComponentLocationAnalysisOperationIT {
 
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
-            dockerAssertions.successfulOperation("Generate Component Location Analysis File for All Components");
+            dockerAssertions.successfulOperation("Generating Component Location Analysis File for All Components");
         }
     }
     @Test
@@ -41,7 +41,7 @@ public class GenerateComponentLocationAnalysisOperationIT {
 
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
-            dockerAssertions.successfulOperation("Generate Component Location Analysis File for Reported Components");
+            dockerAssertions.successfulOperation("Generating Component Location Analysis File for Reported Components");
         }
     }
 }


### PR DESCRIPTION
Throw exception and fail Component Location Analysis in all cases where the output file cannot be generated (unsupported detectors, unsupported scan mode, empty rapid results, etc).

This is necessary so that the exception thrown is handled by Operation Runner Wrapper and the Detect scan is successful regardless. 