### PR TITLE
Fix for IDETECT-3994

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
@@ -64,7 +64,6 @@ public class GenerateComponentLocationAnalysisOperation {
             logger.info(ReportConstants.RUN_SEPARATOR);
             logger.info("Component Location Analysis requires a BDIO file with at least one component. Skipping location analysis.");
             failComponentLocationAnalysisOperation();
-
         }
     }
 
@@ -97,7 +96,6 @@ public class GenerateComponentLocationAnalysisOperation {
     }
 
     private void runComponentLocator(List<Component> componentsList, File scanOutputFolder, File projectSrcDir) throws ComponentLocatorException, DetectUserFriendlyException {
-     
         Input componentLocatorInput = generateComponentLocatorInput(componentsList, projectSrcDir);
         String outputFilepath = scanOutputFolder + "/" + LOCATOR_OUTPUT_FILE_NAME;
         if (logger.isDebugEnabled()) {

--- a/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
@@ -58,7 +58,14 @@ public class GenerateComponentLocationAnalysisOperation {
      */
     public void locateComponentsForOfflineDetectorScan(BdioResult bdio, File scanOutputFolder, File projectSrcDir) throws ComponentLocatorException, DetectUserFriendlyException {
         List<Component> componentsList = bdioTransformer.transformBdioToComponentList(bdio);
-        runComponentLocator(componentsList, scanOutputFolder, projectSrcDir);
+        if(!componentsList.isEmpty())
+            runComponentLocator(componentsList, scanOutputFolder, projectSrcDir);
+        else {
+            logger.info(ReportConstants.RUN_SEPARATOR);
+            logger.info("Component Location Analysis requires a BDIO file with at least one component. Skipping location analysis.");
+            failComponentLocationAnalysisOperation();
+
+        }
     }
 
     public void locateComponentsForOnlineIntelligentScan() throws ComponentLocatorException {
@@ -90,6 +97,7 @@ public class GenerateComponentLocationAnalysisOperation {
     }
 
     private void runComponentLocator(List<Component> componentsList, File scanOutputFolder, File projectSrcDir) throws ComponentLocatorException, DetectUserFriendlyException {
+     
         Input componentLocatorInput = generateComponentLocatorInput(componentsList, projectSrcDir);
         String outputFilepath = scanOutputFolder + "/" + LOCATOR_OUTPUT_FILE_NAME;
         if (logger.isDebugEnabled()) {


### PR DESCRIPTION
# Description

Addresses the issue reported here - IDETECT-3994

Handles scenario when bdio codelocations count is returned greater than zero but component list is empty (no dependency type listed in bdio file)
