### PR TITLE
Ensure detector scan is explicitly mentioned

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -512,7 +512,7 @@ public class OperationRunner {
             } else {
                 Set<Component> componentsSet = new ScanResultToComponentListTransformer().transformScanResultToComponentList(rapidFullResults);
                 if (componentsSet.isEmpty()) {
-                    failComponentLocationAnalysisOperationTask("Component Location Analysis requires at least one dependency in Rapid/Stateless Scan results. Skipping location analysis.");
+                    failComponentLocationAnalysisOperationTask("Component Location Analysis requires at least one dependency in Rapid/Stateless Detector Scan results. Skipping location analysis.");
                 } else {
                     auditLog.namedPublic(
                             OPERATION_NAME,


### PR DESCRIPTION
# Description

Ensure detector scan is explicitly mentioned when no dependencies are associated with detector scan

