### PR TITLE
upgrade blackduck common version

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.3'
+gradle.ext.blackDuckCommonVersion='66.2.5'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
This gets us a new blackduck-common and blackduck-common-api to work with BD 2023.4.2 and some of its new v6 endpoints.