### PR TITLE
feat: Include non-zero subprocess exit code in status reason. (IDETECT-3879)

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -8,6 +8,7 @@
 * The Ephemeral Scan Mode, that was deprecated in [solution_name] 8.x, has been removed in favor of Stateless Scan Mode. See the [Stateless Scans page](runningdetect/statelessscan.md) for further details.
 * npm 6, which was deprecated in [solution_name] 8.x, is no longer supported.
 * [solution_name] 7.x has entered end of support. See the [Product Maintenance, Support, and Service Schedule page](https://sig-product-docs.synopsys.com/bundle/blackduck-compatibility/page/topics/Support-and-Service-Schedule.html) for further details.
+* (IDETECT-3879) The detectors[N].statusDescription field of the status.json file will now contain the exit code of the detector subprocess command in cases when the code is non-zero.
 
 ### Resolved issues
 

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/report/DetectorStatusUtil.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/report/DetectorStatusUtil.java
@@ -36,7 +36,11 @@ public class DetectorStatusUtil {
         if (extraction.getError() instanceof ExecutableFailedException) {
             ExecutableFailedException failedException = (ExecutableFailedException) extraction.getError();
             if (failedException.hasReturnCode()) {
-                return "Failed to execute command, returned non-zero: " + failedException.getExecutableDescription();
+                return String.format(
+                    "Failed to execute command, returned non-zero (%d): %s",
+                    failedException.getReturnCode(),
+                    failedException.getExecutableDescription()
+                );
             } else if (failedException.getExecutableException() != null) {
                 return "Failed to execute command, " + failedException.getExecutableException().getMessage() + " : " + failedException.getExecutableDescription();
             } else {

--- a/src/test/java/com/synopsys/integration/detect/tool/detector/report/DetectorStatusUtilTest.java
+++ b/src/test/java/com/synopsys/integration/detect/tool/detector/report/DetectorStatusUtilTest.java
@@ -1,0 +1,28 @@
+package com.synopsys.integration.detect.tool.detector.report;
+
+import com.synopsys.integration.detectable.detectable.executable.ExecutableFailedException;
+import com.synopsys.integration.detectable.extraction.Extraction;
+
+import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DetectorStatusUtilTest {
+
+    @Test
+    void testGetFailedStatusReason_withNonZeroExitStatusCode() {
+        Extraction extraction = Mockito.mock(Extraction.class);
+        ExecutableFailedException exception = Mockito.mock(ExecutableFailedException.class);
+
+        Mockito.when(extraction.getError()).thenReturn(exception);
+
+        Mockito.when(exception.hasReturnCode()).thenReturn(true);
+        Mockito.when(exception.getReturnCode()).thenReturn(137);
+        Mockito.when(exception.getExecutableDescription()).thenReturn("some-exec-desc");
+
+        assertEquals(
+            "Failed to execute command, returned non-zero (137): some-exec-desc",
+            DetectorStatusUtil.getFailedStatusReason(extraction)
+        );
+    }
+}


### PR DESCRIPTION
When a detector fails due to an executable returning a non-zero status code the generated status.json file used to not contain the information about what the status code was.

This change includes the non-zero status code in the statusReason string for the failed detector.