### PR TITLE
remove de command line arg to create diagnostic zip and just use d

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -6,7 +6,7 @@
 
 * The `detect.diagnostic.extended` property, that was deprecated in [solution_name] 8.x, has been removed. `detect.diagnostic` can be used instead.
 * The Ephemeral Scan Mode, that was deprecated in [solution_name] 8.x, has been removed in favor of Stateless Scan Mode. See the [Stateless Scans page](runningdetect/statelessscan.md) for further details.
-* The -de command line option has been removed in favor -d as the two options have been identical since [solution_name] 8.x. 
+* The -de command line option has been removed in favor of -d as the two options have been identical since [solution_name] 8.x. 
 * npm 6, which was deprecated in [solution_name] 8.x, is no longer supported.
 * [solution_name] 7.x has entered end of support. See the [Product Maintenance, Support, and Service Schedule page](https://sig-product-docs.synopsys.com/bundle/blackduck-compatibility/page/topics/Support-and-Service-Schedule.html) for further details.
 * (IDETECT-3879) The detectors\[N\].statusReason field of the status.json file will now contain the exit code of the detector subprocess command in cases when the code is non-zero.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -6,6 +6,7 @@
 
 * The `detect.diagnostic.extended` property, that was deprecated in [solution_name] 8.x, has been removed. `detect.diagnostic` can be used instead.
 * The Ephemeral Scan Mode, that was deprecated in [solution_name] 8.x, has been removed in favor of Stateless Scan Mode. See the [Stateless Scans page](runningdetect/statelessscan.md) for further details.
+* The -de command line option has been removed in favor -d as the two options have been identical since [solution_name] 8.x. 
 * npm 6, which was deprecated in [solution_name] 8.x, is no longer supported.
 * [solution_name] 7.x has entered end of support. See the [Product Maintenance, Support, and Service Schedule page](https://sig-product-docs.synopsys.com/bundle/blackduck-compatibility/page/topics/Support-and-Service-Schedule.html) for further details.
 * (IDETECT-3879) The detectors\[N\].statusReason field of the status.json file will now contain the exit code of the detector subprocess command in cases when the code is non-zero.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -4,7 +4,7 @@
 
 ### Changed features
 
-* The `detect.diagnostic.extended` property and the -de command line option, that were deprecated in [solution_name] 8.x, have been removed. `detect.diagnostic`, and the command line option -d, can be used instead.
+* The `detect.diagnostic.extended` property and the -de command line option, that were deprecated in [solution_name] 8.x, have been removed. Use `detect.diagnostic`, and the command line option -d, instead.
 * The Ephemeral Scan Mode, that was deprecated in [solution_name] 8.x, has been removed in favor of Stateless Scan Mode. See the [Stateless Scans page](runningdetect/statelessscan.md) for further details.
 * npm 6, which was deprecated in [solution_name] 8.x, is no longer supported.
 * [solution_name] 7.x has entered end of support. See the [Product Maintenance, Support, and Service Schedule page](https://sig-product-docs.synopsys.com/bundle/blackduck-compatibility/page/topics/Support-and-Service-Schedule.html) for further details.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -4,9 +4,8 @@
 
 ### Changed features
 
-* The `detect.diagnostic.extended` property, that was deprecated in [solution_name] 8.x, has been removed. `detect.diagnostic` can be used instead.
+* The `detect.diagnostic.extended` property and the -de command line option, that were deprecated in [solution_name] 8.x, have been removed. `detect.diagnostic`, and the command line option -d, can be used instead.
 * The Ephemeral Scan Mode, that was deprecated in [solution_name] 8.x, has been removed in favor of Stateless Scan Mode. See the [Stateless Scans page](runningdetect/statelessscan.md) for further details.
-* The -de command line option has been removed in favor of -d as the two options have been identical since [solution_name] 8.x. 
 * npm 6, which was deprecated in [solution_name] 8.x, is no longer supported.
 * [solution_name] 7.x has entered end of support. See the [Product Maintenance, Support, and Service Schedule page](https://sig-product-docs.synopsys.com/bundle/blackduck-compatibility/page/topics/Support-and-Service-Schedule.html) for further details.
 * (IDETECT-3879) The detectors\[N\].statusReason field of the status.json file will now contain the exit code of the detector subprocess command in cases when the code is non-zero.

--- a/src/main/java/com/synopsys/integration/detect/configuration/help/DetectArgumentStateParser.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/help/DetectArgumentStateParser.java
@@ -16,9 +16,6 @@ public class DetectArgumentStateParser {
         boolean isDeprecatedHelp = parser.isArgumentPresent("-hd", "--helpDeprecated");
 
         boolean isDiagnostic = parser.isArgumentPresent("-d", "--diagnostic");
-        if (!isDiagnostic) {
-            isDiagnostic = parser.isArgumentPresent("-de", "--diagnostic");
-        }
 
         boolean isGenerateAirGapZip = parser.isArgumentPresent("-z", "--zip");
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/help/print/HelpPrinter.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/help/print/HelpPrinter.java
@@ -15,8 +15,7 @@ import com.synopsys.integration.detect.configuration.help.DetectArgumentState;
 public class HelpPrinter {
     private static final String DIAGNOSTIC_HELP_TEXT = "\nDiagnostics mode:\n\n" +
         "In diagnostics mode, Detect will produce a diagnostics zip file that contains a collection of intermediate and output files\n" +
-        "that can be very useful for troubleshooting. Extended diagnostics mode writes additional files to the diagnostics zip file.\n" +
-        "Invoke diagnostics mode by adding -d (diagnostics mode) or -de (extended diagnostics mode) to the command line.\n" +
+        "that can be very useful for troubleshooting. Invoke diagnostics mode by adding -d to the command line.\n" +
         "The path to the generated diagnostics file can be found in the log (look for: \"Diagnostics file created at: ...\").\n" +
         "The diagnostics file can be large, so you may want to generate it only when you will actually use it.\n";
 


### PR DESCRIPTION
In Detect 8 there is no difference between -de (extended diagnostic zip) and -d. Removing -de in favor of -d