### PR TITLE
Use relative workspace and process all types of dependencies

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
@@ -126,14 +126,14 @@ public class NpmCliParser {
                     .map(JsonPrimitive::getAsString)
                     .orElse(null);
             
-            if (combinedPackageJson.getConvertedWorkspaces() != null && possibleWorkspaceDependency != null) {
+            if (combinedPackageJson.getRelativeWorkspaces() != null && possibleWorkspaceDependency != null) {
                 // workspaces under the root resolve as file../<path to workspace> 
                 // remove that and see if any absolute workspace paths have this subpath
                 String convertedPossibleWorkspaceDependency =
-                        possibleWorkspaceDependency.replace("file:..", "");
+                        possibleWorkspaceDependency.replace("file:../", "");
                 
                 directWorkspaceDependency = 
-                        combinedPackageJson.getConvertedWorkspaces().stream().anyMatch(workspace -> workspace.contains(convertedPossibleWorkspaceDependency));
+                        combinedPackageJson.getRelativeWorkspaces().stream().anyMatch(workspace -> workspace.equals(convertedPossibleWorkspaceDependency));
             }
 
             populateChildren(graph, child, children, directWorkspaceDependency, combinedPackageJson);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -138,6 +138,9 @@ public class NpmDependencyConverter {
                 if (packageLockPackage.peerDependencies != null) {
                     packageLockPackage.dependencies.putAll(packageLockPackage.peerDependencies);
                 }
+                if (packageLockPackage.optionalDependencies != null) {
+                    packageLockPackage.dependencies.putAll(packageLockPackage.optionalDependencies);
+                } 
             }
             
             // Look for any relationships previously nested in the dependencies object prior to

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -21,7 +21,6 @@ import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmReq
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.PackageLock;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.PackageLockPackage;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.CombinedPackageJson;
-import com.synopsys.integration.detectable.detectables.npm.packagejson.model.PackageJson;
 
 public class NpmDependencyConverter {
     private final ExternalIdFactory externalIdFactory;
@@ -68,12 +67,6 @@ public class NpmDependencyConverter {
 
         for (Map.Entry<String, PackageLockPackage> packageEntry : packages.entrySet()) {
             String packageName = packageEntry.getKey();
-            // TODO debug
-            if (packageName.equals("packages/react-components")
-                    || packageName.equals("@mdx-js/mdx")
-                    || packageName.equals("@babel/core")) {
-                System.out.println("");
-            }
             PackageLockPackage packageLockDependency = packageEntry.getValue();
 
             NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer);
@@ -124,12 +117,11 @@ public class NpmDependencyConverter {
             return;
         }
                 
-        for(String packageName : packageLock.packages.keySet()) { 
-            
-            // TODO do for everything or just workspaces? 
-            // Fix up requires. In the dependencies object requires is just a dump of all dependencies +
-            // devDependencies + peerDependencies. This happens regardless of filtering. We need to reconstruct 
-            // this requires type which is now packages/dependencies instead of dependencies/requires
+        for(String packageName : packageLock.packages.keySet()) {  
+            // We need to reconstruct the new packages/dependencies setup to look like the old dependencies/requires 
+            // setup so the later graph construction works. This is just a dump of all dependencies + devDependencies 
+            // + peerDependencies + the new optionalDependences. This happens regardless of filtering with 
+            // detect.npm.dependency.types.excluded.
             PackageLockPackage packageLockPackage = packageLock.packages.get(packageName);
             if (packageLockPackage.dependencies != null) {
                 if (packageLockPackage.devDependencies != null) {
@@ -149,13 +141,6 @@ public class NpmDependencyConverter {
             // before loading data into packageLock. This character is not allowed in npm package names and
             // indicates we should link up this set of packages.
             if (packageName.contains("*")) { 
-                if (packageName.equals("packages/react-components*@mdx-js/mdx*@babel/core")) {
-                    String breakHere = "";
-                }
-                if (packageName.equals("packages/react-components*@mdx-js/mdx")) {
-                    String breakHere = "";
-                }
-                
                 // This packageName contains one or more *'s indicating a parent/child relationship.
                 // The parent will be the portion of the package name up to and not including the final *.
                 PackageLockPackage parentPackage = 
@@ -172,25 +157,10 @@ public class NpmDependencyConverter {
                 packagesToRemove.add(packageName);
             }
         }
-                
+            
         // Now that they are processed, get rid of any packages containing a parent/child relationship. 
         // This makes the final packages structure more like the previous dependencies structure so most of the
         // detector code does not need to be altered to support npm 9 and later.
         packageLock.packages.keySet().removeAll(packagesToRemove);
-        
-        // TODO debug code
-        for(String packageName : packageLock.packages.keySet()) { 
-            if (packageName.equals("packages/react-components")) {
-                PackageLockPackage parentPackage = 
-                        packageLock.packages.get(packageName);
-                for(String child1Name : parentPackage.packages.keySet()) { 
-                    if (child1Name.equals("@mdx-js/mdx")) {
-                        PackageLockPackage child1Package = 
-                                parentPackage.packages.get(child1Name); 
-                        System.out.println("");
-                    }
-                }
-            }
-        }
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/PackageLockPackage.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/PackageLockPackage.java
@@ -12,6 +12,12 @@ public class PackageLockPackage {
     @SerializedName("dependencies")
     public Map<String, String> dependencies;
     
+    @SerializedName("devDependencies")
+    public Map<String, String> devDependencies;
+    
+    @SerializedName("peerDependencies")
+    public Map<String, String> peerDependencies;
+    
     @SerializedName("workspaces")
     public List<String> workspaces;
     

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/PackageLockPackage.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/model/PackageLockPackage.java
@@ -18,6 +18,9 @@ public class PackageLockPackage {
     @SerializedName("peerDependencies")
     public Map<String, String> peerDependencies;
     
+    @SerializedName("optionalDependencies")
+    public Map<String, String> optionalDependencies;
+    
     @SerializedName("workspaces")
     public List<String> workspaces;
     

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -1,6 +1,5 @@
 package com.synopsys.integration.detectable.detectables.npm.lockfile.parse;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -88,8 +87,7 @@ public class NpmLockfileGraphTransformer {
         if (!shouldIncludeDependency(npmDependency)) {
             return;
         }
-        
-        // TODO check all code paths some callers still sending absolute
+
         // add workspaces as direct dependencies
         if (workspaces != null && !StringUtils.isBlank(npmDependency.getName()) &&
                 workspaces.stream().anyMatch(x -> x.equals(npmDependency.getName()))) {
@@ -101,19 +99,11 @@ public class NpmLockfileGraphTransformer {
                 dependencyGraph.addChildrenToRoot(workspaceDependency);
             }
         } else {
-        
-            // TODO is it okay to do this again if the workspace triggered it above?
             npmDependency.getRequires().forEach(required -> {
-                if (required.getName().equals("node-notifier")) {
-                    System.out.println("");
-                }
-                logger.trace(String.format("Required package: %s of version: %s", required.getName(),
-                        required.getFuzzyVersion()));
-                Dependency resolved = lookupDependency(required.getName(), npmDependency, npmProject,
-                        externalDependencies);
+                logger.trace(String.format("Required package: %s of version: %s", required.getName(), required.getFuzzyVersion()));
+                Dependency resolved = lookupDependency(required.getName(), npmDependency, npmProject, externalDependencies);
                 if (resolved != null) {
-                    logger.trace(String.format("Found package: %s with version: %s", resolved.getName(),
-                            resolved.getVersion()));
+                    logger.trace(String.format("Found package: %s with version: %s", resolved.getName(), resolved.getVersion()));
                     dependencyGraph.addChildWithParent(resolved, npmDependency);
                 } else {
                     logger.debug("No resolved dependency found for required package: {}", required.getName());
@@ -151,9 +141,6 @@ public class NpmLockfileGraphTransformer {
 
     private Dependency firstDependencyWithName(List<NpmDependency> dependencies, String name) {
         for (NpmDependency current : dependencies) {
-            if (name.equals("react-scripts")) {
-                System.out.println("");
-            }
             if (current.getName().equals(name)) {
                 return current;
             }
@@ -165,17 +152,5 @@ public class NpmLockfileGraphTransformer {
         return (!packageLockDependency.isDevDependency() && !packageLockDependency.isPeerDependency()) // If the type is not dev or peer, we always want to include it.
             || (packageLockDependency.isDevDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.DEV))
             || (packageLockDependency.isPeerDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.PEER));
-    }
-    
-    class DependencyComparator implements Comparator<NpmDependency> {
-
-        @Override
-        public int compare(NpmDependency o1, NpmDependency o2) {
-                NpmDependency one = (NpmDependency) o1;
-                NpmDependency two = (NpmDependency) o2;
-                // TODO Auto-generated method stub
-                return one.getName().compareTo(two.getName());
-        }
-        
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -1,6 +1,5 @@
 package com.synopsys.integration.detectable.detectables.npm.lockfile.parse;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -38,31 +38,31 @@ public class NpmLockfileGraphTransformer {
 
             //First we will recreate the graph from the resolved npm dependencies
             for (NpmDependency resolved : project.getResolvedDependencies()) {
-                if (resolved.getName().contains("react-components")) {
+                if (resolved.getName().contains("@jest/reporters")) {
                     System.out.println("");
                     
-                    // TODO debug
-                    
-                    for (NpmDependency dependency : resolved.getDependencies()) {
-                        //System.out.println(dependency.getName());
-                        // TODO go after child dependencies until run out of them then go after requires
-                        List<NpmDependency> dependencies = dependency.getDependencies();
-                        Collections.sort(dependencies, new DependencyComparator());
-                        for (NpmDependency childDependency1 : dependencies) {
-                           // System.out.println(childDependency1.getName());
-                            List<NpmDependency> child1Dependencies = childDependency1.getDependencies();
-                            Collections.sort(child1Dependencies, new DependencyComparator());
-                            for (NpmDependency childDependency2: child1Dependencies) {
-                                System.out.println(childDependency2.getName());
-                            }
-                        }
-                    }
-                    
-                    for (NpmRequires requires : resolved.getRequires()) {
-                        System.out.println(requires.getName() + ": " + requires.getFuzzyVersion());
-                    }
-                    
-                    
+//                    // TODO debug
+//                    
+//                    for (NpmDependency dependency : resolved.getDependencies()) {
+//                        //System.out.println(dependency.getName());
+//                        // TODO go after child dependencies until run out of them then go after requires
+//                        List<NpmDependency> dependencies = dependency.getDependencies();
+//                        Collections.sort(dependencies, new DependencyComparator());
+//                        for (NpmDependency childDependency1 : dependencies) {
+//                           // System.out.println(childDependency1.getName());
+//                            List<NpmDependency> child1Dependencies = childDependency1.getDependencies();
+//                            Collections.sort(child1Dependencies, new DependencyComparator());
+//                            for (NpmDependency childDependency2: child1Dependencies) {
+//                                System.out.println(childDependency2.getName());
+//                            }
+//                        }
+//                    }
+//                    
+//                    for (NpmRequires requires : resolved.getRequires()) {
+//                        System.out.println(requires.getName() + ": " + requires.getFuzzyVersion());
+//                    }
+//                    
+//                    
                 }
                 transformTreeToGraph(resolved, project, dependencyGraph, externalDependencies, workspaces);
             }
@@ -126,20 +126,26 @@ public class NpmLockfileGraphTransformer {
                 Dependency workspaceDependency = lookupDependency(required.getName(), npmDependency, npmProject, externalDependencies);
                 dependencyGraph.addChildrenToRoot(workspaceDependency);
             }
-            
-        }
+        } else {
         
-        // TODO is it okay to do this again if the workspace triggered it above?
-        npmDependency.getRequires().forEach(required -> {
-            logger.trace(String.format("Required package: %s of version: %s", required.getName(), required.getFuzzyVersion()));
-            Dependency resolved = lookupDependency(required.getName(), npmDependency, npmProject, externalDependencies);
-            if (resolved != null) {
-                logger.trace(String.format("Found package: %s with version: %s", resolved.getName(), resolved.getVersion()));
-                dependencyGraph.addChildWithParent(resolved, npmDependency);
-            } else {
-                logger.debug("No resolved dependency found for required package: {}", required.getName());
-            }
-        });
+            // TODO is it okay to do this again if the workspace triggered it above?
+            npmDependency.getRequires().forEach(required -> {
+                if (required.getName().equals("node-notifier")) {
+                    System.out.println("");
+                }
+                logger.trace(String.format("Required package: %s of version: %s", required.getName(),
+                        required.getFuzzyVersion()));
+                Dependency resolved = lookupDependency(required.getName(), npmDependency, npmProject,
+                        externalDependencies);
+                if (resolved != null) {
+                    logger.trace(String.format("Found package: %s with version: %s", resolved.getName(),
+                            resolved.getVersion()));
+                    dependencyGraph.addChildWithParent(resolved, npmDependency);
+                } else {
+                    logger.debug("No resolved dependency found for required package: {}", required.getName());
+                }
+            });
+        }
 
         npmDependency.getDependencies().forEach(child -> transformTreeToGraph(child, npmProject, dependencyGraph, externalDependencies, workspaces));
     }
@@ -171,6 +177,9 @@ public class NpmLockfileGraphTransformer {
 
     private Dependency firstDependencyWithName(List<NpmDependency> dependencies, String name) {
         for (NpmDependency current : dependencies) {
+            if (name.equals("react-scripts")) {
+                System.out.println("");
+            }
             if (current.getName().equals(name)) {
                 return current;
             }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -38,32 +38,6 @@ public class NpmLockfileGraphTransformer {
 
             //First we will recreate the graph from the resolved npm dependencies
             for (NpmDependency resolved : project.getResolvedDependencies()) {
-                if (resolved.getName().contains("@jest/reporters")) {
-                    System.out.println("");
-                    
-//                    // TODO debug
-//                    
-//                    for (NpmDependency dependency : resolved.getDependencies()) {
-//                        //System.out.println(dependency.getName());
-//                        // TODO go after child dependencies until run out of them then go after requires
-//                        List<NpmDependency> dependencies = dependency.getDependencies();
-//                        Collections.sort(dependencies, new DependencyComparator());
-//                        for (NpmDependency childDependency1 : dependencies) {
-//                           // System.out.println(childDependency1.getName());
-//                            List<NpmDependency> child1Dependencies = childDependency1.getDependencies();
-//                            Collections.sort(child1Dependencies, new DependencyComparator());
-//                            for (NpmDependency childDependency2: child1Dependencies) {
-//                                System.out.println(childDependency2.getName());
-//                            }
-//                        }
-//                    }
-//                    
-//                    for (NpmRequires requires : resolved.getRequires()) {
-//                        System.out.println(requires.getName() + ": " + requires.getFuzzyVersion());
-//                    }
-//                    
-//                    
-                }
                 transformTreeToGraph(resolved, project, dependencyGraph, externalDependencies, workspaces);
             }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
@@ -5,6 +5,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +22,7 @@ import com.synopsys.integration.bdio.model.externalid.ExternalId;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.NpmDependencyConverter;
+import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmDependency;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmProject;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.PackageLock;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.result.NpmPackagerResult;
@@ -60,16 +65,53 @@ public class NpmLockfilePackager {
         
         NpmProject project = dependencyConverter.convertLockFile(packageLock, combinedPackageJson);
         
+        for (NpmDependency dependency : project.getResolvedDependencies()) {
+            //System.out.println(dependency.getName());
+            // TODO go after child dependencies until run out of them then go after requires
+            List<NpmDependency> dependencies = dependency.getDependencies();
+            Collections.sort(dependencies, new DependencyComparator());
+            for (NpmDependency childDependency1 : dependencies) {
+               // System.out.println(childDependency1.getName());
+                List<NpmDependency> child1Dependencies = childDependency1.getDependencies();
+                Collections.sort(child1Dependencies, new DependencyComparator());
+                for (NpmDependency childDependency2: child1Dependencies) {
+                    System.out.println(childDependency2.getName());
+                }
+            }
+        }
+        
         DependencyGraph dependencyGraph = graphTransformer.transform(packageLock, project, externalDependencies, 
-                combinedPackageJson == null ? null : combinedPackageJson.getConvertedWorkspaces());
+                combinedPackageJson == null ? null : combinedPackageJson.getRelativeWorkspaces());
         ExternalId projectId = projectIdTransformer.transform(combinedPackageJson, packageLock);
         CodeLocation codeLocation = new CodeLocation(dependencyGraph, projectId);
         return new NpmPackagerResult(projectId.getName(), projectId.getVersion(), codeLocation);
     }
 
     public String removePathInfoFromPackageName(String lockFileText) {
-        List<String> searchList = new ArrayList<>(Arrays.asList("/node_modules/", "node_modules/"));
-        List<String> replaceList = new ArrayList<>(Arrays.asList("*", ""));
+        List<String> searchList = new LinkedList<>();
+        List<String> replaceList = new LinkedList<>();
+        
+        // If we have workspaces, make sure to strip those off as well
+        //"packages/react-components/node_modules/@mdx-js/mdx/node_modules/@babel/core"
+//        if (rootJsonPath != null && absoluteWorkpacePaths != null && absoluteWorkpacePaths.size() > 0) {
+//            String projectRoot = rootJsonPath.substring(0, rootJsonPath.lastIndexOf("/") + 1); 
+//            
+//            for (String absoluteWorkspacePath : absoluteWorkpacePaths) {
+//                int rootIndex = absoluteWorkspacePath.indexOf(projectRoot);
+//                if (rootIndex != -1) {
+//                    int packageStartIndex = rootIndex + projectRoot.length();
+//                    if (packageStartIndex < absoluteWorkspacePath.length()) {
+//                        searchList.add(absoluteWorkspacePath.substring(packageStartIndex) + "/node_modules/");
+//                        replaceList.add("");
+//                    }
+//                }
+//            }
+//        }
+        
+        searchList.add("node_modules/");
+        replaceList.add("");
+        searchList.add("/node_modules/");
+        replaceList.add("*");
 
         // Flatten the lock file, removing node_modules from the package names. The code expects them in this
         // format as it aligns with the previous dependencies section of the lock file that was removed in npm9. 
@@ -79,5 +121,17 @@ public class NpmLockfilePackager {
                 searchList.toArray(new String[searchList.size()]), 
                 replaceList.toArray(new String[replaceList.size()]));
         return lockFileText;
+    }
+    
+    class DependencyComparator implements Comparator<NpmDependency> {
+
+        @Override
+        public int compare(NpmDependency o1, NpmDependency o2) {
+                NpmDependency one = (NpmDependency) o1;
+                NpmDependency two = (NpmDependency) o2;
+                // TODO Auto-generated method stub
+                return one.getName().compareTo(two.getName());
+        }
+        
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
@@ -65,21 +65,6 @@ public class NpmLockfilePackager {
         
         NpmProject project = dependencyConverter.convertLockFile(packageLock, combinedPackageJson);
         
-//        for (NpmDependency dependency : project.getResolvedDependencies()) {
-//            //System.out.println(dependency.getName());
-//            // TODO go after child dependencies until run out of them then go after requires
-//            List<NpmDependency> dependencies = dependency.getDependencies();
-//            Collections.sort(dependencies, new DependencyComparator());
-//            for (NpmDependency childDependency1 : dependencies) {
-//               // System.out.println(childDependency1.getName());
-//                List<NpmDependency> child1Dependencies = childDependency1.getDependencies();
-//                Collections.sort(child1Dependencies, new DependencyComparator());
-//                for (NpmDependency childDependency2: child1Dependencies) {
-//                    System.out.println(childDependency2.getName());
-//                }
-//            }
-//        }
-        
         DependencyGraph dependencyGraph = graphTransformer.transform(packageLock, project, externalDependencies, 
                 combinedPackageJson == null ? null : combinedPackageJson.getRelativeWorkspaces());
         ExternalId projectId = projectIdTransformer.transform(combinedPackageJson, packageLock);
@@ -88,30 +73,8 @@ public class NpmLockfilePackager {
     }
 
     public String removePathInfoFromPackageName(String lockFileText) {
-        List<String> searchList = new LinkedList<>();
-        List<String> replaceList = new LinkedList<>();
-        
-        // If we have workspaces, make sure to strip those off as well
-        //"packages/react-components/node_modules/@mdx-js/mdx/node_modules/@babel/core"
-//        if (rootJsonPath != null && absoluteWorkpacePaths != null && absoluteWorkpacePaths.size() > 0) {
-//            String projectRoot = rootJsonPath.substring(0, rootJsonPath.lastIndexOf("/") + 1); 
-//            
-//            for (String absoluteWorkspacePath : absoluteWorkpacePaths) {
-//                int rootIndex = absoluteWorkspacePath.indexOf(projectRoot);
-//                if (rootIndex != -1) {
-//                    int packageStartIndex = rootIndex + projectRoot.length();
-//                    if (packageStartIndex < absoluteWorkspacePath.length()) {
-//                        searchList.add(absoluteWorkspacePath.substring(packageStartIndex) + "/node_modules/");
-//                        replaceList.add("");
-//                    }
-//                }
-//            }
-//        }
-        
-        searchList.add("node_modules/");
-        replaceList.add("");
-        searchList.add("/node_modules/");
-        replaceList.add("*");
+        List<String> searchList = new ArrayList<>(Arrays.asList("/node_modules/", "node_modules/"));
+        List<String> replaceList = new ArrayList<>(Arrays.asList("*", ""));
 
         // Flatten the lock file, removing node_modules from the package names. The code expects them in this
         // format as it aligns with the previous dependencies section of the lock file that was removed in npm9. 
@@ -121,17 +84,5 @@ public class NpmLockfilePackager {
                 searchList.toArray(new String[searchList.size()]), 
                 replaceList.toArray(new String[replaceList.size()]));
         return lockFileText;
-    }
-    
-    class DependencyComparator implements Comparator<NpmDependency> {
-
-        @Override
-        public int compare(NpmDependency o1, NpmDependency o2) {
-                NpmDependency one = (NpmDependency) o1;
-                NpmDependency two = (NpmDependency) o2;
-                // TODO Auto-generated method stub
-                return one.getName().compareTo(two.getName());
-        }
-        
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
@@ -1,18 +1,10 @@
 package com.synopsys.integration.detectable.detectables.npm.lockfile.parse;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,14 +14,11 @@ import com.synopsys.integration.bdio.model.externalid.ExternalId;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.NpmDependencyConverter;
-import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmDependency;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.NpmProject;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.model.PackageLock;
 import com.synopsys.integration.detectable.detectables.npm.lockfile.result.NpmPackagerResult;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.CombinedPackageJson;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.CombinedPackageJsonExtractor;
-import com.synopsys.integration.detectable.detectables.npm.packagejson.PackageJsonExtractor;
-import com.synopsys.integration.detectable.detectables.npm.packagejson.model.PackageJson;
 import com.synopsys.integration.util.NameVersion;
 
 public class NpmLockfilePackager {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
@@ -65,20 +65,20 @@ public class NpmLockfilePackager {
         
         NpmProject project = dependencyConverter.convertLockFile(packageLock, combinedPackageJson);
         
-        for (NpmDependency dependency : project.getResolvedDependencies()) {
-            //System.out.println(dependency.getName());
-            // TODO go after child dependencies until run out of them then go after requires
-            List<NpmDependency> dependencies = dependency.getDependencies();
-            Collections.sort(dependencies, new DependencyComparator());
-            for (NpmDependency childDependency1 : dependencies) {
-               // System.out.println(childDependency1.getName());
-                List<NpmDependency> child1Dependencies = childDependency1.getDependencies();
-                Collections.sort(child1Dependencies, new DependencyComparator());
-                for (NpmDependency childDependency2: child1Dependencies) {
-                    System.out.println(childDependency2.getName());
-                }
-            }
-        }
+//        for (NpmDependency dependency : project.getResolvedDependencies()) {
+//            //System.out.println(dependency.getName());
+//            // TODO go after child dependencies until run out of them then go after requires
+//            List<NpmDependency> dependencies = dependency.getDependencies();
+//            Collections.sort(dependencies, new DependencyComparator());
+//            for (NpmDependency childDependency1 : dependencies) {
+//               // System.out.println(childDependency1.getName());
+//                List<NpmDependency> child1Dependencies = childDependency1.getDependencies();
+//                Collections.sort(child1Dependencies, new DependencyComparator());
+//                for (NpmDependency childDependency2: child1Dependencies) {
+//                    System.out.println(childDependency2.getName());
+//                }
+//            }
+//        }
         
         DependencyGraph dependencyGraph = graphTransformer.transform(packageLock, project, externalDependencies, 
                 combinedPackageJson == null ? null : combinedPackageJson.getRelativeWorkspaces());

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJson.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJson.java
@@ -12,6 +12,7 @@ public class CombinedPackageJson {
     private String version;
     private List<String> workspaces = new ArrayList<>();
     private List<String> convertedWorkspaces = new ArrayList<>();
+    private List<String> relativeWorkspaces = new ArrayList<>();
     
     private MultiValuedMap<String, String> dependencies;
     private MultiValuedMap<String, String> devDependencies;
@@ -49,6 +50,24 @@ public class CombinedPackageJson {
 
     public void setConvertedWorkspaces(List<String> convertedWorkspaces) {
         this.convertedWorkspaces = convertedWorkspaces;
+    }
+    
+    public List<String> getRelativeWorkspaces() {        
+        return relativeWorkspaces;
+    }
+    
+    public void setRelativeWorkspaces(String rootJsonPath) {
+        String projectRoot = rootJsonPath.substring(0, rootJsonPath.lastIndexOf("/") + 1);
+
+        for (String absoluteWorkspacePath : convertedWorkspaces) {
+            int rootIndex = absoluteWorkspacePath.indexOf(projectRoot);
+            if (rootIndex != -1) {
+                int packageStartIndex = rootIndex + projectRoot.length();
+                if (packageStartIndex < absoluteWorkspacePath.length()) {
+                    relativeWorkspaces.add(absoluteWorkspacePath.substring(packageStartIndex));
+                }
+            }
+        }
     }
 
     public String getName() {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJson.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJson.java
@@ -10,7 +10,6 @@ public class CombinedPackageJson {
     
     private String name;
     private String version;
-    private List<String> workspaces = new ArrayList<>();
     private List<String> convertedWorkspaces = new ArrayList<>();
     private List<String> relativeWorkspaces = new ArrayList<>();
     
@@ -34,14 +33,6 @@ public class CombinedPackageJson {
 
     public MultiValuedMap<String, String> getPeerDependencies() {
         return peerDependencies;
-    }
-
-    public List<String> getWorkspaces() {
-        return workspaces;
-    }
-
-    public void setWorkspaces(List<String> workspaces) {
-        this.workspaces = workspaces;
     }
     
     public List<String> getConvertedWorkspaces() {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJson.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJson.java
@@ -10,7 +10,6 @@ public class CombinedPackageJson {
     
     private String name;
     private String version;
-    private List<String> convertedWorkspaces = new ArrayList<>();
     private List<String> relativeWorkspaces = new ArrayList<>();
     
     private MultiValuedMap<String, String> dependencies;
@@ -35,30 +34,8 @@ public class CombinedPackageJson {
         return peerDependencies;
     }
     
-    public List<String> getConvertedWorkspaces() {
-        return convertedWorkspaces;
-    }
-
-    public void setConvertedWorkspaces(List<String> convertedWorkspaces) {
-        this.convertedWorkspaces = convertedWorkspaces;
-    }
-    
     public List<String> getRelativeWorkspaces() {        
         return relativeWorkspaces;
-    }
-    
-    public void setRelativeWorkspaces(String rootJsonPath) {
-        String projectRoot = rootJsonPath.substring(0, rootJsonPath.lastIndexOf("/") + 1);
-
-        for (String absoluteWorkspacePath : convertedWorkspaces) {
-            int rootIndex = absoluteWorkspacePath.indexOf(projectRoot);
-            if (rootIndex != -1) {
-                int packageStartIndex = rootIndex + projectRoot.length();
-                if (packageStartIndex < absoluteWorkspacePath.length()) {
-                    relativeWorkspaces.add(absoluteWorkspacePath.substring(packageStartIndex));
-                }
-            }
-        }
     }
 
     public String getName() {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
@@ -65,7 +65,7 @@ public class CombinedPackageJsonExtractor {
                 if (!Files.exists(workspaceJsonPath)) {
                     continue;
                 } else {
-                    combinedPackageJson.getConvertedWorkspaces().add(convertedWorkspace);
+                    addRelativeWorkspace(combinedPackageJson, projectRoot, convertedWorkspace);
                 }
                 
                 String workspaceJsonString 
@@ -81,11 +81,30 @@ public class CombinedPackageJsonExtractor {
                     combinedPackageJson.getPeerDependencies().putAll(workspacePackageJson.peerDependencies);
                 }
             }
-            // TODO maybe just carry this and get rid of the absolute one but there are a few callers to check
-            combinedPackageJson.setRelativeWorkspaces(rootJsonPath);
         }
         
         return combinedPackageJson;
+    }
+
+
+    /**
+     * Takes an absolute path to a workspace and converts it to a relative one for
+     * future comparisons with contents of the package-lock.json file.
+     * 
+     * @param combinedPackageJson the combined package json we are constructing
+     * @param projectRoot         Path to the root of the project
+     * @param convertedWorkspace  An absolute path to a workspace with wildcards
+     *                            replaced
+     */
+    private void addRelativeWorkspace(CombinedPackageJson combinedPackageJson, String projectRoot,
+            String convertedWorkspace) {
+        int rootIndex = convertedWorkspace.indexOf(projectRoot);
+        if (rootIndex != -1) {
+            int packageStartIndex = rootIndex + projectRoot.length();
+            if (packageStartIndex < convertedWorkspace.length()) {
+                combinedPackageJson.getRelativeWorkspaces().add(convertedWorkspace.substring(packageStartIndex));
+            }
+        }
     }
 
     /**

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
@@ -43,7 +43,6 @@ public class CombinedPackageJsonExtractor {
         // Take fields that will be related to BD projects from the root project.json
         combinedPackageJson.setName(packageJson.name);
         combinedPackageJson.setVersion(packageJson.version);
-        combinedPackageJson.setWorkspaces(packageJson.workspaces);
         
         // Add dependencies from the root of the project
         combinedPackageJson.getDependencies().putAll(packageJson.dependencies);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
@@ -82,6 +82,8 @@ public class CombinedPackageJsonExtractor {
                     combinedPackageJson.getPeerDependencies().putAll(workspacePackageJson.peerDependencies);
                 }
             }
+            // TODO maybe just carry this and get rid of the absolute one but there are a few callers to check
+            combinedPackageJson.setRelativeWorkspaces(rootJsonPath);
         }
         
         return combinedPackageJson;

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
@@ -45,6 +45,21 @@ public class NpmDependencyConverterTest {
         validatePackageLinkage(lockFileText);
     }
     
+    @Test
+    public void testAllDependenciesAddedToDependencies() {
+        String lockFileText = FunctionalTestFiles.asString("/npm/packages-linkage-test/package-lock-multiple-deps.json");
+        lockFileText = packager.removePathInfoFromPackageName(lockFileText);
+        PackageLock packageLock = gson.fromJson(lockFileText, PackageLock.class);
+        converter.linkPackagesDependencies(packageLock);
+        
+        PackageLockPackage testPackage = packageLock.packages.get("testpackage");
+        
+        Assertions.assertNotNull(testPackage);
+        Assertions.assertTrue(testPackage.dependencies.containsKey("dep1"));
+        Assertions.assertTrue(testPackage.dependencies.containsKey("dev1"));
+        Assertions.assertTrue(testPackage.dependencies.containsKey("peer1"));
+    }
+    
     private void validatePackageLinkage(String lockFileText) {
         lockFileText = packager.removePathInfoFromPackageName(lockFileText);   
         PackageLock packageLock = gson.fromJson(lockFileText, PackageLock.class);  

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/CombinedPackageJsonExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/CombinedPackageJsonExtractorTest.java
@@ -72,10 +72,10 @@ public class CombinedPackageJsonExtractorTest {
         Assertions.assertTrue(assertMapsEqual(expectedDependencies, combinedPackageJson.getDependencies()));
         
         // Test we correctly discovered all workspaces
-        Assertions.assertTrue(combinedPackageJson.getConvertedWorkspaces().contains(projectRoot + "packages/a"));
-        Assertions.assertTrue(combinedPackageJson.getConvertedWorkspaces().contains(projectRoot + "packages/b"));
-        Assertions.assertTrue(combinedPackageJson.getConvertedWorkspaces().contains(projectRoot + "packages/a/c"));
-        Assertions.assertTrue(combinedPackageJson.getConvertedWorkspaces().contains(projectRoot + "packages/b/d"));
+        Assertions.assertTrue(combinedPackageJson.getRelativeWorkspaces().contains("packages/a"));
+        Assertions.assertTrue(combinedPackageJson.getRelativeWorkspaces().contains("packages/b"));
+        Assertions.assertTrue(combinedPackageJson.getRelativeWorkspaces().contains("packages/a/c"));
+        Assertions.assertTrue(combinedPackageJson.getRelativeWorkspaces().contains("packages/b/d"));
     }
     
     private boolean assertMapsEqual(MultiValuedMap<String, String> expectedMap, MultiValuedMap<String, String> actualMap) {

--- a/detectable/src/test/resources/detectables/functional/npm/packages-linkage-test/package-lock-multiple-deps.json
+++ b/detectable/src/test/resources/detectables/functional/npm/packages-linkage-test/package-lock-multiple-deps.json
@@ -1,0 +1,22 @@
+{
+  "name": "npmworkspace",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/testpackage": {
+      "name": "testpackage",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dep1": "1.0.0"
+      },
+      "devDependencies": {
+        "dev1": "1.0.0"
+      },
+      "peerDependencies": {
+        "peer1": "1.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This work improves a few things for certain cases:

1) It uses relative workspaces so we can directly compare these with what is in the package-lock.json. This means we aren't guessing if we are dealing with a workspace, we should know.

2) It groups together npm dependencies (per, dev, optional) so that they can be considered for inclusion in the project. The user can still strip them out with command line arguments but we now consider them.