### PR TITLE
add all flag when calling npm ls

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
@@ -56,7 +56,8 @@ public class NpmCliExtractor {
         List<String> exeArgs = new ArrayList<>();
         exeArgs.add("ls");
         exeArgs.add("-json");
-
+        exeArgs.add("--all");
+        
         Optional.ofNullable(npmArguments)
             .map(arg -> arg.split(" "))
             .ifPresent(additionalArguments -> exeArgs.addAll(Arrays.asList(additionalArguments)));


### PR DESCRIPTION
Starting with npm 7, npm ls does not return transitive dependencies unless the --all flag is used. This work adds the --all flag so that we can process things as we did in npm 6.