### PR TITLE
rework code to work with java 8

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -127,7 +128,7 @@ public class CombinedPackageJsonExtractor {
     
     private String replaceWildcards(String path, List<String> convertedWorkspaces) {        
         if (!path.contains("*")) {
-            convertedWorkspaces.add(Path.of(path).normalize().toString());
+            convertedWorkspaces.add(Paths.get(path).normalize().toString());
             return path;
         }
         


### PR DESCRIPTION
Current code makes use of a Path.of method that exists only in Java 11. Since Detect supports Java 8 we need to use something earlier. Switching to Paths.get instead.