### PR TITLE
change to npm forge for package json detector

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.detectable.detectables.npm.packagejson;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -70,7 +71,7 @@ public class PackageJsonExtractor {
 
     private List<Dependency> transformDependencies(MultiValuedMap<String, String> dependencies) {
         if (dependencies == null || dependencies.size() == 0) {
-            return Collections.emptyList();
+            return new ArrayList<>();
         }
         return dependencies.entries().stream()
             .map(entry -> entryToDependency(entry.getKey(), entry.getValue()))
@@ -78,7 +79,7 @@ public class PackageJsonExtractor {
     }
 
     private Dependency entryToDependency(String key, String value) {
-        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, key, value);
+        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, key, value);
         return new Dependency(externalId);
     }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
@@ -3,7 +3,6 @@ package com.synopsys.integration.detectable.detectables.npm.packagejson;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,7 +70,7 @@ public class PackageJsonExtractor {
 
     private List<Dependency> transformDependencies(MultiValuedMap<String, String> dependencies) {
         if (dependencies == null || dependencies.size() == 0) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
         return dependencies.entries().stream()
             .map(entry -> entryToDependency(entry.getKey(), entry.getValue()))

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/functional/PackageJsonExtractorFunctionalTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/functional/PackageJsonExtractorFunctionalTest.java
@@ -39,12 +39,12 @@ public class PackageJsonExtractorFunctionalTest {
     @BeforeEach
     void setUp() {
         ExternalIdFactory externalIdFactory = new ExternalIdFactory();
-        testDep1 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "name1", "version1");
-        testDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "name2", "version2");
-        testDevDep1 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "nameDev1", "versionDev1");
-        testDevDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "nameDev2", "versionDev2");
-        testPeerDep1 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "namePeer1", "versionPeer1");
-        testPeerDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "namePeer2", "versionPeer2");
+        testDep1 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "name1", "version1");
+        testDep2 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "name2", "version2");
+        testDevDep1 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "nameDev1", "versionDev1");
+        testDevDep2 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "nameDev2", "versionDev2");
+        testPeerDep1 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "namePeer1", "versionPeer1");
+        testPeerDep2 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "namePeer2", "versionPeer2");
 
         packageJsonFile = new File("src/test/resources/detectables/functional/npm/package.json");
     }
@@ -62,7 +62,7 @@ public class PackageJsonExtractorFunctionalTest {
         CodeLocation codeLocation = extraction.getCodeLocations().get(0);
         DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
 
-        GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootDependency(testDep1);
         graphAssert.hasRootDependency(testDep2);
         graphAssert.hasNoDependency(testDevDep1);
@@ -96,7 +96,7 @@ public class PackageJsonExtractorFunctionalTest {
         CodeLocation codeLocation = extraction.getCodeLocations().get(0);
         DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
 
-        GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootDependency(testDep1);
         graphAssert.hasRootDependency(testDep2);
         graphAssert.hasRootDependency(testPeerDep1);

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
@@ -33,10 +33,10 @@ class PackageJsonExtractorTest {
     @BeforeEach
     void setUp() {
         ExternalIdFactory externalIdFactory = new ExternalIdFactory();
-        testDep1 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "name1", "version1");
-        testDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "name2", "version2");
-        testDevDep1 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "nameDev1", "versionDev1");
-        testDevDep2 = externalIdFactory.createNameVersionExternalId(Forge.RUBYGEMS, "nameDev2", "versionDev2");
+        testDep1 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "name1", "version1");
+        testDep2 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "name2", "version2");
+        testDevDep1 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "nameDev1", "versionDev1");
+        testDevDep2 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "nameDev2", "versionDev2");
     }
 
     private PackageJsonExtractor createExtractor(NpmDependencyType... excludedTypes) {
@@ -53,7 +53,7 @@ class PackageJsonExtractorTest {
         CodeLocation codeLocation = extraction.getCodeLocations().get(0);
         DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
 
-        GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootDependency(testDep1);
         graphAssert.hasRootDependency(testDep2);
         graphAssert.hasNoDependency(testDevDep1);
@@ -69,7 +69,7 @@ class PackageJsonExtractorTest {
         CodeLocation codeLocation = extraction.getCodeLocations().get(0);
         DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
 
-        GraphAssert graphAssert = new GraphAssert(Forge.RUBYGEMS, dependencyGraph);
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, dependencyGraph);
         graphAssert.hasRootDependency(testDep1);
         graphAssert.hasRootDependency(testDep2);
         graphAssert.hasRootDependency(testDevDep1);


### PR DESCRIPTION
The npm package json parser creates external IDs using the rubygem forge. This is rather odd as it should be using the npmjs forge. This PR switches the code to use that so we are able to appropriately match npm packages to KB results.