### PR TITLE
Revert "optimize how detect project clone categories are sent"

### DIFF
--- a/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumallnone/list/AllNoneEnumListBase.java
+++ b/configuration/src/main/java/com/synopsys/integration/configuration/property/types/enumallnone/list/AllNoneEnumListBase.java
@@ -76,22 +76,6 @@ public class AllNoneEnumListBase<E extends Enum<E>, B extends Enum<B>> implement
             return toPresentValues();
         }
     }
-    
-    /**
-     * This returns null if the properties' value is set to ALL values of the Enum.
-     * It returns an empty array if the value is set to NONE.
-     * This indicates all to Black Duck and streamlines things for newer endpoints.
-     * Older endpoints should use representedValues.
-     */
-    public List<B> representedValuesStreamlined() {
-        if (containsNone()) {
-            return new ArrayList<>();
-        } else if (containsAll()) {
-            return null;
-        } else {
-            return toPresentValues();
-        }
-    }
 
     public Set<B> representedValueSet() {
         return new HashSet<>(representedValues());

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -326,7 +326,7 @@ public class DetectConfigurationFactory {
         Integer projectTier = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_TIER);
         String projectDescription = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_DESCRIPTION);
         String projectVersionNotes = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NOTES);
-        List<ProjectCloneCategoriesType> cloneCategories = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).representedValuesStreamlined();
+        List<ProjectCloneCategoriesType> cloneCategories = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES).representedValues();
         Boolean projectLevelAdjustments = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_LEVEL_ADJUSTMENTS);
         Boolean forceProjectVersionUpdate = detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_VERSION_UPDATE);
         String projectVersionNickname = detectConfiguration.getNullableValue(DetectProperties.DETECT_PROJECT_VERSION_NICKNAME);

--- a/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
+++ b/src/test/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactoryTests.java
@@ -3,7 +3,6 @@ package com.synopsys.integration.detect.configuration;
 import static com.synopsys.integration.detect.configuration.DetectConfigurationFactoryTestUtils.factoryOf;
 import static com.synopsys.integration.detect.configuration.DetectConfigurationFactoryTestUtils.spyFactoryOf;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,14 +11,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectCloneCategoriesType;
 import com.synopsys.integration.common.util.Bdo;
 import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.synopsys.integration.detect.configuration.enumeration.DefaultDetectorSearchExcludedDirectories;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detect.configuration.enumeration.RapidCompareMode;
 import com.synopsys.integration.detect.tool.signaturescanner.BlackDuckSignatureScannerOptions;
-import com.synopsys.integration.detect.workflow.blackduck.project.options.ProjectSyncOptions;
 import com.synopsys.integration.rest.credentials.Credentials;
 
 public class DetectConfigurationFactoryTests {
@@ -90,43 +87,5 @@ public class DetectConfigurationFactoryTests {
         BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = factory.createBlackDuckSignatureScannerOptions();
 
         Assertions.assertTrue(RapidCompareMode.BOM_COMPARE_STRICT.equals(blackDuckSignatureScannerOptions.getBomCompareMode()));
-    }
-    
-    @Test
-    public void testAllCloneCategories() {
-        DetectConfigurationFactory factory = factoryOf(Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, "ALL"));
-        
-        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions();
-
-        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
-        
-        Assertions.assertTrue(cloneCategories == null);
-    }
-    
-    @Test
-    public void testNoCloneCategories() {
-        DetectConfigurationFactory factory = factoryOf(Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, "NONE"));
-        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions();
-
-        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
-        
-        Assertions.assertTrue(cloneCategories.isEmpty()); 
-    }
-    
-    @Test
-    public void testSpecificCloneCategories() {
-        DetectConfigurationFactory factory = factoryOf(
-                Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, 
-                        ProjectCloneCategoriesType.CUSTOM_FIELD_DATA.toString() 
-                        + "," 
-                        + ProjectCloneCategoriesType.DEEP_LICENSE.toString()
-                ));
-        
-        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions();
-
-        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
-        
-        Assertions.assertTrue(cloneCategories.contains(ProjectCloneCategoriesType.CUSTOM_FIELD_DATA));
-        Assertions.assertTrue(cloneCategories.contains(ProjectCloneCategoriesType.DEEP_LICENSE));
     }
 }


### PR DESCRIPTION
Reverting this as we can only make calls like this for project creation. We'll reapply this fix once BlackDuck can handle updates as well.