### PR TITLE
stop using Path of so Java 8 can run Detect

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
@@ -52,7 +52,7 @@ public class CombinedPackageJsonExtractor {
         
         if (packageJson.workspaces != null && rootJsonPath != null) {
             // If there are workspaces there are additional package.json's we need to parse
-            String projectRoot = rootJsonPath.substring(0, rootJsonPath.lastIndexOf("/") + 1);
+            String projectRoot = rootJsonPath.substring(0, rootJsonPath.lastIndexOf(File.separator) + 1);
             
             List<String> convertedWorkspaces = 
                     convertWorkspaceWildcards(projectRoot, packageJson.workspaces);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
@@ -59,7 +59,7 @@ public class CombinedPackageJsonExtractor {
             
             for(String convertedWorkspace : convertedWorkspaces) {
                 Path workspaceJsonPath =
-                        Path.of(convertedWorkspace + "/package.json").normalize();
+                        Paths.get(convertedWorkspace + "/package.json").normalize();
                 
                 // We are looking for a package.json but they aren't always where we expect them.
                 // Don't try to read a file that doesn't exist.


### PR DESCRIPTION
Path.of appears in Java 11, since we support back to Java 8 for runtime, we should not use it.