### PR TITLE
fix windows path issues with npm

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
@@ -103,7 +103,11 @@ public class CombinedPackageJsonExtractor {
         if (rootIndex != -1) {
             int packageStartIndex = rootIndex + projectRoot.length();
             if (packageStartIndex < convertedWorkspace.length()) {
-                combinedPackageJson.getRelativeWorkspaces().add(convertedWorkspace.substring(packageStartIndex));
+                // Replace any \'s with /'s so we can properly compare workspace names with what is in 
+                // the package-lock.json file. The \\\\ looks strange as replaceAll uses a regex and we
+                // need to escape the \ that escapes the \.
+                String relativeWorkspace = convertedWorkspace.substring(packageStartIndex).replaceAll("\\\\", "/");
+                combinedPackageJson.getRelativeWorkspaces().add(relativeWorkspace);
             }
         }
     }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/CombinedPackageJsonExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/CombinedPackageJsonExtractorTest.java
@@ -1,6 +1,8 @@
 package com.synopsys.integration.detectable.detectables.npm.packagejson.unit;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map.Entry;
 
@@ -21,12 +23,12 @@ public class CombinedPackageJsonExtractorTest {
         CombinedPackageJsonExtractor combinedPackageJsonExtractor = new CombinedPackageJsonExtractor(gson);
                
         String packageJsonText = FunctionalTestFiles.asString("/npm/workspace-test/package-wildcard.json");
-        String projectRoot = System.getProperty("user.dir") + "/src/test/resources/detectables/functional/npm/workspace-test/";
-        
+        String rootPackageJson = System.getProperty("user.dir") + "/src/test/resources/detectables/functional/npm/workspace-test/package-wildcard.json";
+        rootPackageJson = Paths.get(rootPackageJson).toString();
         CombinedPackageJson combinedPackageJson = 
-                combinedPackageJsonExtractor.constructCombinedPackageJson(projectRoot + "package-wildcard.json", packageJsonText);
+                combinedPackageJsonExtractor.constructCombinedPackageJson(rootPackageJson, packageJsonText);
         
-        validateDiscoveredWorkspaceInformation(projectRoot, combinedPackageJson);     
+        validateDiscoveredWorkspaceInformation(combinedPackageJson);     
     }
     
     @Test
@@ -35,12 +37,12 @@ public class CombinedPackageJsonExtractorTest {
         CombinedPackageJsonExtractor combinedPackageJsonExtractor = new CombinedPackageJsonExtractor(gson);
                
         String packageJsonText = FunctionalTestFiles.asString("/npm/workspace-test/package-wildcard-and-relative.json");
-        String projectRoot = System.getProperty("user.dir") + "/src/test/resources/detectables/functional/npm/workspace-test/";
-        
+        String rootPackageJson = System.getProperty("user.dir") + "/src/test/resources/detectables/functional/npm/workspace-test/package-wildcard-and-relative.json";
+        rootPackageJson = Paths.get(rootPackageJson).toString();
         CombinedPackageJson combinedPackageJson = 
-                combinedPackageJsonExtractor.constructCombinedPackageJson(projectRoot + "package-wildcard-and-relative.json", packageJsonText);
+                combinedPackageJsonExtractor.constructCombinedPackageJson(rootPackageJson + "", packageJsonText);
         
-        validateDiscoveredWorkspaceInformation(projectRoot, combinedPackageJson);     
+        validateDiscoveredWorkspaceInformation(combinedPackageJson);     
     }
     
     @Test
@@ -49,15 +51,15 @@ public class CombinedPackageJsonExtractorTest {
         CombinedPackageJsonExtractor combinedPackageJsonExtractor = new CombinedPackageJsonExtractor(gson);
                
         String packageJsonText = FunctionalTestFiles.asString("/npm/workspace-test/package-relative.json");
-        String projectRoot = System.getProperty("user.dir") + "/src/test/resources/detectables/functional/npm/workspace-test/";
-        
+        String rootPackageJson = System.getProperty("user.dir") + "/src/test/resources/detectables/functional/npm/workspace-test/package-relative.json";
+        rootPackageJson = Paths.get(rootPackageJson).toString();
         CombinedPackageJson combinedPackageJson = 
-                combinedPackageJsonExtractor.constructCombinedPackageJson(projectRoot + "package-relative.json", packageJsonText);
+                combinedPackageJsonExtractor.constructCombinedPackageJson(rootPackageJson, packageJsonText);
         
-        validateDiscoveredWorkspaceInformation(projectRoot, combinedPackageJson);     
+        validateDiscoveredWorkspaceInformation(combinedPackageJson);     
     }
 
-    private void validateDiscoveredWorkspaceInformation(String projectRoot, CombinedPackageJson combinedPackageJson) {
+    private void validateDiscoveredWorkspaceInformation(CombinedPackageJson combinedPackageJson) {
         // Test basic information
         Assertions.assertTrue(combinedPackageJson.getName().equals("npmworkspace"));
         Assertions.assertTrue(combinedPackageJson.getVersion().equals("1.0.0"));

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/CombinedPackageJsonExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/CombinedPackageJsonExtractorTest.java
@@ -40,7 +40,7 @@ public class CombinedPackageJsonExtractorTest {
         String rootPackageJson = System.getProperty("user.dir") + "/src/test/resources/detectables/functional/npm/workspace-test/package-wildcard-and-relative.json";
         rootPackageJson = Paths.get(rootPackageJson).toString();
         CombinedPackageJson combinedPackageJson = 
-                combinedPackageJsonExtractor.constructCombinedPackageJson(rootPackageJson + "", packageJsonText);
+                combinedPackageJsonExtractor.constructCombinedPackageJson(rootPackageJson, packageJsonText);
         
         validateDiscoveredWorkspaceInformation(combinedPackageJson);     
     }


### PR DESCRIPTION
A few tests were failing when running them on windows. This improves / and \ handling during our comparison code so it is more platform independent