### PR TITLE
Container scanning - Add container scan success/failure status to status summaries

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1000,6 +1000,16 @@ public class OperationRunner {
         exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_BLACKDUCK_FEATURE_ERROR, "BINARY_SCAN");
     }
 
+    public void publishContainerFailure(Exception e) {
+        logger.error("Container scan failure: {}", e.getMessage());
+        statusEventPublisher.publishStatusSummary(Status.forTool(DetectTool.CONTAINER_SCAN, StatusType.FAILURE));
+        exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_BLACKDUCK_FEATURE_ERROR, "CONTAINER_SCAN");
+    }
+
+    public void publishContainerSuccess() {
+        statusEventPublisher.publishStatusSummary(Status.forTool(DetectTool.CONTAINER_SCAN, StatusType.SUCCESS));
+    }
+
     public void publishImpactFailure(Exception e) {
         logger.error("Impact analysis failure: {}", e.getMessage());
         statusEventPublisher.publishStatusSummary(Status.forTool(DetectTool.IMPACT_ANALYSIS, StatusType.FAILURE));


### PR DESCRIPTION
### Description
Adds the `CONTAINER_SCAN: <status>` to the "Detect Status" section in our CLI output by publishing the container scan status (SUCCESS/FAILURE) to the status summaries consumed by our Event System. 


In case of any exception during the container scan steps, we exit with exit code type as `FAILURE_BLACKDUCK_FEATURE_ERROR`.

### JIRA
IDETECT-4041