### PR TITLE
Container scanning - Refactor usage of existing API endpoints and minor logger updates

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1000,6 +1000,16 @@ public class OperationRunner {
         exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_BLACKDUCK_FEATURE_ERROR, "BINARY_SCAN");
     }
 
+    public void publishContainerFailure(Exception e) {
+        logger.error("Container scan failure: {}", e.getMessage());
+        statusEventPublisher.publishStatusSummary(Status.forTool(DetectTool.CONTAINER_SCAN, StatusType.FAILURE));
+        exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_BLACKDUCK_FEATURE_ERROR, "CONTAINER_SCAN");
+    }
+
+    public void publishContainerSuccess() {
+        statusEventPublisher.publishStatusSummary(Status.forTool(DetectTool.CONTAINER_SCAN, StatusType.SUCCESS));
+    }
+
     public void publishImpactFailure(Exception e) {
         logger.error("Impact analysis failure: {}", e.getMessage());
         statusEventPublisher.publishStatusSummary(Status.forTool(DetectTool.IMPACT_ANALYSIS, StatusType.FAILURE));

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -217,9 +217,9 @@ public class OperationRunner {
     private final OperationAuditLog auditLog;
     private static final int[] LIMITED_FIBONACCI_SEQUENCE = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55};
     private static final int MIN_POLLING_INTERVAL_THRESHOLD_IN_SECONDS = 5;
-    private static final String RAPID_SCAN_ENDPOINT = "/api/developer-scans";
-    private static final String RAPID_SCAN_CONTENT_TYPE = "application/vnd.blackducksoftware.scan-evidence-1+protobuf";
-    private static final String INTELLIGENT_SCAN_ENDPOINT = "/api/intelligent-persistence-scans";
+    private static final String DEVELOPER_SCAN_ENDPOINT = ApiDiscovery.DEVELOPER_SCANS_PATH.getPath();
+    private static final String DEVELOPER_SCAN_CONTENT_TYPE = "application/vnd.blackducksoftware.scan-evidence-1+protobuf";
+    private static final String INTELLIGENT_SCAN_ENDPOINT = ApiDiscovery.INTELLIGENT_PERSISTENCE_SCANS_PATH.getPath();
     private static final String INTELLIGENT_SCAN_CONTENT_TYPE = "application/vnd.blackducksoftware.intelligent-persistence-scan-3+protobuf";
 
     //Internal: Operation -> Action
@@ -362,14 +362,14 @@ public class OperationRunner {
         if (detectConfigurationFactory.createScanMode() == BlackduckScanMode.INTELLIGENT) {
             return INTELLIGENT_SCAN_ENDPOINT;
         }
-        return RAPID_SCAN_ENDPOINT;
+        return DEVELOPER_SCAN_ENDPOINT;
     }
 
     public String getScanServicePostContentType() {
         if (detectConfigurationFactory.createScanMode() == BlackduckScanMode.INTELLIGENT) {
             return INTELLIGENT_SCAN_CONTENT_TYPE;
         }
-        return RAPID_SCAN_CONTENT_TYPE;
+        return DEVELOPER_SCAN_CONTENT_TYPE;
     }
 
     public File downloadContainerImage(Gson gson, File downloadDirectory, String containerImageUri) throws DetectUserFriendlyException, IntegrationException, IOException {
@@ -477,7 +477,7 @@ public class OperationRunner {
         BlackDuckServicesFactory blackDuckServicesFactory = blackDuckRunData.getBlackDuckServicesFactory();
         BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
 
-        final String contentType = RAPID_SCAN_CONTENT_TYPE;
+        final String contentType = DEVELOPER_SCAN_CONTENT_TYPE;
         HttpUrl putUrl = new HttpUrl(blackDuckRunData.getBlackDuckServerConfig().getBlackDuckUrl().toString()
                 + "/api/developer-scans/" + bdScanId);
 


### PR DESCRIPTION
Refactoring to use the developer scan and intelligent persistent scan endpoints defined as constants in the [ApiDiscovery class](https://github.com/blackducksoftware/blackduck-common-api/blob/master/src/main/java/com/synopsys/integration/blackduck/api/generated/discovery/ApiDiscovery.java) of blackduck-common-api. This is to ensure we get our endpoints from blackduck-common-api and avoid having them defined as constants in Detect.
**Note:** blackduck-common-api doesn't include storage service API endpoints yet. Once Hub container scanning support is officially available, it would be nice to update blackduck-common-api to also include the storage service endpoints and pull them in Detect.