### PR TITLE
fix(binary-scan): Exit with code 11 if feature registration check fails

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
@@ -63,7 +63,7 @@ public class BinaryUploadOperation {
             return codeLocationCreationData;
         } catch (IntegrationException e) {
             statusEventPublisher.publishStatusSummary(new Status(STATUS_KEY, StatusType.FAILURE));
-            throw new DetectUserFriendlyException("Failed to upload binary scan file.", e, ExitCodeType.FAILURE_BLACKDUCK_CONNECTIVITY);
+            throw new DetectUserFriendlyException("Failed to upload binary scan file.", e, ExitCodeType.FAILURE_BLACKDUCK_FEATURE_ERROR);
         }
     }
 


### PR DESCRIPTION
### Description
When running a binary scan in the default Intelligent mode of Detect, there is a validation check on Hub during the binary file upload operation to confirm if Hub has a valid "Black Duck Binary Analysis" license registered.
If the license is invalid or not found, Hub responds with a "402 Payment required" status code. Detect catches this server exception however is currently exiting with the exit code 1.

Exit code 1 is FAILURE_BLACKDUCK_CONNECTIVITY that reads "Detect was unable to connect to Black Duck. Check your configuration and connection." which is meant for the initial BD connectivity check, not for license checks.
 
For feature registration checks, we should use exit code 11 i.e. FAILURE_BLACKDUCK_FEATURE_ERROR that reads "Detect encountered an error while attempting an operation on Black Duck. Ensure that your Black Duck version is compatible with this version of Detect, and that your Black Duck user account has the required roles."

### JIRA
IDETECT-4049