### PR TITLE
Update documents to point to detect9 instead of detect8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ Synopsys Detect scans code bases in your projects and folders to perform composi
 *Available from GitHub for Linux/MacOS by running:*
 
 ```bash
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh)
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh)
 ```
 
 *Available from GitHub for Windows by running in **command prompt**:*
 
 ```cmd
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect"
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect"
 ```
 
 *Available from GitHub for Windows/Linux by running in **powershell**:*
 ```powershell
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect
 ```
 
 For scripts, please see [Detect Scripts](https://github.com/synopsys-sig/synopsys-detect-scripts).

--- a/buildSrc/src/main/java/com/synopsys/integration/detect/docs/content/Terms.java
+++ b/buildSrc/src/main/java/com/synopsys/integration/detect/docs/content/Terms.java
@@ -8,8 +8,8 @@ public class Terms {
 
     public Terms() {
         termMap.put("solution_name", "Synopsys Detect");
-        termMap.put("script_repo_url_bash", "https://detect.synopsys.com/detect8.sh");
-        termMap.put("script_repo_url_powershell", "https://detect.synopsys.com/detect8.ps1");
+        termMap.put("script_repo_url_bash", "https://detect.synopsys.com/detect9.sh");
+        termMap.put("script_repo_url_powershell", "https://detect.synopsys.com/detect9.ps1");
         termMap.put("binary_repo_url_project", "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect");
         termMap.put("binary_repo_ui_url_project", "https://sig-repo.synopsys.com/ui/repos/tree/General/bds-integrations-release/com/synopsys/integration/synopsys-detect");
 		termMap.put("binary_repo_jenkins_url_project", "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/blackducksoftware/integration/blackduck-detect/");

--- a/documentation/keywords.ditamap
+++ b/documentation/keywords.ditamap
@@ -7,8 +7,8 @@
   <keydef keys="binary_repo_type"><topicmeta><keywords><keyword>Artifactory</keyword></keywords></topicmeta></keydef>
   <keydef keys="solution_name"><topicmeta><keywords><keyword>Synopsys Detect</keyword></keywords></topicmeta></keydef>
   <keydef keys="source_project_name"><topicmeta><keywords><keyword>synopsys-detect</keyword></keywords></topicmeta></keydef>
-  <keydef keys="bash_script_name"><topicmeta><keywords><keyword>detect8.sh</keyword></keywords></topicmeta></keydef>
-  <keydef keys="powershell_script_name"><topicmeta><keywords><keyword>detect8.ps1</keyword></keywords></topicmeta></keydef>
+  <keydef keys="bash_script_name"><topicmeta><keywords><keyword>detect9.sh</keyword></keywords></topicmeta></keydef>
+  <keydef keys="powershell_script_name"><topicmeta><keywords><keyword>detect9.ps1</keyword></keywords></topicmeta></keydef>
   <keydef keys="blackduck_product_name"><topicmeta><keywords><keyword>Black Duck</keyword></keywords></topicmeta></keydef>
   <keydef keys="coverity_product_name"><topicmeta><keywords><keyword>Coverity</keyword></keywords></topicmeta></keydef>
   <keydef keys="blackduck_signature_scanner_name"><topicmeta><keywords><keyword>Black Duck Signature Scanner</keyword></keywords></topicmeta></keydef>

--- a/documentation/src/main/markdown/configuring/commandline.md
+++ b/documentation/src/main/markdown/configuring/commandline.md
@@ -12,5 +12,5 @@ There is a space before and between each complete property setting, but there ar
 For example,
 to set property *detect.project.name*:
 ```
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.project.name=MyProject
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.project.name=MyProject
 ```

--- a/documentation/src/main/markdown/configuring/configfile.md
+++ b/documentation/src/main/markdown/configuring/configfile.md
@@ -11,7 +11,7 @@ For example, if you wanted to set property *detect.project.name* using a configu
 could do it as follows:
 ````
 echo "detect.project.name=myproject" > application.properties
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.source.path=/opt/projects/project1
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.source.path=/opt/projects/project1
 ````
 Because the configuration file has one of the file names that Spring looks for by default
 (in this case, application.properties) and exists in one of the locations

--- a/documentation/src/main/markdown/configuring/envvars.md
+++ b/documentation/src/main/markdown/configuring/envvars.md
@@ -7,7 +7,7 @@ is the property name converted to uppercase, with period characters (".") conver
 characters ("_"). For example:
 ```
 export DETECT_PROJECT_NAME=MyProject
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh)
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh)
 ```
 
 On Windows, the environment variable name can either be the original property
@@ -15,5 +15,5 @@ name, or the property name converted to uppercase with period characters (".") c
 characters ("_"). For example:
 ```
 $Env:DETECT_PROJECT_NAME = MyProject
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect"
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect"
 ```

--- a/documentation/src/main/markdown/configuring/profiles.md
+++ b/documentation/src/main/markdown/configuring/profiles.md
@@ -14,7 +14,7 @@ Populate it with property assignments as previously described.
 To select one or more profiles on the [solution_name] command line, assign the the comma-separated list of profiles
 to the Spring Boot property *spring.profiles.active*:
 ```
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --spring.profiles.active={profilename}
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --spring.profiles.active={profilename}
 ```
 
 This capability is provided by Spring Boot. For more information, refer to

--- a/documentation/src/main/markdown/gettingstarted/quickstart.md
+++ b/documentation/src/main/markdown/gettingstarted/quickstart.md
@@ -34,13 +34,13 @@ The command you run looks like this:
 On Linux or Mac:
 
 ````
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --blackduck.url={your Black Duck server URL} --blackduck.api.token={your Black Duck access token}
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --blackduck.url={your Black Duck server URL} --blackduck.api.token={your Black Duck access token}
 ````
 
 On Windows:
 
 ````
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect" --blackduck.url={your Black Duck server URL} --blackduck.api.token={your Black Duck access token}
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect" --blackduck.url={your Black Duck server URL} --blackduck.api.token={your Black Duck access token}
 ````
 
 The operations performed by [solution_name] depends on what it finds in your source directory.

--- a/documentation/src/main/markdown/gettingstarted/terms/properties.md
+++ b/documentation/src/main/markdown/gettingstarted/terms/properties.md
@@ -5,11 +5,11 @@ A property to which you assign a value is like a flag or a parameter on the comm
 When setting a property value, the property name is prefixed with two hyphens (--). 
 
 ````
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) <--property=value>
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) <--property=value>
 ````
 
 Example using properties to specify project name and [blackduck_product_name] URL:
 
 ````
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.project.name=MyProject --blackduck.url=https://blackduck.yourdomain.com
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.project.name=MyProject --blackduck.url=https://blackduck.yourdomain.com
 ````

--- a/documentation/src/main/markdown/gettingstarted/terms/script.md
+++ b/documentation/src/main/markdown/gettingstarted/terms/script.md
@@ -6,10 +6,10 @@ You download and run the latest version of [solution_name] using the following c
 
 Windows:
 ````
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect"
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect"
 ````
 
 Linux/MacOs:
 ````
-bash <(curl -s https://detect.synopsys.com/detect8.sh)
+bash <(curl -s https://detect.synopsys.com/detect9.sh)
 ````

--- a/documentation/src/main/markdown/integrations/bitbucket/bitbucketintegration.md
+++ b/documentation/src/main/markdown/integrations/bitbucket/bitbucketintegration.md
@@ -41,7 +41,7 @@ This section describes how to run [solution_name] with Bitbucket pipelines using
 3.	Add the following snippet to the `bitbucket-pipelines.yml` file:
 
 ```
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --blackduck.url="${BLACKDUCK_URL}" 
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --blackduck.url="${BLACKDUCK_URL}" 
 --blackduck.api.token="${BLACKDUCK_TOKEN}" --blackduck.trust.cert=true --<any other flags>
 ```
 
@@ -68,7 +68,7 @@ pipelines:
     - step:
         name: synopsys-detect
         script:
-          - bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --blackduck.url="${BLACKDUCK_URL}" --blackduck.api.token="${BLACKDUCK_TOKEN} --blackduck.trust.cert=true"
+          - bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --blackduck.url="${BLACKDUCK_URL}" --blackduck.api.token="${BLACKDUCK_TOKEN} --blackduck.trust.cert=true"
 ```
 
 <note type="note">Configure [solution_name] as a command after the code-build step as it relies on access to the code tree and the build environment.</note>
@@ -97,7 +97,7 @@ When you commit the modified YAML file, the build is triggered. After the pipeli
 4.	Add the following snippet to the `bitbucket-pipelines.yml` file:
 
 ```
-bash <(curl -s https://detect.synopsys.com/detect8.sh) 
+bash <(curl -s https://detect.synopsys.com/detect9.sh) 
 --blackduck.url="${BLACKDUCK_URL}" --blackduck.username="${BLACKDUCK_USERNAME}" 
 --blackduck.password="${BLACKDUCK_PASSWORD}" --blackduck.trust.cert=true --<any other flags>
 ```	
@@ -125,7 +125,7 @@ pipelines:
     - step:
         name: synopsys-detect
         script:
-          - bash <(curl -s https://detect.synopsys.com/detect8.sh) --blackduck.url="${BLACKDUCK_URL}" --blackduck.username="${BLACKDUCK_USERNAME}" --blackduck.password="${BLACKDUCK_PASSWORD}" --blackduck.hub.trust.cert=true 
+          - bash <(curl -s https://detect.synopsys.com/detect9.sh) --blackduck.url="${BLACKDUCK_URL}" --blackduck.username="${BLACKDUCK_USERNAME}" --blackduck.password="${BLACKDUCK_PASSWORD}" --blackduck.hub.trust.cert=true 
 ```
 	
 When you commit the modified YAML file, the build is triggered. After the pipeline build with [solution_name] completes, you can view the complete scan results in your [blackduck_product_name] instance. For additional information and properties for [solution_name], refer to [Detect properties](../../properties/all-properties.md) for more details.

--- a/documentation/src/main/markdown/integrations/gitlab/gitlabintegration.md
+++ b/documentation/src/main/markdown/integrations/gitlab/gitlabintegration.md
@@ -46,7 +46,7 @@ The recommended way of configuring [solution_name] from a GitLab pipeline is to
 	test:
 		stage: test
 		script:
-		- bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --blackduck.url="${HUB\_URL}" --blackduck.api.token={your Black Duck access token} --blackduck.trust.cert=true --<any other flags>
+		- bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --blackduck.url="${HUB\_URL}" --blackduck.api.token={your Black Duck access token} --blackduck.trust.cert=true --<any other flags>
     ~~~
 
 5.	Configure [solution_name] as a script build step. Otherwise, GitLab cannot enforce build changes influenced by [solution_name]. For example, checking for policy, failing builds according to policy, and others.
@@ -88,7 +88,7 @@ For improved security, Synopsys recommends a revocable API token, as described i
 	test:
 		stage: test
 		script:
-			- bash <(curl -s -L <https://detect.synopsys.com/detect8.sh>) --blackduck.url="${HUB\_URL}"  --blackduck.hub.username="${HUB\_USERNAME}" --blackduck.hub.password="${HUB\_PASSWORD}" --blackduck.api.token={your Black Duck access token} --blackduck.trust.cert=true --<any other flags>
+			- bash <(curl -s -L <https://detect.synopsys.com/detect9.sh>) --blackduck.url="${HUB\_URL}"  --blackduck.hub.username="${HUB\_USERNAME}" --blackduck.hub.password="${HUB\_PASSWORD}" --blackduck.api.token={your Black Duck access token} --blackduck.trust.cert=true --<any other flags>
     ~~~
 
 5.	Configure [solution_name] as a script build step. Otherwise, GitLab cannot enforce build changes influenced by [solution_name]. For example, checking for policy, failing builds according to policy, and others.

--- a/documentation/src/main/markdown/packagemgrs/bazel.md
+++ b/documentation/src/main/markdown/packagemgrs/bazel.md
@@ -162,7 +162,7 @@ maven_install repository rule:
 ````
 git clone https://github.com/bazelbuild/rules_jvm_external
 cd rules_jvm_external/
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.bazel.target='//tests/integration:ArtifactExclusionsTest'
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.bazel.target='//tests/integration:ArtifactExclusionsTest'
 ````
 
 ### haskell_cabal_library rule example
@@ -176,5 +176,5 @@ haskell_cabal_library repository rule:
 ````
 git clone https://github.com/tweag/rules_haskell.git
 cd rules_haskell/examples
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.bazel.target='//cat_hs/lib/args:args'
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.bazel.target='//cat_hs/lib/args:args'
 ````

--- a/documentation/src/main/markdown/packagemgrs/docker/intro.md
+++ b/documentation/src/main/markdown/packagemgrs/docker/intro.md
@@ -146,7 +146,7 @@ Suppose you need to set Docker Inspector's `service.timeout` value (the length o
 
 For example:
 ```
-./detect8.sh --detect.docker.image=ubuntu:latest --detect.docker.passthrough.service.timeout=480000
+./detect9.sh --detect.docker.image=ubuntu:latest --detect.docker.passthrough.service.timeout=480000
 ```
 
 You can set any [docker_inspector_name] property using this method.
@@ -160,7 +160,7 @@ If you have been running the Black Duck Docker Inspector directly, and need to t
 invoking [docker_inspector_name] from [solution_name], here are some recommendations likely to 
 help you make the transition:
 
-1. If you run Black Duck Docker Inspector with `blackduck-docker-inspector.sh`, replace `blackduck-docker-inspector.sh` in your command line with `detect8.sh` (adjust the [solution_name] major version as necessary).
+1. If you run Black Duck Docker Inspector with `blackduck-docker-inspector.sh`, replace `blackduck-docker-inspector.sh` in your command line with `detect9.sh` (adjust the [solution_name] major version as necessary).
 See the [solution_name] documentation for information on where to get the [solution_name] script.
 1. If you run Black Duck Docker Inspector with `java -jar blackduck-docker-inspector-{version}.jar`, replace `blackduck-docker-inspector-{version}.jar` in your command line with `synopsys-detect-{version}.jar`.
 See the [solution_name] documentation for information on where to get the [solution_name] .jar.

--- a/documentation/src/main/markdown/packagemgrs/docker/isolatingapplication.md
+++ b/documentation/src/main/markdown/packagemgrs/docker/isolatingapplication.md
@@ -11,7 +11,7 @@ Find the last element in the *RootFS.Layers* array. This is the platform top lay
 *sha256:b079b3fa8d1b4b30a71a6e81763ed3da1327abaf0680ed3ed9f00ad1d5de5e7c*.
 Set the value of the Docker Inspector property docker.platform.top.layer.id to the platform top layer ID. For example:
 ````
-./detect8.sh ... --detect.docker.image={your application image} --detect.docker.platform.top.layer.id=sha256:b079b3fa8d1b4b30a71a6e81763ed3da1327abaf0680ed3ed9f00ad1d5de5e7c
+./detect9.sh ... --detect.docker.image={your application image} --detect.docker.platform.top.layer.id=sha256:b079b3fa8d1b4b30a71a6e81763ed3da1327abaf0680ed3ed9f00ad1d5de5e7c
 ````
 In this mode, there may be some loss in match accuracy from the [blackduck_signature_scanner_name] because, in this scenario, the [blackduck_signature_scanner_name] may be deprived of some contextual information, such as the operating system files that enable it to determine the Linux distribution, and that that may negatively affect its ability to accurately identify components.
 

--- a/documentation/src/main/markdown/packagemgrs/docker/properties.md
+++ b/documentation/src/main/markdown/packagemgrs/docker/properties.md
@@ -6,7 +6,7 @@ For example, suppose you need to set Docker Inspector's `service.timeout` value 
 
 For example:
 ```
-./detect8.sh --detect.docker.image=ubuntu:latest --detect.docker.passthrough.service.timeout=480000
+./detect9.sh --detect.docker.image=ubuntu:latest --detect.docker.passthrough.service.timeout=480000
 ```
 
 You can set any Docker Inspector property using this method.

--- a/documentation/src/main/markdown/packagemgrs/sbt.md
+++ b/documentation/src/main/markdown/packagemgrs/sbt.md
@@ -45,5 +45,5 @@ and the SBT detector runs.
 You can apply the workaround suggested in that github issue using the
 *detect.sbt.arguments* property:
 ```
-./detect8.sh --detect.sbt.arguments="-Djline.terminal=jline.UnsupportedTerminal"
+./detect9.sh --detect.sbt.arguments="-Djline.terminal=jline.UnsupportedTerminal"
 ```

--- a/documentation/src/main/markdown/runningdetect/basics/choosingrunmethod.md
+++ b/documentation/src/main/markdown/runningdetect/basics/choosingrunmethod.md
@@ -14,7 +14,7 @@ Each script limits itself to a specific [solution_name] major version (for examp
 this default behavior.
 
 | [solution_name] version | Script Type | Script Name |
-|----| --- |-------------|
+|---| --- |-------------|
 | 9 | Bash | detect9.sh  |
 | 9 | PowerShell | detect9.ps1 |
 | 8 | Bash | detect8.sh  |

--- a/documentation/src/main/markdown/runningdetect/basics/choosingrunmethod.md
+++ b/documentation/src/main/markdown/runningdetect/basics/choosingrunmethod.md
@@ -14,7 +14,7 @@ Each script limits itself to a specific [solution_name] major version (for examp
 this default behavior.
 
 | [solution_name] version | Script Type | Script Name |
-|-------------------------| --- |-------------|
+|----| --- |-------------|
 | 9 | Bash | detect9.sh  |
 | 9 | PowerShell | detect9.ps1 |
 | 8 | Bash | detect8.sh  |

--- a/documentation/src/main/markdown/runningdetect/basics/choosingrunmethod.md
+++ b/documentation/src/main/markdown/runningdetect/basics/choosingrunmethod.md
@@ -14,15 +14,15 @@ Each script limits itself to a specific [solution_name] major version (for examp
 this default behavior.
 
 | [solution_name] version | Script Type | Script Name |
-| --- | --- | --- |
-| 8 | Bash | detect8.sh |
+|-------------------------| --- |-------------|
+| 9 | Bash | detect9.sh  |
+| 9 | PowerShell | detect9.ps1 |
+| 8 | Bash | detect8.sh  |
 | 8 | PowerShell | detect8.ps1 |
-| 7 | Bash | detect7.sh |
-| 7 | PowerShell | detect7.ps1 |
 
 Instuctions and examples in this documentation that reference the scripts assume you are running
-[solution_name] 8, so refer to detect8.sh or detect8.ps1. To run [solution_name] 7 instead,
-substitute detect7.sh for detect8.sh, or detect7.ps1 for detect8.ps1.
+[solution_name] 9, so refer to detect9.sh or detect9.ps1. To run [solution_name] 8 instead,
+substitute detect8.sh for detect9.sh, or detect8.ps1 for detect9.ps1.
 
 The primary reason to run the [solution_name] .jar directly is that this method provides
 direct control over the exact [solution_name] version;

--- a/documentation/src/main/markdown/runningdetect/basics/runningjar.md
+++ b/documentation/src/main/markdown/runningdetect/basics/runningjar.md
@@ -19,5 +19,5 @@ You can use the [solution_name] Bash script ([bash_script_name]) to download the
 
 ````
 export DETECT_DOWNLOAD_ONLY=1
-./detect8.sh
+./detect9.sh
 ````

--- a/documentation/src/main/markdown/runningdetect/basics/runningscript.md
+++ b/documentation/src/main/markdown/runningdetect/basics/runningscript.md
@@ -16,13 +16,13 @@ On Linux or Mac, execute the [solution_name] script ([bash_script_name], which i
 To download and run the latest version of [solution_name] in a single command:
 
 ````
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh)
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh)
 ````
 
 Append any command line arguments to the end, separated by spaces. For example:
 
 ````
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --blackduck.url=https://blackduck.mydomain.com --blackduck.api.token=myaccesstoken
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --blackduck.url=https://blackduck.mydomain.com --blackduck.api.token=myaccesstoken
 ````
 
 See [Quoting and escaping shell script arguments](../../scripts/script-escaping-special-characters.md) for details about quoting and escaping arguments.
@@ -31,14 +31,14 @@ See [Quoting and escaping shell script arguments](../../scripts/script-escaping-
 
 ````
 export DETECT_LATEST_RELEASE_VERSION={Synopsys Detect version}
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh)
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh)
 ````
 
 For example, to run [solution_name] version 7.13.2:
 
 ````
 export DETECT_LATEST_RELEASE_VERSION=7.13.2
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh)
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh)
 ````
 
 ## Running the script on Windows
@@ -51,13 +51,13 @@ from [Command Prompt](https://en.wikipedia.org/wiki/Cmd.exe) or from inside a Po
 To download and run the latest version of [solution_name] in a single command from Command Prompt:
 
 ````
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect"
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect"
 ````
 
 Append any command line arguments to the end, separated by spaces. For example:
 
 ````
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect" --blackduck.url=https://blackduck.mydomain.com --blackduck.api.token=myaccesstoken
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect" --blackduck.url=https://blackduck.mydomain.com --blackduck.api.token=myaccesstoken
 ````
 
 See [Quoting and escaping shell script arguments](../../scripts/script-escaping-special-characters.md) for details about quoting and escaping arguments.
@@ -66,21 +66,21 @@ See [Quoting and escaping shell script arguments](../../scripts/script-escaping-
 
 ````
 set DETECT_LATEST_RELEASE_VERSION={Synopsys Detect version}
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect"
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect"
 ````
 
 For example, to run [solution_name] version 5.5.0:
 
 ````
 set DETECT_LATEST_RELEASE_VERSION=5.5.0
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect"
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect"
 ````
 
 ### Running from Windows Powershell
 
 To download and run the latest version of [solution_name] in a single command from PowerShell:
 ````
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect
 ````
 
 _Note that when running the above command, the PowerShell session is not exited. See [here](../../scripts/script-escaping-special-characters.md) for more information on the difference between the two commands._
@@ -93,13 +93,13 @@ See [Quoting and escaping shell script arguments](../../scripts/script-escaping-
 
 ````
 $Env:DETECT_LATEST_RELEASE_VERSION = "{Synopsys Detect version}"
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect
 ````
 
 Or:
 
 ````
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; $Env:DETECT_LATEST_RELEASE_VERSION = "{Synopsys Detect version}"; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; $Env:DETECT_LATEST_RELEASE_VERSION = "{Synopsys Detect version}"; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect
 ````
 
 
@@ -107,12 +107,12 @@ For example, to run [solution_name] version 7.0.0:
 
 ````
 $Env:DETECT_LATEST_RELEASE_VERSION = "7.0.0"
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect
 ````
 
 Or:
 
 ````
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; $Env:DETECT_LATEST_RELEASE_VERSION="7.0.0"; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; $Env:DETECT_LATEST_RELEASE_VERSION="7.0.0"; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect
 ````
 

--- a/documentation/src/main/markdown/runningdetect/proxies.md
+++ b/documentation/src/main/markdown/runningdetect/proxies.md
@@ -57,7 +57,7 @@ For example:
     ${r"set BLACKDUCK_PROXY_PORT"}=$ProxyPort
     ${r"set BLACKDUCK_PROXY_PASSWORD"}=$ProxyUsername
     ${r"set BLACKDUCK_PROXY_USERNAME"}=$ProxyPassword
-    powershell "Import-Module FULL_PATH_TO_DOWNLOADED_SCRIPT/detect8.ps1; detect"
+    powershell "Import-Module FULL_PATH_TO_DOWNLOADED_SCRIPT/detect9.ps1; detect"
 
 For additional information on these properties, including alternate key formats, see the [Shell script configuration reference](../scripts/overview.md).
 

--- a/documentation/src/main/markdown/scripts/script-escaping-special-characters.md
+++ b/documentation/src/main/markdown/scripts/script-escaping-special-characters.md
@@ -13,19 +13,19 @@ When an argument contains a space or other non double quote special character, y
 For example:
 ```
 # name: Project Test
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.project.name='Project Test'
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.project.name='Project Test'
 
 # name: Project Test
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.project.name=Project\ Test
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.project.name=Project\ Test
 
 # name: Project!Test
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.project.name=Project\!Test
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.project.name=Project\!Test
 ```
 
 You can include a double quote by single quoting the string, and escaping the double quotes with backslashes:
 ```
 # license: BSD 3-clause "New" or "Revised" License
-bash <(curl -s -L https://detect.synopsys.com/detect8.sh) --detect.project.version.license='BSD 3-clause \"New\" or \"Revised\" License' 
+bash <(curl -s -L https://detect.synopsys.com/detect9.sh) --detect.project.version.license='BSD 3-clause \"New\" or \"Revised\" License' 
 ```
 
 ## Running in Command Prompt (cmd) on Windows ([powershell_script_name])
@@ -43,13 +43,13 @@ When an argument contains a space or other non quote special character, you can 
 For example:
 ```
 # name: Project Test
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect" --detect.project.name='Project Test'
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect" --detect.project.name='Project Test'
 
 # name: Project Test
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect" '--detect.project.name=Project Test'
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect" '--detect.project.name=Project Test'
 
 # name: Project Test
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect" --detect.project.name=Project` Test
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect" --detect.project.name=Project` Test
 ```   
 
 When an argument contains a comma, you can wrap the argument in single quotes, and escape the special character with a backtick (`). In the case of a name with a comma and a space, you would use a backtick in front of both the comma and space.
@@ -57,25 +57,25 @@ When an argument contains a comma, you can wrap the argument in single quotes, a
 For example:
 ```
 # name: Project,Test   
-Powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm  https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect --blackduck.url=<url> --detect.project.name='Project,Test'"   
+Powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm  https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect --blackduck.url=<url> --detect.project.name='Project,Test'"   
 
 # name: Project,Test   
-Powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm  https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect --blackduck.url=<url> '--detect.project.name=Project,Test'"   
+Powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm  https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect --blackduck.url=<url> '--detect.project.name=Project,Test'"   
 
 # name: Project, Test   
-Powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm  https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect --blackduck.url=<url> --detect.project.name=Project`,` Test"   
+Powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm  https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect --blackduck.url=<url> --detect.project.name=Project`,` Test"   
 ```
 
 You can include a single quote by doubling it:
 ```
 # name: singlequote'
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect" --detect.project.name='singlequote'''
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect" --detect.project.name='singlequote'''
 ```
 
 You can include a double quote using this sequence: double quote, 2 backslashes, 2 double quotes:
 ```
 # license: BSD 3-clause "New" or "Revised" License
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect" --detect.project.version.license='BSD 3-clause "\\""New"\\"" or "\\""Revised"\\"" License'
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect" --detect.project.version.license='BSD 3-clause "\\""New"\\"" or "\\""Revised"\\"" License'
 ```
 
 ## Running in PowerShell on Windows ([powershell_script_name])
@@ -93,10 +93,10 @@ When an argument contains a space or other non-quote special character, you can 
 For example:
 ```
 # name: Project Test
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect --detect.project.name='Project Test'
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect --detect.project.name='Project Test'
 
 # name: Project Test
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect "--detect.project.name=Project Test"
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect "--detect.project.name=Project Test"
 ```
 
 When an argument contains a comma, you must escape the special character with a backtick (`). In the case of a name with a comma and a space, you would use a backtick in front of both the comma and space.
@@ -105,15 +105,15 @@ For example:
 ```
 # name: Project,Test
 [Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https:/
-/detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect --detect.project.name=Project`,Test
+/detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect --detect.project.name=Project`,Test
 
 # name: Project, Test
 [Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https:/
-/detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect --detect.project.name=Project`,` Test
+/detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect --detect.project.name=Project`,` Test
 ```
 
 You can include a double quote using this sequence: backslash, backtick, double quote:
 ```
 # license: BSD 3-clause "New" or "Revised" License
-[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect8.ps1?$(Get-Random) | iex; detect --detect.project.version.license="BSD 3-clause \`"New\`" or \`"Revised\`" License"
+[Net.ServicePointManager]::SecurityProtocol = 'tls12'; $Env:DETECT_EXIT_CODE_PASSTHRU=1; irm https://detect.synopsys.com/detect9.ps1?$(Get-Random) | iex; detect --detect.project.version.license="BSD 3-clause \`"New\`" or \`"Revised\`" License"
 ```

--- a/documentation/src/main/markdown/troubleshooting/solutions.md
+++ b/documentation/src/main/markdown/troubleshooting/solutions.md
@@ -4,11 +4,11 @@
 
 ### Symptom
 
-detect8.sh fails with: DETECT_SOURCE was not set or computed correctly, please check your configuration and environment.
+detect9.sh fails with: DETECT_SOURCE was not set or computed correctly, please check your configuration and environment.
 
 ### Possible cause
 
-detect8.sh is trying to execute this command:
+detect9.sh is trying to execute this command:
 ````
 curl --silent --header \"X-Result-Detail: info\" https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=DETECT_LATEST
 ````
@@ -21,7 +21,7 @@ The response to this command should be similar to the following:
 "uri" : "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect"
 }
 ```
-When that command does not successfully return a value for property DETECT_LATEST, detect8.sh reports:
+When that command does not successfully return a value for property DETECT_LATEST, detect9.sh reports:
 ````
 DETECT_SOURCE was not set or computed correctly, please check your configuration and environment.
 ````


### PR DESCRIPTION
# Description

This PR addresses all the places in the documentation where currently detect8 is being used for downloading and referencing the Detect Script. These changes will update all the references to use detect9 instead of detect8 for the upcoming major version release. 