### PR TITLE
fix(npm): Ignore packages with empty name in package-lock.json

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -117,7 +117,11 @@ public class NpmDependencyConverter {
             return;
         }
                 
-        for(String packageName : packageLock.packages.keySet()) {  
+        for(String packageName : packageLock.packages.keySet()) {
+            if (packageName.isEmpty()) {
+                packagesToRemove.add(packageName);
+            }
+
             gatherAllDependencies(packageLock, packageName);
             
             // Look for any relationships previously nested in the dependencies object prior to


### PR DESCRIPTION
### Description
Fix for regression IDETECT-4051 to ensure we don't consider packages with empty names as dependencies.
NPM detector was adding a new component in the BDIO for an empty NPM project. 
This was because after running `npm init` and `npm install` on an empty project, the package-lock.json file generated would have an empty package under packages.


package-lock.json
```{
  "name": "emptynpm",
  "version": "1.0.0",
  "lockfileVersion": 2,
  "requires": true,
  "packages": {
    "": {
      "name": "emptynpm",
      "version": "1.0.0",
      "license": "ISC"
    }
  }
}
```
### JIRA
IDETECT-4051