### PR TITLE
Fix for IDETECT-4047 - reinstate included/excluded gradle property behavior

### DIFF
--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -213,6 +213,7 @@ def containsWithWildcard(String value, Set<String> tokenSet) {
     for (String token : tokenSet) {
         token = wildCardTokenToRegexToken(token)
         if (value.matches(~/token/)) {
+            
             return true
         }
     }
@@ -228,7 +229,7 @@ def wildCardTokenToRegexToken(String token) {
         } else if (matcher.group(2) != null) {
             matcher.appendReplacement(buffer, "."); 
         } else {
-            matcher.appendReplacement(buffer, '\\\\Q' + m.group(0) + '\\\\E')
+            matcher.appendReplacement(buffer, '\\\\Q' + matcher.group(0) + '\\\\E')
         }
     }
     matcher.appendTail(buffer)

--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -1,4 +1,6 @@
 import java.util.Optional
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -200,11 +202,37 @@ def createTaskOutputDirectory(String outputDirectoryPath) {
 }
 
 def shouldInclude(Set<String> excluded, Set<String> included, String value) {
-    return !excluded.contains(value) && (included.isEmpty() || included.contains(value))
+    return !containsWithWildcard(value, excluded) && (included.isEmpty() || containsWithWildcard(value, included))
 }
 
 def convertStringToSet(String value) {
     return value.tokenize(',').toSet()
+}
+
+def containsWithWildcard(String value, Set<String> tokenSet) {
+    for (String token : tokenSet) {
+        token = wildCardTokenToRegexToken(token)
+        if (value.matches(~/token/)) {
+            return true
+        }
+    }
+    return tokenSet.contains(value)
+}
+
+def wildCardTokenToRegexToken(String token) {
+    Matcher matcher = Pattern.compile(/[^*?]+|(\*)|(\?)/).matcher(token)
+    StringBuffer buffer= new StringBuffer()
+    while (matcher.find()) {
+        if(matcher.group(1) != null) {
+            matcher.appendReplacement(buffer, '.*')
+        } else if (matcher.group(2) != null) {
+            matcher.appendReplacement(buffer, "."); 
+        } else {
+            matcher.appendReplacement(buffer, '\\\\Q' + m.group(0) + '\\\\E')
+        }
+    }
+    matcher.appendTail(buffer)
+    return buffer.toString()
 }
 </#noparse>
 // ## END methods invoked by tasks above

--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -211,13 +211,16 @@ def convertStringToSet(String value) {
 
 def containsWithWildcard(String value, Set<String> tokenSet) {
     for (String token : tokenSet) {
-        token = wildCardTokenToRegexToken(token)
-        if (value.matches(~/token/)) {
-            
+        if (match(value, token) {
             return true
         }
     }
     return tokenSet.contains(value)
+}
+
+def match(String value, String token) {
+    def tokenRegex = wildCardTokenToRegexToken(token)
+    return value.matches(tokenRegex)
 }
 
 def wildCardTokenToRegexToken(String token) {


### PR DESCRIPTION
Wildcard behavior was omitted as part of IDETECT-3441. This MR reinstates that behavior to ensure included/excluded wildcard behavior for Gradle properties is correct.

Resolves IDETECT-4047