### PR TITLE
Use the source directory instead of output directory as working directory.

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliDetectable.java
@@ -52,7 +52,7 @@ public class CpanCliDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) throws ExecutableRunnerException {
-        return cpanCliExtractor.extract(cpanExe, cpanmExe, extractionEnvironment.getOutputDirectory());
+        return cpanCliExtractor.extract(cpanExe, cpanmExe, environment.getDirectory());
     }
 
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cpan/functional/CpanCliDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cpan/functional/CpanCliDetectableTest.java
@@ -28,7 +28,7 @@ public class CpanCliDetectableTest extends DetectableFunctionalTest {
             "perl\t5.1",
             "Test::More\t1.3"
         );
-        addExecutableOutput(getOutputDirectory(), cpanListOutput, "cpan", "-l");
+        addExecutableOutput(getSourceDirectory(), cpanListOutput, "cpan", "-l");
 
         ExecutableOutput cpanmShowDepsOutput = createStandardOutput(
             "--> Working on .",
@@ -38,7 +38,7 @@ public class CpanCliDetectableTest extends DetectableFunctionalTest {
             "perl~5.008001",
             "ExtUtils::MakeMaker"
         );
-        addExecutableOutput(getOutputDirectory(), cpanmShowDepsOutput, "cpanm", "--showdeps", ".");
+        addExecutableOutput(getSourceDirectory(), cpanmShowDepsOutput, "cpanm", "--showdeps", ".");
     }
 
     @NotNull

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -7,3 +7,4 @@
 * Support for Dart is now extended to Dart 3.1.
 
 ### Resolved issues
+* (IDETECT-4056) Resolved a problem with CPAN detector where no components were reported.


### PR DESCRIPTION
Use the source directory instead of output directory as working directory.

# Description

Prior to this change `cpanm --showdeps .` was getting executed on the output directory which was causing the list of reported dependencies to be empty.

# Testing

I ran detect on a test project. Its direct dependencies got reported in the output BDIO and were recognized in Blackduck UI.