### PR TITLE
Allow Detect to complete execution of cpan if it has not been run before

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliDetectable.java
@@ -15,7 +15,7 @@ import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 import com.synopsys.integration.executable.ExecutableRunnerException;
 
-@DetectableInfo(name = "Cpan CLI", language = "Perl", forge = "CPAN", accuracy = DetectableAccuracyType.HIGH, requirementsMarkdown = "File: Makefile.PL. Executable: cpan, and cpanm.")
+@DetectableInfo(name = "Cpan CLI", language = "Perl", forge = "CPAN", accuracy = DetectableAccuracyType.HIGH, requirementsMarkdown = "File: Makefile.PL. Executables: cpan, and cpanm.")
 public class CpanCliDetectable extends Detectable {
     private static final String MAKEFILE = "Makefile.PL";
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliDetectable.java
@@ -52,7 +52,7 @@ public class CpanCliDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) throws ExecutableRunnerException {
-        return cpanCliExtractor.extract(cpanExe, cpanmExe, extractionEnvironment.getOutputDirectory());
+        return cpanCliExtractor.extract(cpanExe, cpanmExe, environment.getDirectory());
     }
 
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliDetectable.java
@@ -15,7 +15,7 @@ import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 import com.synopsys.integration.executable.ExecutableRunnerException;
 
-@DetectableInfo(name = "Cpan CLI", language = "Perl", forge = "CPAN", accuracy = DetectableAccuracyType.HIGH, requirementsMarkdown = "File: Makefile.PL. Executable: cpan.")
+@DetectableInfo(name = "Cpan CLI", language = "Perl", forge = "CPAN", accuracy = DetectableAccuracyType.HIGH, requirementsMarkdown = "File: Makefile.PL. Executable: cpan, and cpanm.")
 public class CpanCliDetectable extends Detectable {
     private static final String MAKEFILE = "Makefile.PL";
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliExtractor.java
@@ -1,7 +1,10 @@
 package com.synopsys.integration.detectable.detectables.cpan;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.synopsys.integration.bdio.graph.DependencyGraph;
 import com.synopsys.integration.detectable.ExecutableTarget;
@@ -27,9 +30,8 @@ public class CpanCliExtractor {
 
     public Extraction extract(ExecutableTarget cpanExe, ExecutableTarget cpanmExe, File workingDirectory) throws ExecutableRunnerException {
         toolVersionLogger.log(workingDirectory, cpanExe);
-        //TODO: Consider command runner to reduce cognitive load.
-        ExecutableOutput cpanListOutput = executableRunner.execute(ExecutableUtils.createFromTarget(workingDirectory, cpanExe, "-l"));
-        List<String> listText = cpanListOutput.getStandardOutputAsList();
+
+        List<String> listText = generateCpanListOutput(workingDirectory, cpanExe);
 
         ExecutableOutput showdepsOutput = executableRunner.execute(ExecutableUtils.createFromTarget(workingDirectory, cpanmExe, "--showdeps", "."));
         List<String> showdeps = showdepsOutput.getStandardOutputAsList();
@@ -37,5 +39,19 @@ public class CpanCliExtractor {
         DependencyGraph dependencyGraph = cpanListParser.parse(listText, showdeps);
         CodeLocation detectCodeLocation = new CodeLocation(dependencyGraph);
         return new Extraction.Builder().success(detectCodeLocation).build();
+    }
+
+    List<String> generateCpanListOutput(File workingDirectory, ExecutableTarget cpanExe) throws ExecutableRunnerException {
+        Map<String, String> environmentVariables = new HashMap<>();
+
+        // When cpan is run on a system for the first time, the user is presented with a number of prompts; this can cause Detect to wait indefinitely.
+        // The following line causes the execution to accept defaults and does not block on any prompts so that Detect can complete its execution:
+        environmentVariables.put("PERL_MM_USE_DEFAULT", "true");
+
+        List<String> args = new ArrayList<String>();
+        args.add("-l");
+
+        ExecutableOutput cpanListOutput = executableRunner.execute(ExecutableUtils.createFromTarget(workingDirectory, environmentVariables, cpanExe, args));
+        return cpanListOutput.getStandardOutputAsList();
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/parse/CpanListParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/parse/CpanListParser.java
@@ -39,7 +39,7 @@ public class CpanListParser {
                 Dependency dependency = new Dependency(name, version, externalId);
                 graph.addChildToRoot(dependency);
             } else {
-                logger.warn(String.format("Could node find resolved version for module: %s", moduleName));
+                logger.warn(String.format("Could not find resolved version for module: %s", moduleName));
             }
         }
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cpan/functional/CpanCliDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cpan/functional/CpanCliDetectableTest.java
@@ -28,7 +28,7 @@ public class CpanCliDetectableTest extends DetectableFunctionalTest {
             "perl\t5.1",
             "Test::More\t1.3"
         );
-        addExecutableOutput(getOutputDirectory(), cpanListOutput, "cpan", "-l");
+        addExecutableOutput(getSourceDirectory(), cpanListOutput, "cpan", "-l");
 
         ExecutableOutput cpanmShowDepsOutput = createStandardOutput(
             "--> Working on .",
@@ -38,7 +38,7 @@ public class CpanCliDetectableTest extends DetectableFunctionalTest {
             "perl~5.008001",
             "ExtUtils::MakeMaker"
         );
-        addExecutableOutput(getOutputDirectory(), cpanmShowDepsOutput, "cpanm", "--showdeps", ".");
+        addExecutableOutput(getSourceDirectory(), cpanmShowDepsOutput, "cpanm", "--showdeps", ".");
     }
 
     @NotNull

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cpan/functional/CpanCliDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/cpan/functional/CpanCliDetectableTest.java
@@ -1,6 +1,9 @@
 package com.synopsys.integration.detectable.detectables.cpan.functional;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
@@ -28,7 +31,9 @@ public class CpanCliDetectableTest extends DetectableFunctionalTest {
             "perl\t5.1",
             "Test::More\t1.3"
         );
-        addExecutableOutput(getSourceDirectory(), cpanListOutput, "cpan", "-l");
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("PERL_MM_USE_DEFAULT", "true");
+        addExecutableOutput(getSourceDirectory(), cpanListOutput, envVars, "cpan", "-l");
 
         ExecutableOutput cpanmShowDepsOutput = createStandardOutput(
             "--> Working on .",

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -7,5 +7,5 @@
 * Support for Dart is now extended to Dart 3.1.
 
 ### Resolved issues
-* (IDETECT-4056) Resolved a problem with CPAN detector where no components were reported.
-  Additionally, if cpan command has not been run and configured on the system previously, Detect instructs cpan to accept default configurations.
+* (IDETECT-4056) Resolved an issue where no components were reported by CPAN detector.
+  If the cpan command has not been previously configured and run on the system, [solution_name] instructs CPAN to accept default configurations.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -8,4 +8,4 @@
 
 ### Resolved issues
 * (IDETECT-4056) Resolved a problem with CPAN detector where no components were reported.
-  Additionally, if cpan command has not been run and configured on the system previously, Detect instructs cpan to accept default configurations. This allows the command to finish executing successfully.
+  Additionally, if cpan command has not been run and configured on the system previously, Detect instructs cpan to accept default configurations.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -7,3 +7,4 @@
 * Support for Dart is now extended to Dart 3.1.
 
 ### Resolved issues
+* (IDETECT-4056) Resolved a problem with CPAN detector where no components were reported.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -8,3 +8,4 @@
 
 ### Resolved issues
 * (IDETECT-4056) Resolved a problem with CPAN detector where no components were reported.
+  Additionally, if cpan command has not been run and configured on the system previously, Detect instructs cpan to accept default configurations. This allows the command to finish executing successfully.


### PR DESCRIPTION
# Description

Allow Detect to complete execution of cpan if it has not been run before by accepting defaults. Otherwise, Detect can hang indefinitely while trying to execute `cpan -l`.

This change will not affect customers/systems that already have cpan configured in any way.

When running `cpan -l` for the first time the user is presented with a prompt to accept default configurations.
If the user chooses to not accept defaults, the following list of prompts is presented (note, defaults are printed inside square brackets):

```
Would you like to configure as much as possible automatically? [yes] no
CPAN build and cache directory? [/Users/<user>/.cpan] 
Download target directory? [/Users/<user>/.cpan/sources] 
Directory where the build process takes place? [/Users/<user>/.cpan/build] 
Store and re-use state information about distributions between
CPAN.pm sessions? [no] 
Directory where to store default options/environment/dialogs for
building modules that need some customization? [/Users/<user>/.cpan/prefs] 
Always commit changes to config variables to disk? [no] 
Cache size for build directory (in MB)? [100] 
Let the index expire after how many days? [1] 
Perform cache scanning ('atstart', 'atexit' or 'never')? [atstart] 
Remove build directory after a successful install? (yes/no)? [no] 
Cache metadata (yes/no)? [yes] 
Use CPAN::SQLite if available? (yes/no)? [no] 
Policy on building prerequisites (follow, ask or ignore)? [follow] 
Policy on installing 'build_requires' modules (yes, no, ask/yes,
ask/no)? [yes] 
Include recommended modules? [yes] 
Include suggested modules? [no] 
Always try to check and verify signatures if a SIGNATURE file is in
the package and Module::Signature is installed (yes/no)? [no] 
Generate test reports if CPAN::Reporter is installed (yes/no)? [no] 
Do you want to rely on the test report history (yes/no)? [no] 
Which YAML implementation would you prefer? [YAML] 
Do you want to enable code deserialisation (yes/no)? [no] 
Where is your make program? [/usr/bin/make] 
Where is your bzip2 program? [/usr/bin/bzip2] 
Where is your gzip program? [/usr/bin/gzip] 
Where is your tar program? [/usr/bin/tar] 
Where is your unzip program? [/usr/bin/unzip] 
Where is your gpg program? [] 
Where is your patch program? [/usr/bin/patch] 
Where is your applypatch program? [] 
Where is your wget program? [] 
Where is your curl program? [/usr/bin/curl] 
What is your favorite pager program? [/usr/bin/less] 
What is your favorite shell? [/bin/zsh] 
Use the external tar program instead of Archive::Tar? [yes] 
Tar command verbosity level (none or v or vv)? [none] 
Verbosity level for loading modules (none or v)? [none] 
Verbosity level for PERL5LIB changes (none or v)? [none] 
Do you want to turn this message off? [no] 
In case you can choose between running a Makefile.PL or a Build.PL,
which installer would you prefer (EUMM or MB or RAND)? [MB] 
Parameters for the 'perl Makefile.PL' command? [] 
Your choice: [] 
or some such. Your choice: [/usr/bin/make] 
Your choice: [] 
Parameters for the 'perl Build.PL' command? [] 
Your choice: [] 
or some such. Your choice: [./Build] 
Your choice: [] 
Do you want to use prompt defaults (yes/no)? [no] 
Timeout for inactivity during {Makefile,Build}.PL? [0] 
Timeout for parsing module versions? [15] 
Do you want to halt on failure (yes/no)? [no] 
Your ftp_proxy? [] 
Your http_proxy? [] 
Your no_proxy? [] 
Shall we always set the FTP_PASSIVE environment variable when dealing
with ftp download (yes/no)? [yes] 
Preferred method for determining the current working directory? [cwd] 
Do you want the command number in the prompt (yes/no)? [yes] 
Do you want to turn ornaments on? [yes] 
Your terminal expects ISO-8859-1 (yes/no)? [yes] 
File to save your history? [/Users/<user>/.cpan/histfile] 
Number of lines to save? [100] 
Always try to show upload date with 'd' and 'm' command (yes/no)? [no] 
Show all individual modules that have no $VERSION? [no] 
Show all individual modules that have a $VERSION of zero? [no] 
If no urllist has been chosen yet, would you prefer CPAN.pm to connect
to the built-in default sites without asking? (yes/no)? [yes] 

Would you like me to automatically choose some CPAN mirror
sites for you? (This means connecting to the Internet) [yes]
```