### PR TITLE
Add container scan status to Detect CLI output for stateless scans

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -94,28 +94,32 @@ public class RapidModeStepRunner {
             }
         });
         
-        stepHelper.runToolIfIncluded(DetectTool.CONTAINER_SCAN, "Container Scanner", () -> {
-            logger.debug("Stateless container scan detected.");
-
-            // Check if this is an SCA environment.
-            if (scaaasFilePath.isPresent()) {
-                List<HttpUrl> containerResultUrls = new ArrayList<>();
-                invokeBdbaRapidScan(blackDuckRunData, projectVersion, blackDuckUrl, containerResultUrls, true, scaaasFilePath.get());
-                processScanResults(containerResultUrls, parsedUrls, formattedCodeLocations, DetectTool.CONTAINER_SCAN.name());
-            } else {
-                logger.debug("Determining if configuration is valid to run a container scan.");
-                ContainerScanStepRunner containerScanStepRunner = new ContainerScanStepRunner(operationRunner, projectVersion, blackDuckRunData, gson);
-                if (containerScanStepRunner.shouldRunContainerScan()) {
-                    logger.debug("Invoking stateless container scan.");
-                    UUID scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
-                    String statelessScanEndpoint = operationRunner.getScanServicePostEndpoint();
-                    HttpUrl scanServiceUrlToPoll = new HttpUrl(blackDuckUrl + statelessScanEndpoint + "/" + scanId.toString());
-                    parsedUrls.add(scanServiceUrlToPoll);
+        stepHelper.runToolIfIncludedWithCallbacks(
+            DetectTool.CONTAINER_SCAN, "Container Scanner",
+            () -> {
+                logger.debug("Stateless container scan detected.");
+                // Check if this is an SCA environment.
+                if (scaaasFilePath.isPresent()) {
+                    List<HttpUrl> containerResultUrls = new ArrayList<>();
+                    invokeBdbaRapidScan(blackDuckRunData, projectVersion, blackDuckUrl, containerResultUrls, true, scaaasFilePath.get());
+                    processScanResults(containerResultUrls, parsedUrls, formattedCodeLocations, DetectTool.CONTAINER_SCAN.name());
                 } else {
-                    logger.debug("Container image file not provided or could not be downloaded. Container scan will not run.");
+                    logger.debug("Determining if configuration is valid to run a container scan.");
+                    ContainerScanStepRunner containerScanStepRunner = new ContainerScanStepRunner(operationRunner, projectVersion, blackDuckRunData, gson);
+                    if (containerScanStepRunner.shouldRunContainerScan()) {
+                        logger.debug("Invoking stateless container scan.");
+                        UUID scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
+                        String statelessScanEndpoint = operationRunner.getScanServicePostEndpoint();
+                        HttpUrl scanServiceUrlToPoll = new HttpUrl(blackDuckUrl + statelessScanEndpoint + "/" + scanId.toString());
+                        parsedUrls.add(scanServiceUrlToPoll);
+                    } else {
+                        logger.debug("Container image file not provided or could not be downloaded. Container scan will not run.");
+                    }
                 }
-            }
-        });
+            },
+            operationRunner::publishContainerSuccess,
+            operationRunner::publishContainerFailure
+        );
 
         // Get info about any scans that were done
         BlackduckScanMode mode = blackDuckRunData.getScanMode();


### PR DESCRIPTION
### Description

Detect's overall status section should show container scan tool status as success/failure. This was added for Intelligent scans in #925 but this log line was missing for stateless scans.

### JIRA
IDETECT-4041

