### PR TITLE
Ensure container scan status is not shown when scan is not eligible to run

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -133,22 +133,15 @@ public class IntelligentModeStepRunner {
             }
         });
 
-        stepHelper.runToolIfIncludedWithCallbacks(
+        stepHelper.runToolIfIncluded(
             DetectTool.CONTAINER_SCAN,
             "Container Scanner",
             () -> {
-                logger.debug("Determining if configuration is valid to run a container scan.");
                 ContainerScanStepRunner containerScanStepRunner = new ContainerScanStepRunner(operationRunner, projectNameVersion, blackDuckRunData, gson);
-                if (containerScanStepRunner.shouldRunContainerScan()) {
-                    logger.debug("Invoking intelligent persistent container scan.");
-                    UUID scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
-                    scanIdsToWaitFor.add(scanId.toString());
-                } else {
-                    logger.debug("Container image file not provided or could not be downloaded. Container scan will not run.");
-                }
-            },
-            operationRunner::publishContainerSuccess,
-            operationRunner::publishContainerFailure
+                logger.debug("Invoking intelligent persistent container scan.");
+                Optional<UUID> scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
+                scanId.ifPresent(uuid -> scanIdsToWaitFor.add(uuid.toString()));
+            }
         );
 
         stepHelper.runToolIfIncludedWithCallbacks(


### PR DESCRIPTION
### Description

Fix for regression IDETECT-4069. 
Updated how `publishContainerSuccess` and `publishContainerFailure` methods are invoked.

Replaced `runToolIfIncludedWithCallbacks` with `runToolIfIncluded` because when using`runToolIfIncludedWithCallbacks`, the success callback `publishContainerSuccess` gets invoked by default if no errors occurred in the supplier method i.e. `() -> {....}`. 

The change ensures that `CONTAINER_SCAN: <status>` is published only after the scan is initiated.
Hence if container scan is not eligible to run, then container scan status won't be shown in the output.

### JIRA
IDETECT-4069
