### PR TITLE
WIP: Log cpanm version (do not merge)

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/cpan/CpanCliExtractor.java
@@ -29,6 +29,8 @@ public class CpanCliExtractor {
     }
 
     public Extraction extract(ExecutableTarget cpanExe, ExecutableTarget cpanmExe, File workingDirectory) throws ExecutableRunnerException {
+        toolVersionLogger.log(workingDirectory, cpanmExe);
+
         List<String> listText = generateCpanListOutput(workingDirectory, cpanExe);
 
         ExecutableOutput showdepsOutput = executableRunner.execute(ExecutableUtils.createFromTarget(workingDirectory, cpanmExe, "--showdeps", "."));


### PR DESCRIPTION
# Description

Attempt to log cpanm version. At the moment, at least on my machine this causes Detect to hang while it tries to run `/opt/homebrew/bin/cpanm --version` and no output gets generated.