### PR TITLE
Stateless scans will retry call when receiving certain BlackDuck response codes

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.8-SNAPSHOT-a'
+gradle.ext.blackDuckCommonVersion='66.2.8'
 gradle.ext.springBootVersion='2.7.12'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.7'
+gradle.ext.blackDuckCommonVersion='66.2.8-SNAPSHOT-a'
 gradle.ext.springBootVersion='2.7.12'

--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -62,6 +62,7 @@ public class Application implements ApplicationRunner {
     private static boolean SHOULD_EXIT = true;
     
     private static final String STATUS_JSON_FILE_NAME = "status.json";
+    public static final Long START_TIME = System.currentTimeMillis();
 
     private final ConfigurableEnvironment environment;
 
@@ -99,7 +100,7 @@ public class Application implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments applicationArguments) {
-        long startTime = System.currentTimeMillis();
+        long startTime = START_TIME;
 
         //Events, Status and Exit Codes are required even if boot fails.
         EventSystem eventSystem = new EventSystem();

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectConfigurationFactory.java
@@ -232,7 +232,8 @@ public class DetectConfigurationFactory {
     public RapidScanOptions createRapidScanOptions() {
         RapidCompareMode rapidCompareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
         BlackduckScanMode scanMode= detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
-        return new RapidScanOptions(rapidCompareMode, scanMode);
+        long detectTimeout = findTimeoutInSeconds();
+        return new RapidScanOptions(rapidCompareMode, scanMode, detectTimeout);
     }
 
     public BlackduckScanMode createScanMode() {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.blackducksoftware.bdio2.Bdio;
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -228,6 +229,8 @@ public class OperationRunner {
     private static final String DEVELOPER_SCAN_CONTENT_TYPE = "application/vnd.blackducksoftware.scan-evidence-1+protobuf";
     private static final String INTELLIGENT_SCAN_ENDPOINT = ApiDiscovery.INTELLIGENT_PERSISTENCE_SCANS_PATH.getPath();
     private static final String INTELLIGENT_SCAN_CONTENT_TYPE = "application/vnd.blackducksoftware.intelligent-persistence-scan-3+protobuf";
+    public static final ImmutableList<Integer> RETRYABLE_AFTER_WAIT_HTTP_EXCEPTIONS = ImmutableList.of(408, 429, 502, 503, 504);
+    public static final ImmutableList<Integer> RETRYABLE_WITH_BACKOFF_HTTP_EXCEPTIONS = ImmutableList.of(425, 500);
 
     //Internal: Operation -> Action
     //Leave OperationSystem, but it becomes 'user facing groups of actions or steps'
@@ -1338,7 +1341,7 @@ public class OperationRunner {
         }
     }
 
-    public int calculateMaxWaitInSeconds(int fibonacciSequenceIndex) {
+    public static int calculateMaxWaitInSeconds(int fibonacciSequenceIndex) {
         int fibonacciSequenceLastIndex = LIMITED_FIBONACCI_SEQUENCE.length - 1;
         if (fibonacciSequenceIndex > fibonacciSequenceLastIndex) {
             return LIMITED_FIBONACCI_SEQUENCE[fibonacciSequenceLastIndex];
@@ -1370,5 +1373,9 @@ public class OperationRunner {
         UUID scanId = UUID.fromString(url.substring(url.lastIndexOf("/") + 1));
 
         return scanId;
+    }
+    
+    public DetectConfigurationFactory getDetectConfigurationFactory() {
+        return this.detectConfigurationFactory;
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidModeUploadOperation.java
@@ -24,7 +24,7 @@ public class RapidModeUploadOperation {
     }
 
     public List<HttpUrl> run(BdioResult bdioResult, RapidScanOptions rapidScanOptions, @Nullable File rapidScanConfig)
-        throws IntegrationException, IOException {
+        throws IntegrationException, IOException, InterruptedException {
         String scanModeString = rapidScanOptions.getScanMode().displayName();
         logger.info("Begin " + scanModeString + " Mode Scan");
         UploadBatch uploadBatch = new UploadBatch();

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanOptions.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanOptions.java
@@ -6,10 +6,12 @@ import com.synopsys.integration.detect.configuration.enumeration.RapidCompareMod
 public class RapidScanOptions {
     private final RapidCompareMode compareMode;
     private final BlackduckScanMode scanMode;
+    private final long detectTimeout;
 
-    public RapidScanOptions(RapidCompareMode compareMode, BlackduckScanMode scanMode) {
+    public RapidScanOptions(RapidCompareMode compareMode, BlackduckScanMode scanMode, long detectTimeout) {
         this.compareMode = compareMode;
         this.scanMode = scanMode;
+        this.detectTimeout = detectTimeout;
     }
 
     public RapidCompareMode getCompareMode() {
@@ -18,5 +20,9 @@ public class RapidScanOptions {
 
     public BlackduckScanMode getScanMode() {
         return scanMode;
+    }
+
+    public long getDetectTimeout() {
+        return detectTimeout;
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanService.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/DetectRapidScanService.java
@@ -49,7 +49,7 @@ public class DetectRapidScanService {
         return new DetectRapidScanService(bdio2FileUploadService, directoryManager);
     }
 
-    public List<HttpUrl> performUpload(UploadBatch uploadBatch, RapidScanOptions rapidScanOptions, @Nullable File rapidScanConfig) throws IntegrationException, IOException {
+    public List<HttpUrl> performUpload(UploadBatch uploadBatch, RapidScanOptions rapidScanOptions, @Nullable File rapidScanConfig) throws IntegrationException, IOException, InterruptedException {
         List<HttpUrl> allScanUrls = new LinkedList<>();
 
         for (UploadTarget uploadTarget : uploadBatch.getUploadTargets()) {

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
@@ -10,13 +10,17 @@ import com.synopsys.integration.blackduck.api.core.BlackDuckPath;
 import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.synopsys.integration.blackduck.bdio2.model.BdioFileContent;
+import com.synopsys.integration.blackduck.exception.BlackDuckIntegrationException;
 import com.synopsys.integration.blackduck.http.BlackDuckRequestBuilder;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.request.BlackDuckRequestBuilderEditor;
 import com.synopsys.integration.blackduck.service.request.BlackDuckResponseRequest;
+import com.synopsys.integration.detect.Application;
+import com.synopsys.integration.detect.lifecycle.run.operation.OperationRunner;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.HttpUrl;
+import com.synopsys.integration.rest.response.Response;
 
 public class RapidScanConfigBdio2StreamUploader {
     // IDETECT-2756
@@ -38,8 +42,7 @@ public class RapidScanConfigBdio2StreamUploader {
         ApiDiscovery apiDiscovery,
         IntLogger logger,
         BlackDuckPath<DeveloperScansScanView> scanPath,
-        String contentType
-    ) {
+        String contentType) {
         this.blackDuckApiClient = blackDuckApiClient;
         this.apiDiscovery = apiDiscovery;
         this.logger = logger;
@@ -47,26 +50,59 @@ public class RapidScanConfigBdio2StreamUploader {
         this.contentType = contentType;
     }
 
-    public HttpUrl start(BdioFileContent header, BlackDuckRequestBuilderEditor editor) throws IntegrationException {
+    public HttpUrl start(BdioFileContent header, BlackDuckRequestBuilderEditor editor, long detectTimeout) throws IntegrationException, InterruptedException {
         HttpUrl url = apiDiscovery.metaSingleResponse(scanPath).getUrl();
         BlackDuckResponseRequest request = new BlackDuckRequestBuilder()
             .postString(header.getContent(), ContentType.create(contentType, StandardCharsets.UTF_8))
             .addHeader(HEADER_CONTENT_TYPE, contentType)
             .apply(editor)
             .buildBlackDuckResponseRequest(url);
-        HttpUrl responseUrl = blackDuckApiClient.executePostRequestAndRetrieveURL(request);
+        Response response = recursiveExecute(request, 0L, 0, detectTimeout);
+        HttpUrl responseUrl = new HttpUrl(response.getHeaderValue("location"));
         logger.debug(String.format("Starting upload to %s", responseUrl.toString()));
         return responseUrl;
     }
+    
+    private Response recursiveExecute(BlackDuckResponseRequest request, long waitInMillis, int backoffRetryCount, long detectTimeout) throws InterruptedException, IntegrationException {
+        Thread.sleep(waitInMillis);
+        Response response = blackDuckApiClient.execute(request);
+        String retryAfterInSeconds = response.getHeaderValue("retry-after");
+        if (OperationRunner.RETRYABLE_AFTER_WAIT_HTTP_EXCEPTIONS.contains(response.getStatusCode()) 
+                && null != retryAfterInSeconds 
+                && !retryAfterInSeconds.equals("0")) {
+            // Response code is one of 408, 429, 502, 503, 504.
+            long retryAfterInMillis = Integer.parseInt(retryAfterInSeconds) * 1000;
+            if (isDetectTimeoutExceededBy(retryAfterInMillis, detectTimeout)) {
+                throw new BlackDuckIntegrationException("Detect timeout exceeded or will be exceeded due to server being busy.");
+            }
+            return recursiveExecute(request, retryAfterInMillis, 0, detectTimeout);
+        } else if (OperationRunner.RETRYABLE_WITH_BACKOFF_HTTP_EXCEPTIONS.contains(response.getStatusCode())) {
+            // Response code is 425 or 500.
+            long fibonacciWaitInMillis = OperationRunner.calculateMaxWaitInSeconds(backoffRetryCount) * 1000;
+            if (isDetectTimeoutExceededBy(fibonacciWaitInMillis, detectTimeout)) {
+                throw new BlackDuckIntegrationException("Detect timeout exceeded or will be exceeded due to a temporary unavailability of the server.");
+            }
+            backoffRetryCount++;
+            return recursiveExecute(request, fibonacciWaitInMillis, backoffRetryCount, detectTimeout);
+        }
+        return response;
+    }
+    
+    private boolean isDetectTimeoutExceededBy(long waitInMillis, long detectTimeout) {
+        long startTime = Application.START_TIME;
+        long currentTime = System.currentTimeMillis();
+        return (currentTime - startTime + waitInMillis) > detectTimeout;
+    }
 
-    public HttpUrl startWithConfig(File zippedConfigAndHeader, BlackDuckRequestBuilderEditor editor) throws IntegrationException {
+    public HttpUrl startWithConfig(File zippedConfigAndHeader, BlackDuckRequestBuilderEditor editor, long detectTimeout) throws IntegrationException, InterruptedException {
         HttpUrl url = apiDiscovery.metaSingleResponse(scanPath).getUrl();
         BlackDuckResponseRequest request = new BlackDuckRequestBuilder()
             .postFile(zippedConfigAndHeader, ContentType.create("application/zip"))
             .addHeader(HEADER_CONTENT_TYPE, "application/vnd.blackducksoftware.developer-scan-1-ld-2-yaml-1+zip")
             .apply(editor)
             .buildBlackDuckResponseRequest(url);
-        HttpUrl responseUrl = blackDuckApiClient.executePostRequestAndRetrieveURL(request);
+        Response response = recursiveExecute(request, 0L, 0, detectTimeout);
+        HttpUrl responseUrl = new HttpUrl(response.getHeaderValue("location"));
         logger.debug(String.format("Starting upload to %s", responseUrl.toString()));
         return responseUrl;
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
@@ -63,9 +63,9 @@ public class RapidScanConfigBdio2StreamUploader {
         return responseUrl;
     }
     
-    private Response recursiveExecute(BlackDuckResponseRequest request, long waitInMillis, int backoffRetryCount, long detectTimeout) throws InterruptedException, IntegrationException {
+    public Response recursiveExecute(BlackDuckResponseRequest request, long waitInMillis, int backoffRetryCount, long detectTimeout) throws InterruptedException, IntegrationException {
         Thread.sleep(waitInMillis);
-        Response response = blackDuckApiClient.execute(request);
+        Response response = blackDuckApiClient.executeAndRetrieveResponse(request);
         String retryAfterInSeconds = response.getHeaderValue("retry-after");
         if (OperationRunner.RETRYABLE_AFTER_WAIT_HTTP_EXCEPTIONS.contains(response.getStatusCode()) 
                 && null != retryAfterInSeconds 
@@ -91,7 +91,7 @@ public class RapidScanConfigBdio2StreamUploader {
     private boolean isDetectTimeoutExceededBy(long waitInMillis, long detectTimeout) {
         long startTime = Application.START_TIME;
         long currentTime = System.currentTimeMillis();
-        return (currentTime - startTime + waitInMillis) > detectTimeout;
+        return (currentTime - startTime + waitInMillis) > (detectTimeout * 1000);
     }
 
     public HttpUrl startWithConfig(File zippedConfigAndHeader, BlackDuckRequestBuilderEditor editor, long detectTimeout) throws IntegrationException, InterruptedException {

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
@@ -75,6 +75,7 @@ public class RapidScanConfigBdio2StreamUploader {
             if (isDetectTimeoutExceededBy(retryAfterInMillis, detectTimeout)) {
                 throw new BlackDuckIntegrationException("Detect timeout exceeded or will be exceeded due to server being busy.");
             }
+            logger.debug("Received code " + response.getStatusCode() + ". Retrying upload in " + retryAfterInSeconds + " seconds.");
             return recursiveExecute(request, retryAfterInMillis, 0, detectTimeout);
         } else if (OperationRunner.RETRYABLE_WITH_BACKOFF_HTTP_EXCEPTIONS.contains(response.getStatusCode())) {
             // Response code is 425 or 500.
@@ -82,6 +83,7 @@ public class RapidScanConfigBdio2StreamUploader {
             if (isDetectTimeoutExceededBy(fibonacciWaitInMillis, detectTimeout)) {
                 throw new BlackDuckIntegrationException("Detect timeout exceeded or will be exceeded due to a temporary unavailability of the server.");
             }
+            logger.debug("Received code " + response.getStatusCode() + ". Backing off and retrying upload in " + fibonacciWaitInMillis + " milliseconds.");
             backoffRetryCount++;
             return recursiveExecute(request, fibonacciWaitInMillis, backoffRetryCount, detectTimeout);
         }

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanUploadService.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanUploadService.java
@@ -49,7 +49,7 @@ public class RapidScanUploadService extends DataService {
     }
 
     public HttpUrl uploadFile(File workingDirectory, UploadTarget uploadTarget, RapidScanOptions rapidScanOptions, @Nullable File rapidScanConfig)
-        throws IntegrationException, IOException {
+        throws IntegrationException, IOException, InterruptedException {
         logger.debug(String.format("Uploading BDIO file %s", uploadTarget.getUploadFile()));
         List<BdioFileContent> bdioFileContentList = bdio2Extractor.extractContent(uploadTarget.getUploadFile());
         NameVersion projectNameVersion = uploadTarget.getProjectAndVersion().orElse(null);
@@ -64,7 +64,7 @@ public class RapidScanUploadService extends DataService {
         @Nullable File rapidScanConfig,
         @Nullable File rapidScanWorkingDirectory
     )
-        throws IntegrationException, IOException {
+        throws IntegrationException, IOException, InterruptedException {
         if (bdioFiles.isEmpty()) {
             throw new IllegalArgumentException("BDIO files cannot be empty.");
         }
@@ -87,12 +87,12 @@ public class RapidScanUploadService extends DataService {
                     .addHeader(Bdio2StreamUploader.VERSION_NAME_HEADER, nameVersion.getVersion());
             }
         };
-
+        long detectTimeout = rapidScanOptions.getDetectTimeout();
         HttpUrl url;
         if (rapidScanConfig != null) {
-            url = bdio2Uploader.startWithConfig(zip(uploadTarget, rapidScanConfig, header, rapidScanWorkingDirectory), editor);
+            url = bdio2Uploader.startWithConfig(zip(uploadTarget, rapidScanConfig, header, rapidScanWorkingDirectory), editor, detectTimeout);
         } else {
-            url = bdio2Uploader.start(header, editor);
+            url = bdio2Uploader.start(header, editor, detectTimeout);
         }
         for (BdioFileContent content : remainingFiles) {
             bdio2Uploader.append(url, count, content, editor);

--- a/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanConfigBdio2StreamUploaderTest.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/blackduck/developer/RapidScanConfigBdio2StreamUploaderTest.java
@@ -1,0 +1,63 @@
+package com.synopsys.integration.detect.workflow.blackduck.developer;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.blackduck.api.core.BlackDuckPath;
+import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
+import com.synopsys.integration.blackduck.api.generated.view.DeveloperScansScanView;
+import com.synopsys.integration.blackduck.bdio2.model.BdioFileContent;
+import com.synopsys.integration.blackduck.http.BlackDuckRequestBuilder;
+import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
+import com.synopsys.integration.blackduck.service.request.BlackDuckResponseRequest;
+import com.synopsys.integration.detect.workflow.blackduck.developer.blackduck.RapidScanConfigBdio2StreamUploader;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.log.Slf4jIntLogger;
+import com.synopsys.integration.rest.HttpUrl;
+import com.synopsys.integration.rest.response.Response;
+
+public class RapidScanConfigBdio2StreamUploaderTest {
+    @Test
+    public void test429Retry() throws IntegrationException, InterruptedException {
+        HttpUrl url = new HttpUrl("https://localhost/api/developer-scans");
+        BdioFileContent header = new BdioFileContent("mock-header", "mock-content");
+        String contentType = "application/vnd.blackducksoftware.developer-scan-1-ld-2+json";
+        
+        BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
+        ApiDiscovery apiDiscovery = Mockito.mock(ApiDiscovery.class);
+        Response response = Mockito.mock(Response.class);
+        
+        IntLogger logger = new Slf4jIntLogger(LoggerFactory.getLogger(this.getClass()));
+        
+        BlackDuckResponseRequest request = new BlackDuckRequestBuilder()
+                .postString(header.getContent(), ContentType.create(contentType, StandardCharsets.UTF_8))
+                .addHeader("Content-type", contentType)
+                .buildBlackDuckResponseRequest(url);
+        
+        RapidScanConfigBdio2StreamUploader uploader = new RapidScanConfigBdio2StreamUploader(
+                blackDuckApiClient,
+                apiDiscovery,
+                logger,
+                new BlackDuckPath("/api/developer-scans", DeveloperScansScanView.class, false),
+                contentType);
+        
+        Mockito.when(blackDuckApiClient.executeAndRetrieveResponse(request)).thenReturn(response);
+        Mockito.when(response.getHeaderValue("retry-after"))
+            .thenReturn("1")
+            .thenReturn(null);
+        
+        Mockito.when(response.getStatusCode())
+            .thenReturn(429)
+            .thenReturn(200);
+        
+        uploader.recursiveExecute(request, 0, 0, 300);
+        
+        // Test that we made two calls, the 429 initial response, and the 200 success
+        Mockito.verify(blackDuckApiClient, Mockito.times(2)).executeAndRetrieveResponse(request);
+    }
+}


### PR DESCRIPTION
This work adds a retry and backoff mechanism when making a start call to the developer-scans endpoint. Similar work for intelligent persistent scans will come in a future PR.

 Basically what happens is that there is now code that examines the response code and

- retries using the retry-after header from BlackDuck if the response code is 408, 429, 502, 503, or 504
- does a Fibonacci backoff sequence if the retry code is 425 or 500