### PR TITLE
Add operations for container scan to status.json

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -360,7 +360,8 @@ public class OperationRunner {
                     );
             }
 
-            return uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeader);
+            String uploadHeaderOperationName = "Upload BDIO Header to Initiate Scan";
+            return uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeader, uploadHeaderOperationName);
         });
     }
 
@@ -470,22 +471,24 @@ public class OperationRunner {
         });
     }
 
-    public UUID uploadBdioHeaderToInitiateScan(BlackDuckRunData blackDuckRunData, File bdioHeaderFile) throws IntegrationException {
-        BlackDuckServicesFactory blackDuckServicesFactory = blackDuckRunData.getBlackDuckServicesFactory();
-        BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
+    public UUID uploadBdioHeaderToInitiateScan(BlackDuckRunData blackDuckRunData, File bdioHeaderFile, String operationName) throws OperationException {
+        return auditLog.namedInternal(operationName, () -> {
+            BlackDuckServicesFactory blackDuckServicesFactory = blackDuckRunData.getBlackDuckServicesFactory();
+            BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
 
-        String scanServicePostEndpoint = getScanServicePostEndpoint();
-        HttpUrl postUrl = blackDuckRunData.getBlackDuckServerConfig().getBlackDuckUrl().appendRelativeUrl(scanServicePostEndpoint);
+            String scanServicePostEndpoint = getScanServicePostEndpoint();
+            HttpUrl postUrl = blackDuckRunData.getBlackDuckServerConfig().getBlackDuckUrl().appendRelativeUrl(scanServicePostEndpoint);
 
-        String scanServicePostContentType = getScanServicePostContentType();
-        BlackDuckResponseRequest buildBlackDuckResponseRequest = new BlackDuckRequestBuilder()
-            .postFile(bdioHeaderFile, ContentType.create(scanServicePostContentType))
-            .buildBlackDuckResponseRequest(postUrl);
+            String scanServicePostContentType = getScanServicePostContentType();
+            BlackDuckResponseRequest buildBlackDuckResponseRequest = new BlackDuckRequestBuilder()
+                .postFile(bdioHeaderFile, ContentType.create(scanServicePostContentType))
+                .buildBlackDuckResponseRequest(postUrl);
 
-        HttpUrl responseUrl = blackDuckApiClient.executePostRequestAndRetrieveURL(buildBlackDuckResponseRequest);
-        String path = responseUrl.uri().getPath();
+            HttpUrl responseUrl = blackDuckApiClient.executePostRequestAndRetrieveURL(buildBlackDuckResponseRequest);
+            String path = responseUrl.uri().getPath();
 
-        return UUID.fromString(path.substring(path.lastIndexOf('/') + 1));
+            return UUID.fromString(path.substring(path.lastIndexOf('/') + 1));
+        });
     }
 
     public void uploadBdioEntries(BlackDuckRunData blackDuckRunData, UUID bdScanId) throws IntegrationException, IOException {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -77,6 +77,7 @@ public class ContainerScanStepRunner {
             logger.info("Container scan image uploaded successfully.");
         } catch (IntegrationException | IOException | OperationException e) {
             operationRunner.publishContainerFailure(e);
+            return Optional.empty();
         }
         return Optional.ofNullable(scanId);
     }
@@ -138,7 +139,7 @@ public class ContainerScanStepRunner {
         }
     }
 
-    public void uploadImageMetadataToStorageService() throws IntegrationException, IOException {
+    public void uploadImageMetadataToStorageService() throws IntegrationException, IOException, OperationException {
         String storageServiceEndpoint = String.join("", STORAGE_CONTAINERS_ENDPOINT, scanId.toString(), "/message");
         String operationName = "Upload Container Scan Image Metadata JSON";
         logger.debug("Uploading container image metadata to storage endpoint: {}", storageServiceEndpoint);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -100,7 +100,7 @@ public class ContainerScanStepRunner {
         return codeLocationNameManager.createContainerScanCodeLocationName(containerImage, projectNameVersion.getName(), projectNameVersion.getVersion());
     }
 
-    public void initiateScan() throws IOException, IntegrationException {
+    public void initiateScan() throws IOException, IntegrationException, OperationException {
         DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
             UUID.randomUUID().toString(),
             "CONTAINER",
@@ -108,7 +108,8 @@ public class ContainerScanStepRunner {
             projectGroupName,
             getContainerScanCodeLocationName());
         File bdioHeaderFile = detectProtobufBdioHeaderUtil.createProtobufBdioHeader(binaryRunDirectory);
-        scanId = operationRunner.uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeaderFile);
+        String operationName = "Upload Container Scan BDIO Header to Initiate Scan";
+        scanId = operationRunner.uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeaderFile, operationName);
         if (scanId == null) {
             logger.warn("Scan ID was not found in the response from the server.");
             throw new IntegrationException("Scan ID was not found in the response from the server.");

--- a/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerContainerScanTest.java
+++ b/src/test/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunnerContainerScanTest.java
@@ -13,6 +13,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
 import com.synopsys.integration.detect.configuration.enumeration.BlackduckScanMode;
+import com.synopsys.integration.detect.lifecycle.OperationException;
 import com.synopsys.integration.detect.testutils.ContainerScanTestUtils;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.NameVersion;
@@ -21,7 +22,8 @@ public class OperationRunnerContainerScanTest {
     private static final Gson gson = new Gson();
     private static final ContainerScanTestUtils containerScanTestUtils = new ContainerScanTestUtils();
 
-    private File updateDetectConfigAndGetContainerImage(BlackduckScanMode blackduckScanMode, String imageFilePath) throws IntegrationException, IOException, DetectUserFriendlyException {
+    private File updateDetectConfigAndGetContainerImage(BlackduckScanMode blackduckScanMode, String imageFilePath)
+        throws IntegrationException, IOException, DetectUserFriendlyException, OperationException {
         OperationRunner operationRunner = containerScanTestUtils.setUpDetectConfig(blackduckScanMode, imageFilePath);
         OperationRunner operationRunnerSpy = Mockito.spy(operationRunner);
         Mockito.doReturn(ContainerScanTestUtils.TEST_IMAGE_DOWNLOADED_FILE).when(operationRunnerSpy).downloadContainerImage(gson, ContainerScanTestUtils.TEST_DOWNLOAD_DIRECTORY, imageFilePath);
@@ -29,7 +31,7 @@ public class OperationRunnerContainerScanTest {
     }
 
     @Test
-    public void testGetContainerScanImageForLocalFilePath() throws DetectUserFriendlyException, IntegrationException, IOException {
+    public void testGetContainerScanImageForLocalFilePath() throws DetectUserFriendlyException, IntegrationException, IOException, OperationException {
         // Intelligent
         File containerImageRetrieved = updateDetectConfigAndGetContainerImage(BlackduckScanMode.INTELLIGENT, ContainerScanTestUtils.TEST_IMAGE_LOCAL_FILE_PATH);
         Assertions.assertTrue(containerImageRetrieved != null && containerImageRetrieved.exists());
@@ -44,7 +46,7 @@ public class OperationRunnerContainerScanTest {
     }
 
     @Test
-    public void testGetContainerScanImageForImageUrl() throws DetectUserFriendlyException, IntegrationException, IOException {
+    public void testGetContainerScanImageForImageUrl() throws DetectUserFriendlyException, IntegrationException, IOException, OperationException {
         // Intelligent
         File containerImageRetrieved = updateDetectConfigAndGetContainerImage(BlackduckScanMode.INTELLIGENT, ContainerScanTestUtils.TEST_IMAGE_URL);
         Assertions.assertTrue(containerImageRetrieved != null && containerImageRetrieved.exists());


### PR DESCRIPTION
### Description

Add operations for Container Scan to the "operations" section in the status.json. Addresses only one part of IDETECT-4086 where container scan operations were not being reported to status.json.

The main thing to note in this PR is that to report an operation in status.json, the container scan operations have been wrapped using the below 2 wrapper methods:

`auditLog.namedInternal(String operationName, OperationWrapper.OperationFunction supplier)`
The `namedInternal` wrapper will report an operation to status.json only if there was a failure during the supplier's execution.

auditLog.namedPublic(String operationName, OperationWrapper.OperationFunction supplier)
The `namedPublic` wrapper will always report an operation to status.json - irrespective of execution status.

### JIRA
IDETECT-4086
