### PR TITLE
Include container scan codelocation in status.json

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/data/BlackDuckRunData.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/data/BlackDuckRunData.java
@@ -86,7 +86,7 @@ public class BlackDuckRunData {
 
     private void determineBlackDuckServerVersion(BlackDuckConnectivityResult blackDuckConnectivityResult) {
         if (blackDuckConnectivityResult == null || blackDuckConnectivityResult.getContactedServerVersion() == null) {
-            blackDuckServerVersion = null;
+            blackDuckServerVersion = Optional.empty();
         } else {
             BlackDuckVersionParser parser = new BlackDuckVersionParser();
             blackDuckServerVersion = parser.parse(blackDuckConnectivityResult.getContactedServerVersion());

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -141,6 +141,9 @@ public class IntelligentModeStepRunner {
                 logger.debug("Invoking intelligent persistent container scan.");
                 Optional<UUID> scanId = containerScanStepRunner.invokeContainerScanningWorkflow();
                 scanId.ifPresent(uuid -> scanIdsToWaitFor.add(uuid.toString()));
+                Set<String> containerScanCodeLocations = new HashSet<>();
+                containerScanCodeLocations.add(containerScanStepRunner.getCodeLocationName());
+                codeLocationAccumulator.addNonWaitableCodeLocation(containerScanCodeLocations);
             }
         );
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -111,6 +111,7 @@ public class RapidModeStepRunner {
                         String statelessScanEndpoint = operationRunner.getScanServicePostEndpoint();
                         HttpUrl scanServiceUrlToPoll = new HttpUrl(blackDuckUrl + statelessScanEndpoint + "/" + scanId.get());
                         parsedUrls.add(scanServiceUrlToPoll);
+                        formattedCodeLocations.add(new FormattedCodeLocation(null, scanId.get(), DetectTool.CONTAINER_SCAN.name()));
                     }
                 }
             }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -111,7 +111,7 @@ public class RapidModeStepRunner {
                         String statelessScanEndpoint = operationRunner.getScanServicePostEndpoint();
                         HttpUrl scanServiceUrlToPoll = new HttpUrl(blackDuckUrl + statelessScanEndpoint + "/" + scanId.get());
                         parsedUrls.add(scanServiceUrlToPoll);
-                        formattedCodeLocations.add(new FormattedCodeLocation(null, scanId.get(), DetectTool.CONTAINER_SCAN.name()));
+                        formattedCodeLocations.add(new FormattedCodeLocation(containerScanStepRunner.getCodeLocationName(), scanId.get(), DetectTool.CONTAINER_SCAN.name()));
                     }
                 }
             }


### PR DESCRIPTION
### Description

Include container scan code location information in status.json for intelligent and stateless modes.
For intelligent modes, the codeLocation array in status.json currently only includes objects with the code location name field.
```
{
      "codeLocationName": <codeLocationName>
}
```

For stateless mode, this array includes objects with the code location name, scan ID and scan type.
```
{
      "codeLocationName": <codeLocationName>,
      "scanId": <UUID>,
      "scanType": "CONTAINER_SCAN"
}
```

We need to add code location info to `codeLocationAccumulator` for Intelligent mode and `formattedCodeLocations` for stateless mode. Detect's event system captures these 2 objects downstream for publishing to status.json.

### JIRA
IDETECT-4086 (part 2 - addressing code locations)
