### PR TITLE
Update CLL version to include bug fixes going in to Detect 9.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ dependencies {
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.6'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
     implementation 'com.synopsys:method-analyzer-core:0.2.0'
-    implementation "${locatorGroup}:${locatorModule}:1.0.16"
+    implementation "${locatorGroup}:${locatorModule}:1.0.17"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
     implementation "org.springframework.boot:spring-boot"


### PR DESCRIPTION
IDETECT-4004 and IDETECT-4066 are fixed in CLL v1.0.17 (matching dummy lib version update is also done). 

No update to release notes since these were bugs reported internally. 
