### PR TITLE
Show scan service URL with scan ID in stateless container scan info logs

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -110,6 +110,7 @@ public class RapidModeStepRunner {
                     if (scanId.isPresent()) {
                         String statelessScanEndpoint = operationRunner.getScanServicePostEndpoint();
                         HttpUrl scanServiceUrlToPoll = new HttpUrl(blackDuckUrl + statelessScanEndpoint + "/" + scanId.get());
+                        logger.info("Stateless mode container scan URL: {}", scanServiceUrlToPoll);
                         parsedUrls.add(scanServiceUrlToPoll);
                         formattedCodeLocations.add(new FormattedCodeLocation(containerScanStepRunner.getCodeLocationName(), scanId.get(), DetectTool.CONTAINER_SCAN.name()));
                     }


### PR DESCRIPTION
Resolves IDETECT-4094. Having this at INFO is useful to trace issues through the Hub logs