### PR TITLE
Update to latest blackduck-common

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,7 @@ def createBatteryPath() {
 def final locatorGroup = "com.synopsys.integration"
 def final locatorModule = "component-locator"
 final def externalRepoHost = "https://sig-repo.synopsys.com"
-final def internalRepoHost = "https://artifactory.internal.synopsys.com"
-//System.getenv('SNPS_INTERNAL_ARTIFACTORY')
+final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 
 repositories {
     println "Checking if environment property SNPS_INTERNAL_ARTIFACTORY is configured: ${internalRepoHost}"

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,8 @@ def createBatteryPath() {
 def final locatorGroup = "com.synopsys.integration"
 def final locatorModule = "component-locator"
 final def externalRepoHost = "https://sig-repo.synopsys.com"
-final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
+final def internalRepoHost = "https://artifactory.internal.synopsys.com"
+//System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 
 repositories {
     println "Checking if environment property SNPS_INTERNAL_ARTIFACTORY is configured: ${internalRepoHost}"

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.9'
+gradle.ext.blackDuckCommonVersion='66.2.11-SNAPSHOT'
 gradle.ext.springBootVersion='2.7.12'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.11-SNAPSHOT'
+gradle.ext.blackDuckCommonVersion='66.2.11'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
This picks up the latest blackduck-common that contains https://github.com/blackducksoftware/blackduck-common/pull/413 which basically keeps the 2023.4.2.2 and updates a message for intelligent persistent retry scans