### PR TITLE
handle no location header

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
@@ -62,7 +62,7 @@ public class RapidScanConfigBdio2StreamUploader {
         
         if (location == null) {
             throw new IntegrationException("Attempted to create a scan by uploading to " + url.toString()
-                    + " but failed with " + response.getStatusCode() + " response code.");
+                    + " but failed with " + response.getStatusCode() + " response code from the Black Duck server.");
         }
         
         HttpUrl responseUrl = new HttpUrl(location);

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
@@ -58,8 +58,13 @@ public class RapidScanConfigBdio2StreamUploader {
             .apply(editor)
             .buildBlackDuckResponseRequest(url);
         Response response = recursiveExecute(request, 0L, 0, detectTimeout);
-        HttpUrl responseUrl = new HttpUrl(response.getHeaderValue("location"));
-        logger.debug(String.format("Starting upload to %s", responseUrl.toString()));
+        String location = response.getHeaderValue("location");
+        
+        HttpUrl responseUrl = null;
+        if (location != null) {
+            responseUrl = new HttpUrl(location);
+            logger.debug(String.format("Starting upload to %s", responseUrl.toString()));
+        }
         return responseUrl;
     }
     

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/developer/blackduck/RapidScanConfigBdio2StreamUploader.java
@@ -60,11 +60,13 @@ public class RapidScanConfigBdio2StreamUploader {
         Response response = recursiveExecute(request, 0L, 0, detectTimeout);
         String location = response.getHeaderValue("location");
         
-        HttpUrl responseUrl = null;
-        if (location != null) {
-            responseUrl = new HttpUrl(location);
-            logger.debug(String.format("Starting upload to %s", responseUrl.toString()));
+        if (location == null) {
+            throw new IntegrationException("Attempted to create a scan by uploading to " + url.toString()
+                    + " but failed with " + response.getStatusCode() + " response code.");
         }
+        
+        HttpUrl responseUrl = new HttpUrl(location);
+        logger.debug(String.format("Starting upload to %s", responseUrl.toString()));
         return responseUrl;
     }
     


### PR DESCRIPTION
If we get no location header we should throw an integration exception like we did before.