### PR TITLE
do not retry scan creation with no or zero header

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.11'
+gradle.ext.blackDuckCommonVersion='66.2.12'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
This pulls in https://github.com/blackducksoftware/blackduck-common/pull/414 which will no longer retry when we get a 429 with no retry-header or a retry-header that is 0