### PR TITLE
Release note for Detect's Docker Image Updates

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -19,5 +19,5 @@
 * (IDETECT-3843) Additional information is now provided when [solution_name] fails to update and [solution_name] is internally hosted.
 
 ### Dependency updates
-* Upgraded Alpine version of Detect's Docker image to 3.18 to allow pulling the latest curl version with no known vulnerabilities.
-* Updated Detect's Ubuntu Docker image to use wget instead of curl to remove curl as a dependency.
+* Upgraded [solution_name] Alpine Docker image to 3.18 to pull the latest curl version with no known vulnerabilities.
+* Removed curl as a dependency by updating [solution_name] Ubuntu Docker image to use wget instead of curl.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -19,5 +19,5 @@
 * (IDETECT-3843) Additional information is now provided when [solution_name] fails to update and [solution_name] is internally hosted.
 
 ### Dependency updates
-* Upgraded [solution_name] Alpine Docker image to 3.18 to pull the latest curl version with no known vulnerabilities.
+* Upgraded [solution_name] Alpine Docker images (standard and buildless) to 3.18 to pull the latest curl version with no known vulnerabilities.
 * Removed curl as a dependency from [solution_name] Ubuntu Docker image by using wget instead of curl.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -17,3 +17,7 @@
 * (IDETECT-4056) Resolved an issue where no components were reported by CPAN detector.
   If the cpan command has not been previously configured and run on the system, [solution_name] instructs CPAN to accept default configurations.
 * (IDETECT-3843) Additional information is now provided when [solution_name] fails to update and [solution_name] is internally hosted.
+
+### Dependency updates
+* Upgraded Alpine version of Detect's Docker image to 3.18 to allow pulling the latest curl version with no known vulnerabilities.
+* Updated Detect's Ubuntu Docker image to use wget instead of curl to remove curl as a dependency.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -20,4 +20,4 @@
 
 ### Dependency updates
 * Upgraded [solution_name] Alpine Docker image to 3.18 to pull the latest curl version with no known vulnerabilities.
-* Removed curl as a dependency by updating [solution_name] Ubuntu Docker image to use wget instead of curl.
+* Removed curl as a dependency from [solution_name] Ubuntu Docker image by using wget instead of curl.


### PR DESCRIPTION
Release note for the updates made to Detect's docker images in https://github.com/blackducksoftware/synopsys-detect-docker/pull/8 to resolve curl vulnerabilities appearing in the POP scans.