### PR TITLE
Add Integration Tests for Nuget Inspector - CPM

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/battery/docker/NugetInspectorTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/NugetInspectorTests.java
@@ -77,6 +77,7 @@ public class NugetInspectorTests {
             blackduckAssertions.hasComponents("Xamarin.UITest");
             blackduckAssertions.hasComponents("Microsoft.NET.Test.Sdk");
             blackduckAssertions.hasComponents("Microsoft.WindowsAppSDK");
+            blackduckAssertions.hasComponents("Microsoft.UI.Xaml");
         }
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/NugetInspectorTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/NugetInspectorTests.java
@@ -1,0 +1,82 @@
+package com.synopsys.integration.detect.battery.docker;
+
+
+import java.io.IOException;
+
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckAssertions;
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckTestConnection;
+import com.synopsys.integration.exception.IntegrationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detect.battery.docker.provider.BuildDockerImageProvider;
+import com.synopsys.integration.detect.battery.docker.util.DetectCommandBuilder;
+import com.synopsys.integration.detect.battery.docker.util.DetectDockerTestRunner;
+import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
+import com.synopsys.integration.detect.configuration.DetectProperties;
+import com.synopsys.integration.detector.base.DetectorType;
+
+//@Tag("integration")
+public class NugetInspectorTests {
+
+    private static final String PROJECT_NAME = "nuget-CPM-docker";
+
+    @Test
+    void nugetCPMStandardTest() throws IOException,IntegrationException {
+        try(DetectDockerTestRunner test = new DetectDockerTestRunner("detect-nuget-inspector-CPM", "detect-dotnet-seven:1.0.1")) {
+            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("CPM_standard.dockerfile"));
+
+            String projectVersion = PROJECT_NAME + "-normal";
+            BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+            BlackDuckAssertions blackduckAssertions = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, projectVersion);
+            blackduckAssertions.emptyOnBlackDuck();
+
+            DetectCommandBuilder commandBuilder = new DetectCommandBuilder().defaults().defaultDirectories(test);
+            commandBuilder.connectToBlackDuck(blackDuckTestConnection);
+            commandBuilder.projectNameVersion(blackduckAssertions);
+            commandBuilder.waitForResults();
+
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, "DETECTOR");
+            commandBuilder.property(DetectProperties.DETECT_INCLUDED_DETECTOR_TYPES, DetectorType.NUGET.toString());
+            DockerAssertions dockerAssertions = test.run(commandBuilder);
+
+            dockerAssertions.logContains("NuGet Solution Native Inspector: SUCCESS");
+            dockerAssertions.atLeastOneBdioFile();
+
+            blackduckAssertions.hasComponents("System.Text.Encodings.Web");
+            blackduckAssertions.hasComponents("MessagePack");
+            blackduckAssertions.hasComponents("Microsoft.CodeAnalysis.CSharp");
+            blackduckAssertions.hasComponents("CSharpIsNullAnalyzer");
+        }
+    }
+
+    @Test
+    void nugetMultiplePropsFileTest() throws IOException, IntegrationException {
+        try(DetectDockerTestRunner test = new DetectDockerTestRunner("detect-nuget-inspector-multiple-CPM", "detect-dotnet-seven:1.0.2")) {
+            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("CPM_multiple_propsfile.dockerfile"));
+
+            String projectVersion = PROJECT_NAME + "-multiple_props_file";
+            BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+            BlackDuckAssertions blackduckAssertions = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, projectVersion);
+            blackduckAssertions.emptyOnBlackDuck();
+
+            DetectCommandBuilder commandBuilder = new DetectCommandBuilder().defaults().defaultDirectories(test);
+            commandBuilder.connectToBlackDuck(blackDuckTestConnection);
+            commandBuilder.projectNameVersion(blackduckAssertions);
+            commandBuilder.waitForResults();
+
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, "DETECTOR");
+            commandBuilder.property(DetectProperties.DETECT_INCLUDED_DETECTOR_TYPES, DetectorType.NUGET.toString());
+            commandBuilder.property(DetectProperties.DETECT_DETECTOR_SEARCH_DEPTH, String.valueOf(5));
+            DockerAssertions dockerAssertions = test.run(commandBuilder);
+
+            dockerAssertions.logContains("NuGet Solution Native Inspector: SUCCESS");
+            dockerAssertions.atLeastOneBdioFile();
+
+            blackduckAssertions.hasComponents("Uno.Core.Extensions.Collections");
+            blackduckAssertions.hasComponents("Xamarin.UITest");
+            blackduckAssertions.hasComponents("Microsoft.NET.Test.Sdk");
+            blackduckAssertions.hasComponents("Microsoft.WindowsAppSDK");
+        }
+    }
+}

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/NugetInspectorTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/NugetInspectorTests.java
@@ -16,7 +16,7 @@ import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
 import com.synopsys.integration.detect.configuration.DetectProperties;
 import com.synopsys.integration.detector.base.DetectorType;
 
-//@Tag("integration")
+@Tag("integration")
 public class NugetInspectorTests {
 
     private static final String PROJECT_NAME = "nuget-CPM-docker";

--- a/src/test/resources/docker/CPM_multiple_propsfile.dockerfile
+++ b/src/test/resources/docker/CPM_multiple_propsfile.dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:7.0
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 
 ENV SRC_DIR=/opt/project/src
 

--- a/src/test/resources/docker/CPM_multiple_propsfile.dockerfile
+++ b/src/test/resources/docker/CPM_multiple_propsfile.dockerfile
@@ -1,0 +1,18 @@
+FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:7.0
+
+ENV SRC_DIR=/opt/project/src
+
+RUN apt-get update
+
+# Install java
+RUN mkdir -p /usr/share/man/man1/
+# Above due to: https://github.com/geerlingguy/ansible-role-java/issues/64
+RUN apt-get install -y openjdk-11-jre
+
+# Install git
+RUN apt-get install -y git
+
+# Set up the test project
+RUN mkdir -p ${SRC_DIR}
+WORKDIR ${SRC_DIR}
+RUN git clone --depth 1 https://github.com/unoplatform/uno.toolkit.ui.git ${SRC_DIR}

--- a/src/test/resources/docker/CPM_standard.dockerfile
+++ b/src/test/resources/docker/CPM_standard.dockerfile
@@ -1,0 +1,18 @@
+FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:7.0
+
+ENV SRC_DIR=/opt/project/src
+
+RUN apt-get update
+
+# Install java
+RUN mkdir -p /usr/share/man/man1/
+# Above due to: https://github.com/geerlingguy/ansible-role-java/issues/64
+RUN apt-get install -y openjdk-11-jre
+
+# Install git
+RUN apt-get install -y git
+
+# Set up the test project
+RUN mkdir -p ${SRC_DIR}
+WORKDIR ${SRC_DIR}
+RUN git clone --depth 1 https://github.com/microsoft/CsWin32.git ${SRC_DIR}

--- a/src/test/resources/docker/CPM_standard.dockerfile
+++ b/src/test/resources/docker/CPM_standard.dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:7.0
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 
 ENV SRC_DIR=/opt/project/src
 


### PR DESCRIPTION
This PR adds a few integration test cases for Nuget Inspector CPM and covers various different cases while validating the components found in Blackduck. The components which are asserted are derived from various places such as standard PackageVersion, GlobalPackageReference, Multiple Directory.Packages.props and also versions which are specified in the Property Group Tags. 

I ran a comprehensive pipeline after NI release today and the build was passing correctly.
