### PR TITLE
Container scan - Send image file size in Protobuf BDIO Header to Hub

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -25,12 +25,14 @@ public class ContainerScanStepRunner {
 
     private final OperationRunner operationRunner;
     private UUID scanId;
+    private String scanType = "CONTAINER";
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final NameVersion projectNameVersion;
     private final String projectGroupName;
     private final BlackDuckRunData blackDuckRunData;
     private final File binaryRunDirectory;
     private final File containerImage;
+    private final Long containerImageSizeInBytes;
     private String codeLocationName;
     private static final BlackDuckVersion MIN_BLACK_DUCK_VERSION = new BlackDuckVersion(2023, 10, 0);
     private static final String STORAGE_CONTAINERS_ENDPOINT = "/api/storage/containers/";
@@ -48,6 +50,7 @@ public class ContainerScanStepRunner {
         }
         projectGroupName = operationRunner.calculateProjectGroupOptions().getProjectGroup();
         containerImage = operationRunner.getContainerScanImage(gson, binaryRunDirectory);
+        containerImageSizeInBytes = containerImage != null && containerImage.exists() ? containerImage.length() : 0;
     }
 
     public Optional<UUID> invokeContainerScanningWorkflow() {
@@ -108,10 +111,11 @@ public class ContainerScanStepRunner {
     private void initiateScan() throws IOException, IntegrationException, OperationException {
         DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
             UUID.randomUUID().toString(),
-            "CONTAINER",
+            scanType,
             projectNameVersion,
             projectGroupName,
-            codeLocationName);
+            codeLocationName,
+            containerImage.length());
         File bdioHeaderFile = detectProtobufBdioHeaderUtil.createProtobufBdioHeader(binaryRunDirectory);
         String operationName = "Upload Container Scan BDIO Header to Initiate Scan";
         scanId = operationRunner.uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeaderFile, operationName);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -115,7 +115,7 @@ public class ContainerScanStepRunner {
             projectNameVersion,
             projectGroupName,
             codeLocationName,
-            containerImage.length());
+            containerImageSizeInBytes);
         File bdioHeaderFile = detectProtobufBdioHeaderUtil.createProtobufBdioHeader(binaryRunDirectory);
         String operationName = "Upload Container Scan BDIO Header to Initiate Scan";
         scanId = operationRunner.uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeaderFile, operationName);

--- a/src/main/java/com/synopsys/integration/detect/util/bdio/protobuf/DetectProtobufBdioHeaderUtil.java
+++ b/src/main/java/com/synopsys/integration/detect/util/bdio/protobuf/DetectProtobufBdioHeaderUtil.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.UUID;
 import java.util.zip.ZipOutputStream;
 
 import com.blackducksoftware.bdio.proto.ProtobufBdioWriter;
@@ -14,11 +15,24 @@ import com.synopsys.integration.util.NameVersion;
 public class DetectProtobufBdioHeaderUtil {
     private final String scanId;
     private final String scanType;
-    private final NameVersion projectNameVersion;
-    private final String projectGroupName;
     private final String codeLocationName;
-    private final Long fileSystemSizeInBytes;
+
+    private final NameVersion projectNameVersion;
+    private final String publisherName;
+    private final String publisherVersion;
+    private final String publisherComment;
     private static final String CREATOR_NAME = "SYNOPSYS_DETECT";
+    private final Instant creationTime;
+    private final String sourceRepository;
+    private final String sourceBranch;
+    private final String projectGroupName;
+    private final UUID correlationId;
+    private final Long matchConfidenceThreshold;
+    private final String baseDir;
+    private final Boolean withStringSearch;
+    private final Boolean withSnippetMatching;
+    private final Boolean retainUnmatchedFiles;
+    private final Long fileSystemSizeInBytes;
 
     public DetectProtobufBdioHeaderUtil(String scanId,
         String scanType,
@@ -29,9 +43,21 @@ public class DetectProtobufBdioHeaderUtil {
     ) {
         this.scanId = scanId;
         this.scanType = scanType;
-        this.projectNameVersion = projectNameVersion;
-        this.projectGroupName = projectGroupName;
         this.codeLocationName = codeLocationName;
+        this.projectNameVersion = projectNameVersion;
+        this.publisherName = "";
+        this.publisherVersion = "";
+        this.publisherComment = "";
+        this.creationTime = Instant.now();
+        this.sourceRepository = null;
+        this.sourceBranch = null;
+        this.projectGroupName = projectGroupName;
+        this.correlationId = null;
+        this.matchConfidenceThreshold = 1L;
+        this.baseDir = "/";
+        this.withStringSearch = false;
+        this.withSnippetMatching = false;
+        this.retainUnmatchedFiles = null;
         this.fileSystemSizeInBytes = fileSystemSizeInBytes;
     }
 
@@ -42,20 +68,20 @@ public class DetectProtobufBdioHeaderUtil {
             codeLocationName,
             projectNameVersion.getName(),
             projectNameVersion.getVersion(),
-            "",
-            "",
-            "",
+            publisherName,
+            publisherVersion,
+            publisherComment,
             CREATOR_NAME,
-            Instant.now(),
-            null,
-            null,
+            creationTime,
+            sourceRepository,
+            sourceBranch,
             projectGroupName,
-            null,
-            1L,
-            "/",
-            true,
-            true,
-            null,
+            correlationId,
+            matchConfidenceThreshold,
+            baseDir,
+            withStringSearch,
+            withSnippetMatching,
+            retainUnmatchedFiles,
             fileSystemSizeInBytes)
             ;
 

--- a/src/main/java/com/synopsys/integration/detect/util/bdio/protobuf/DetectProtobufBdioHeaderUtil.java
+++ b/src/main/java/com/synopsys/integration/detect/util/bdio/protobuf/DetectProtobufBdioHeaderUtil.java
@@ -17,14 +17,22 @@ public class DetectProtobufBdioHeaderUtil {
     private final NameVersion projectNameVersion;
     private final String projectGroupName;
     private final String codeLocationName;
+    private final Long fileSystemSizeInBytes;
     private static final String CREATOR_NAME = "SYNOPSYS_DETECT";
 
-    public DetectProtobufBdioHeaderUtil(String scanId, String scanType, NameVersion projectNameVersion, String projectGroupName, String codeLocationName) {
+    public DetectProtobufBdioHeaderUtil(String scanId,
+        String scanType,
+        NameVersion projectNameVersion,
+        String projectGroupName,
+        String codeLocationName,
+        Long fileSystemSizeInBytes
+    ) {
         this.scanId = scanId;
         this.scanType = scanType;
         this.projectNameVersion = projectNameVersion;
         this.projectGroupName = projectGroupName;
         this.codeLocationName = codeLocationName;
+        this.fileSystemSizeInBytes = fileSystemSizeInBytes;
     }
 
     public File createProtobufBdioHeader(File targetDirectory) throws IOException {
@@ -48,7 +56,7 @@ public class DetectProtobufBdioHeaderUtil {
             true,
             true,
             null,
-            null)
+            fileSystemSizeInBytes)
             ;
 
         String tempBdioArchivePath = targetDirectory.toPath() + "/bdio-protobuf.zip";


### PR DESCRIPTION
### Description

Send the container image file size (in bytes) in the protobuf bdio header that Detect uploads to Hub to initiate container scan. `ContainerScanStepRunner` is the main class to look for this particular change.
(Also vertified file size in bytes that Detect computes matches file size bytes on local file system)

In the `DetectProtobufBDIOHeaderUtil` class, the 2 fields `withStringSearch` and `withSnippetMatching` have been updated to `false` after discussion with Hub. Hub uses these fields to determine whether string search and snippet matching will follow the initiated scan. For container scan, this is not applicable. Hence, unnecessary invocation of these 2 workflows is skipped early on Hub end. 

(Other changes are minor refactoring-related)

### JIRA Issue
IDETECT-4174