### PR TITLE
Fix for IDETECT-4182 - CVE-2023-2976.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ subprojects {
 
 allprojects {
     dependencies {
-        implementation "com.google.guava:guava:31.1-jre"
+        implementation "com.google.guava:guava:32.1.2-jre"
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'
 
         implementation 'org.freemarker:freemarker:2.3.31'


### PR DESCRIPTION
# Description

Upgrades Guava from 31.1 to 32.1.2 for CVE-2023-2976.

# Github Issues

IDETECT-4182
