### PR TITLE
Changed message description for Deprecated Values

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -479,8 +479,8 @@ public class DetectProperties {
             .setHelp(
                 "Use this value to enable the various snippet scanning modes. For a full explanation, please refer to the 'Running a component scan using the Signature Scanner command line' section in your Black Duck server's online help. Corresponding Signature Scanner CLI Arguments: --snippet-matching, --snippet-matching-only, --full-snippet-scan.")
             .setGroups(DetectGroup.SIGNATURE_SCANNER, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN)
-            .build().deprecateValue(SnippetMatching.FULL_SNIPPET_MATCHING,"Will be deprecated in the next major release")
-                .deprecateValue(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY,"Will be deprecated in the next major release");
+            .build().deprecateValue(SnippetMatching.FULL_SNIPPET_MATCHING,"Is deprecated and will be removed in the next major release")
+                .deprecateValue(SnippetMatching.FULL_SNIPPET_MATCHING_ONLY,"Is deprecated and will be removed in the next major release");
     
     public static final ExtendedEnumProperty<ExtendedReducedPersistanceMode, ReducedPersistence> DETECT_BLACKDUCK_SIGNATURE_SCANNER_REDUCED_PERSISTENCE =
             ExtendedEnumProperty.newBuilder(


### PR DESCRIPTION
As per @karolynSynopsys's suggestion, I am changing the message which appears in the Detect logs for the deprecated values. The earlier message was confusing as the properties have already been deprecated.
