### PR TITLE
cp_IDETECT-4185_doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ For AirGap, please use our [Artifactory](https://sig-repo.synopsys.com/webapp/#/
 
 The latest quickstart documentation is [here](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/gettingstarted/quickstart.html).
 
-The latest full documentation is [here](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/introduction.html).
-
-Links to certain earlier versions can be found [here](https://community.synopsys.com/s/user-guide-archive).
+The latest full documentation and archived documentation in PDF format is [here](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/introduction.html).
 
 ## Getting help
 

--- a/documentation/src/main/markdown/components/inspectors.md
+++ b/documentation/src/main/markdown/components/inspectors.md
@@ -28,7 +28,7 @@ If you are offline the Docker Inspector jar file and required Docker image tar f
 
 In either case the Docker Inspector jar is run by default which uses your Docker engine to start and stop the container-based services.
 
-The source code for Docker Inspector is located at [GitHub](https://github.com/blackducksoftware/blackduck-docker-inspector).
+The source code for Docker Inspector is located at [GitHub](https://github.com/blackducksoftware/detect-docker-inspector).
 
 ## NuGet Inspector
 

--- a/documentation/src/main/markdown/components/inspectors.md
+++ b/documentation/src/main/markdown/components/inspectors.md
@@ -2,16 +2,16 @@
 
 An inspector is typically a plugin that a [solution_name] detector uses to access the internal resources of a package manager through its API.
 
-There are currently three inspectors that [solution_name] might download and one inspector it has internally.
+There are currently three inspectors that [solution_name] might download and one internally coded inspector.
 
-If [solution_name] decides that your package manager needs an external inspector you must either be online or have the applicable air gap files.
+If [solution_name] decides that your package manager requries an external inspector you must either be online or have the applicable air gap files available.
 
 ## Gradle inspector
 
-For Gradle a common integrations library is added as a dependency to a temporary Gradle script file that is executed by the [solution_name] Gradle detector. 
+For Gradle, a common integrations library is added as a dependency to a temporary Gradle script file that is executed by the [solution_name] Gradle detector. 
 
-If you are online the Synopsys Artifactory instance is added as a Maven repository and the library is downloaded by Gradle.
-If you are offline the air gap library jar files are added as classpath file dependencies.
+If you are online, the Synopsys Artifactory instance is added as a Maven repository and the library is downloaded by Gradle.
+If you are offline, the air gap library jar files are added as classpath file dependencies.
 
 In both cases, the [solution_name] Gradle detector executes the custom Gradle script mentioned above, which invokes a custom Gradle task.
 
@@ -21,9 +21,9 @@ The source code for the library is located at [GitHub](https://github.com/blackd
 
 The Docker Inspector is available as a Java jar file or shell script for Linux or Mac.
 
-If you are online the Synopsys Artifactory instance is used to download the Docker Inspector jar file.
+If you are online, the Synopsys Artifactory instance is used to download the Docker Inspector jar file.
 
-If you are offline the Docker Inspector jar file and required Docker image tar files are sourced from the provided path to the Docker Inspector air gap files.
+If you are offline, the Docker Inspector jar file and required Docker image tar files are sourced from the path provided to the Docker Inspector air gap files.
 [solution_name] loads the Docker images (container-based services that Docker Inspector depends on) from the provided image tar files so they are available to the Docker Inspector.
 
 In either case the Docker Inspector jar is run by default which uses your Docker engine to start and stop the container-based services.
@@ -32,10 +32,10 @@ The source code for Docker Inspector is located at [GitHub](https://github.com/b
 
 ## NuGet Inspector
 
-The NuGet inspector is available as an independent executable for Windows, Linux and Mac.
+The NuGet inspector is available as an independent executable for Windows, Linux, and Mac.
 
-If you are online the Synopsys Artifactory instance is used to download the applicable NuGet inspector which is then unzipped and the runtime files are located.
-If you are offline the air gap inspector runtime files are located at the provided path.
+If you are online, the Synopsys Artifactory instance is used to download the applicable NuGet inspector which is then unzipped and the runtime files are located.
+If you are offline, the air gap inspector runtime files are located at the provided path.
 
 In either case the located executable is run which communicates with NuGet and the dotnet build system.
 

--- a/documentation/src/main/markdown/components/inspectors.md
+++ b/documentation/src/main/markdown/components/inspectors.md
@@ -4,7 +4,7 @@ An inspector is typically a plugin that a [solution_name] detector uses to acces
 
 There are currently three inspectors that [solution_name] might download and one internally coded inspector.
 
-If [solution_name] decides that your package manager requries an external inspector you must either be online or have the applicable air gap files available.
+If [solution_name] decides that your package manager requires an external inspector you must either be online or have the applicable air gap files available.
 
 ## Gradle inspector
 

--- a/documentation/src/main/markdown/components/inspectors.md
+++ b/documentation/src/main/markdown/components/inspectors.md
@@ -2,7 +2,7 @@
 
 An inspector is typically a plugin that a [solution_name] detector uses to access the internal resources of a package manager through its API.
 
-There are currently three inspectors that [solution_name] might download and one internally coded inspector.
+There are currently three inspectors that [solution_name] might download, and one internally coded inspector.
 
 If [solution_name] decides that your package manager requires an external inspector you must either be online or have the applicable air gap files available.
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -2,8 +2,6 @@
 
 ## Version 9.3.0
 
-### New features
-
 ### Changed features
 
 * Any arguments that specify the number of threads to be used provided as part of the `detect.maven.build.command` [solution_name] property will be omitted when executing the Maven CLI.
@@ -14,3 +12,6 @@
 * (IDETECT-4176) The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options, currently controlled via registration key, for the --detect.blackduck.signature.scanner.snippet.matching property are deprecated and will be removed in the next major release of [solution_name].
 
 ### Dependency updates
+
+* Updated Guava library from 31.1 to 32.1.2 to resolve high severity [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976).
+

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -11,6 +11,6 @@
 ### Resolved Issues
 
 * (IDETECT-4174) Resolved an issue where [solution_name] was not sending the container scan size to [blackduck_product_name] server, resulting in  [blackduck_product_name]'s "Scans" page reporting the size as zero.
-* (IDETECT-4176) The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options, currently controlled via registration key, for the --detect.blackduck.signature.scanner.snippet.matching property will be deprecated in the next major release of [solution_name].
+* (IDETECT-4176) The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options, currently controlled via registration key, for the --detect.blackduck.signature.scanner.snippet.matching property are deprecated and will be removed in the next major release of [solution_name].
 
 ### Dependency updates

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -8,10 +8,11 @@
 
 ### Resolved Issues
 
+* (IDETECT-4164) Improved Component Location Analysis parser support for package managers like Poetry that employ variable delimiters, for better location accuracy.
+* (IDETECT-4171) Improved Component Location Analysis data validation support for package managers like NPM.
 * (IDETECT-4174) Resolved an issue where [solution_name] was not sending the container scan size to [blackduck_product_name] server, resulting in  [blackduck_product_name]'s "Scans" page reporting the size as zero.
 * (IDETECT-4176) The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options, currently controlled via registration key, for the --detect.blackduck.signature.scanner.snippet.matching property are deprecated and will be removed in the next major release of [solution_name].
 
 ### Dependency updates
 
 * Updated Guava library from 31.1 to 32.1.2 to resolve high severity [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976).
-


### PR DESCRIPTION
update: docker inspector link here: https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/components/inspectors.html  to: https://github.com/blackducksoftware/detect-docker-inspector
Correct the wording for IDETECT-4176. Should say "it is deprecated and will be removed in the next major release".
Release note page tweaks.