### PR TITLE
cp_IDETECT-4196_doc

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -1,18 +1,19 @@
 # Current Release notes
 
-## Version 9.3.0
+## Version 9.4.0
+
+### New features
+
+* 
 
 ### Changed features
 
-* Any arguments that specify the number of threads to be used provided as part of the `detect.maven.build.command` [solution_name] property will be omitted when executing the Maven CLI.
+* 
 
-### Resolved Issues
+### Resolved issues
 
-* (IDETECT-4164) Improved Component Location Analysis parser support for package managers like Poetry that employ variable delimiters, for better location accuracy.
-* (IDETECT-4171) Improved Component Location Analysis data validation support for package managers like NPM.
-* (IDETECT-4174) Resolved an issue where [solution_name] was not sending the container scan size to [blackduck_product_name] server, resulting in  [blackduck_product_name]'s "Scans" page reporting the size as zero.
-* (IDETECT-4176) The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options, currently controlled via registration key, for the --detect.blackduck.signature.scanner.snippet.matching property are deprecated and will be removed in the next major release of [solution_name].
+* 
 
 ### Dependency updates
 
-* Updated Guava library from 31.1 to 32.1.2 to resolve high severity [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976).
+* 

--- a/documentation/src/main/markdown/previousreleasenotes.md
+++ b/documentation/src/main/markdown/previousreleasenotes.md
@@ -1,6 +1,23 @@
 <!-- Check the support matrix to determine supported, non-current major version releases -->
 # Release notes for previous supported versions
 
+## Version 9.3.0
+
+### Changed features
+
+* Any arguments that specify the number of threads to be used provided as part of the `detect.maven.build.command` [solution_name] property will be omitted when executing the Maven CLI.
+
+### Resolved issues
+
+* (IDETECT-4164) Improved Component Location Analysis parser support for package managers like Poetry that employ variable delimiters, for better location accuracy.
+* (IDETECT-4171) Improved Component Location Analysis data validation support for package managers like NPM.
+* (IDETECT-4174) Resolved an issue where [solution_name] was not sending the container scan size to [blackduck_product_name] server, resulting in  [blackduck_product_name]'s "Scans" page reporting the size as zero.
+* (IDETECT-4176) The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options, currently controlled via registration key, for the --detect.blackduck.signature.scanner.snippet.matching property are deprecated and will be removed in the next major release of [solution_name].
+
+### Dependency updates
+
+* Updated Guava library from 31.1 to 32.1.2 to resolve high severity [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976).
+
 ## Version 9.2.0
 
 ### New features
@@ -14,7 +31,7 @@
 
 * pnpm 6, and pnpm 7 using the default v5 pnpm-lock.yaml file, are being deprecated. Support will be removed in [solution_name] 10.
 
-### Resolved Issues
+### Resolved issues
 
 * (IDETECT-3515) Resolved an issue where the Nuget Inspector was not supporting "\<Version\>" tags for "\<PackageReference\>" on the second line and was not cascading to Project Inspector in case of failure.
 

--- a/documentation/topics.ditamap
+++ b/documentation/topics.ditamap
@@ -7,7 +7,7 @@
 		<prodinfo>
 			<prodname>Synopsys Detect</prodname>
 			<vrmlist>
-				<vrm version="9.3.0"/>
+				<vrm version="9.4.0"/>
 			</vrmlist>
 		</prodinfo>
 		<!-- zoomin bundle name -->


### PR DESCRIPTION
Prep the documentation so that devs don’t need to worry about re-organizing release note content.
Update version string
Update release note files in preparation for 9.4.0 content.
