### PR TITLE
Added Doc changes for Nuget Inspector release

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* Nuget Inspector will now support exclusion of different dependency types from BOM with the use of a new property --detect.nuget.dependency.types.excluded added in [solution_name].
+* Nuget Inspector now supports the exclusion of user-specified dependency types from the Bill of Materials (BOM) via the [solution_name] property --detect.nuget.dependency.types.excluded. See the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property for more information.
 
 ### Changed features
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -1,18 +1,15 @@
 # Current Release notes
 
-## Version 9.3.0
+## Version 9.4.0
+
+### New features
+
+* Nuget Inspector will now support exclusion of different dependency types from BOM with the use of a new property --detect.nuget.dependency.types.excluded added in [solution_name]. 
 
 ### Changed features
 
-* Any arguments that specify the number of threads to be used provided as part of the `detect.maven.build.command` [solution_name] property will be omitted when executing the Maven CLI.
-
 ### Resolved Issues
-
-* (IDETECT-4164) Improved Component Location Analysis parser support for package managers like Poetry that employ variable delimiters, for better location accuracy.
-* (IDETECT-4171) Improved Component Location Analysis data validation support for package managers like NPM.
-* (IDETECT-4174) Resolved an issue where [solution_name] was not sending the container scan size to [blackduck_product_name] server, resulting in  [blackduck_product_name]'s "Scans" page reporting the size as zero.
-* (IDETECT-4176) The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options, currently controlled via registration key, for the --detect.blackduck.signature.scanner.snippet.matching property are deprecated and will be removed in the next major release of [solution_name].
 
 ### Dependency updates
 
-* Updated Guava library from 31.1 to 32.1.2 to resolve high severity [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976).
+* Released and Upgraded Nuget Inspector to version 1.3.0.

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -21,6 +21,10 @@ The detectors run a platform dependent self-contained executable that is current
 * The NuGet Detectors do not work with mono.
 </note>
 
+## Excluding dependency types
+[solution_name] offers the ability to exclude package manager specific dependency types from the BOM.
+Nuget dependency types can be filtered with the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property.
+
 ### [solution_name] NuGet Inspector downloads
 
 [solution_name] jar execution will automatically download any required binaries not located in the cache.

--- a/documentation/src/main/markdown/previousreleasenotes.md
+++ b/documentation/src/main/markdown/previousreleasenotes.md
@@ -1,6 +1,23 @@
 <!-- Check the support matrix to determine supported, non-current major version releases -->
 # Release notes for previous supported versions
 
+## Version 9.3.0
+
+### Changed features
+
+* Any arguments that specify the number of threads to be used provided as part of the `detect.maven.build.command` [solution_name] property will be omitted when executing the Maven CLI.
+
+### Resolved Issues
+
+* (IDETECT-4164) Improved Component Location Analysis parser support for package managers like Poetry that employ variable delimiters, for better location accuracy.
+* (IDETECT-4171) Improved Component Location Analysis data validation support for package managers like NPM.
+* (IDETECT-4174) Resolved an issue where [solution_name] was not sending the container scan size to [blackduck_product_name] server, resulting in  [blackduck_product_name]'s "Scans" page reporting the size as zero.
+* (IDETECT-4176) The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options, currently controlled via registration key, for the --detect.blackduck.signature.scanner.snippet.matching property are deprecated and will be removed in the next major release of [solution_name].
+
+### Dependency updates
+
+* Updated Guava library from 31.1 to 32.1.2 to resolve high severity [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976).
+
 ## Version 9.2.0
 
 ### New features


### PR DESCRIPTION
As part of this [PR#1032](https://github.com/blackducksoftware/synopsys-detect/pull/1032), there was a new property added in Detect for excluding different dependency types in Nuget. These are the related doc changes for enhancement IDETECT-4140 to be released in Detect 9.4.0. Also added that a new version of NI will be released with this Detect release.
