### PR TITLE
PIP Requirements File Parsing Detector - Part 1

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFile.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFile.java
@@ -1,0 +1,10 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+
+public class RequirementsFile {
+    @SerializedName("default")
+    public Map<String, RequirementsFileDependencyEntry> dependencies;
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependency.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependency.java
@@ -1,0 +1,19 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+public class RequirementsFileDependency {
+    private final String name;
+    private final String version;
+
+    public RequirementsFileDependency(String name, String version) {
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyEntry.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyEntry.java
@@ -1,0 +1,8 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import com.google.gson.annotations.SerializedName;
+
+public class RequirementsFileDependencyEntry {
+    @SerializedName("version")
+    public String version;
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyTransformer.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsFileDependencyTransformer {
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyTransformer.java
@@ -1,2 +1,27 @@
-package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsFileDependencyTransformer {
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import java.util.List;
+
+import com.synopsys.integration.bdio.graph.BasicDependencyGraph;
+import com.synopsys.integration.bdio.graph.DependencyGraph;
+import com.synopsys.integration.bdio.model.Forge;
+import com.synopsys.integration.bdio.model.dependency.Dependency;
+import com.synopsys.integration.bdio.model.dependency.DependencyFactory;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+
+public class RequirementsFileDependencyTransformer {
+    private final ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+    private final DependencyFactory dependencyFactory = new DependencyFactory(externalIdFactory);
+
+    public DependencyGraph transform(List<RequirementsFileDependency> dependencies) {
+        DependencyGraph dependencyGraph = new BasicDependencyGraph();
+        dependencies.stream()
+            .map(this::createDependency)
+            .forEach(dependencyGraph::addChildToRoot);
+        return dependencyGraph;
+    }
+
+    private Dependency createDependency(RequirementsFileDependency dependency) {
+        return dependencyFactory.createNameVersionDependency(Forge.PYPI, dependency.getName(), dependency.getVersion());
+    }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyVersionParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyVersionParser.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsFileDependencyVersionParser {
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyVersionParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDependencyVersionParser.java
@@ -1,2 +1,12 @@
-package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsFileDependencyVersionParser {
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import org.jetbrains.annotations.Nullable;
+
+public class RequirementsFileDependencyVersionParser {
+    public String parseRawVersion(@Nullable String rawVersion) {
+        if (rawVersion == null) {
+            return null;
+        }
+        return rawVersion.replace("==", "");
+    }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectable.java
@@ -1,0 +1,52 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import java.io.File;
+
+import com.synopsys.integration.common.util.finder.FileFinder;
+import com.synopsys.integration.detectable.Detectable;
+import com.synopsys.integration.detectable.DetectableEnvironment;
+import com.synopsys.integration.detectable.detectable.DetectableAccuracyType;
+import com.synopsys.integration.detectable.detectable.Requirements;
+import com.synopsys.integration.detectable.detectable.annotation.DetectableInfo;
+import com.synopsys.integration.detectable.detectable.result.DetectableResult;
+import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
+import com.synopsys.integration.detectable.detectables.npm.packagejson.PackageJsonExtractor;
+import com.synopsys.integration.detectable.extraction.Extraction;
+import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
+
+@DetectableInfo(name = "PIP Requirements Parse", language = "Python", forge = "PyPi", accuracy = DetectableAccuracyType.LOW, requirementsMarkdown = "File: requirements.txt")
+public class PipRequirementsParseDetectable extends Detectable {
+    public static final String REQUIREMENTS_FILE_NAME = "requirements.txt"; // TODO if provided, override with requirements txt file name from Detect's property
+
+    private final FileFinder fileFinder;
+    private final PackageJsonExtractor packageJsonExtractor;
+
+    private File packageJsonFile;
+
+    public PipRequirementsParseDetectable(DetectableEnvironment environment, FileFinder fileFinder, PackageJsonExtractor packageJsonExtractor) {
+        super(environment);
+        this.fileFinder = fileFinder;
+        this.packageJsonExtractor = packageJsonExtractor;
+    }
+
+    @Override
+    public DetectableResult applicable() {
+        Requirements requirements = new Requirements(fileFinder, environment);
+        packageJsonFile = requirements.file(REQUIREMENTS_FILE_NAME);
+        return requirements.result();
+    }
+
+    @Override
+    public DetectableResult extractable() {
+        return new PassedDetectableResult();
+    }
+
+    @Override
+    public Extraction extract(ExtractionEnvironment extractionEnvironment) {
+        try {
+            return packageJsonExtractor.extract(packageJsonFile);
+        } catch (Exception e) {
+            return new Extraction.Builder().exception(e).failure(String.format("Failed to parse %s", REQUIREMENTS_FILE_NAME)).build();
+        }
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectableOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectableOptions.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsFileDetectableOptions {
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectableOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectableOptions.java
@@ -1,2 +1,24 @@
-package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsFileDetectableOptions {
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+public class RequirementsFileDetectableOptions {
+    private final String pipProjectName;
+    private final List<Path> requirementsFilePaths;
+
+    public RequirementsFileDetectableOptions(String pipProjectName, List<Path> requirementsFilePaths) {
+        this.pipProjectName = pipProjectName;
+        this.requirementsFilePaths = requirementsFilePaths;
+    }
+
+    public Optional<String> getPipProjectName() {
+        return Optional.ofNullable(pipProjectName);
+    }
+
+    public List<Path> getRequirementsFilePaths() {
+        return requirementsFilePaths;
+    }
+
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileExtractor.java
@@ -13,16 +13,13 @@ import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.extraction.Extraction;
 
 public class RequirementsFileExtractor {
-    private final Gson gson;
     private final RequirementsFileTransformer requirementsFileTransformer;
     private final RequirementsFileDependencyTransformer requirementsFileDependencyTransformer;
 
     public RequirementsFileExtractor(
-        Gson gson,
         RequirementsFileTransformer requirementsFileTransformer,
         RequirementsFileDependencyTransformer requirementsFileDependencyTransformer
     ) {
-        this.gson = gson;
         this.requirementsFileTransformer = requirementsFileTransformer;
         this.requirementsFileDependencyTransformer = requirementsFileDependencyTransformer;
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileExtractor.java
@@ -1,0 +1,43 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.bdio.graph.DependencyGraph;
+import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
+import com.synopsys.integration.detectable.detectables.pipenv.parse.PipfileLockDependencyTransformer;
+import com.synopsys.integration.detectable.detectables.pipenv.parse.PipfileLockTransformer;
+import com.synopsys.integration.detectable.detectables.pipenv.parse.data.PipfileLock;
+import com.synopsys.integration.detectable.detectables.pipenv.parse.model.PipfileLockDependency;
+import com.synopsys.integration.detectable.extraction.Extraction;
+
+public class PipRequirementsExtractor {
+    private final Gson gson;
+//    private final PipfileLockTransformer pipfileLockTransformer;
+//    private final PipfileLockDependencyTransformer pipfileLockDependencyTransformer;
+
+    public PipRequirementsExtractor(
+        Gson gson,
+        PipfileLockTransformer pipfileLockParser,
+        PipfileLockDependencyTransformer pipfileLockTransformer
+    ) {
+        this.gson = gson;
+//        this.pipfileLockTransformer = pipfileLockParser;
+//        this.pipfileLockDependencyTransformer = pipfileLockTransformer;
+    }
+
+    public Extraction extract(File pipfileLockFile) throws IOException {
+        String pipfileLockText = FileUtils.readFileToString(pipfileLockFile, StandardCharsets.UTF_8);
+        PipfileLock pipfileLock = gson.fromJson(pipfileLockText, PipfileLock.class);
+        List<PipfileLockDependency> dependencies = pipfileLockTransformer.transform(pipfileLock);
+        DependencyGraph dependencyGraph = pipfileLockDependencyTransformer.transform(dependencies);
+        CodeLocation codeLocation = new CodeLocation(dependencyGraph);
+        // No project info - hoping git can help with that.
+        return Extraction.success(codeLocation);
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileExtractor.java
@@ -10,34 +10,28 @@ import org.apache.commons.io.FileUtils;
 import com.google.gson.Gson;
 import com.synopsys.integration.bdio.graph.DependencyGraph;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
-import com.synopsys.integration.detectable.detectables.pipenv.parse.PipfileLockDependencyTransformer;
-import com.synopsys.integration.detectable.detectables.pipenv.parse.PipfileLockTransformer;
-import com.synopsys.integration.detectable.detectables.pipenv.parse.data.PipfileLock;
-import com.synopsys.integration.detectable.detectables.pipenv.parse.model.PipfileLockDependency;
 import com.synopsys.integration.detectable.extraction.Extraction;
 
-public class PipRequirementsExtractor {
+public class RequirementsFileExtractor {
     private final Gson gson;
-//    private final PipfileLockTransformer pipfileLockTransformer;
-//    private final PipfileLockDependencyTransformer pipfileLockDependencyTransformer;
+    private final RequirementsFileTransformer requirementsFileTransformer;
+    private final RequirementsFileDependencyTransformer requirementsFileDependencyTransformer;
 
-    public PipRequirementsExtractor(
+    public RequirementsFileExtractor(
         Gson gson,
-        PipfileLockTransformer pipfileLockParser,
-        PipfileLockDependencyTransformer pipfileLockTransformer
+        RequirementsFileTransformer requirementsFileTransformer,
+        RequirementsFileDependencyTransformer requirementsFileDependencyTransformer
     ) {
         this.gson = gson;
-//        this.pipfileLockTransformer = pipfileLockParser;
-//        this.pipfileLockDependencyTransformer = pipfileLockTransformer;
+        this.requirementsFileTransformer = requirementsFileTransformer;
+        this.requirementsFileDependencyTransformer = requirementsFileDependencyTransformer;
     }
 
-    public Extraction extract(File pipfileLockFile) throws IOException {
-        String pipfileLockText = FileUtils.readFileToString(pipfileLockFile, StandardCharsets.UTF_8);
-        PipfileLock pipfileLock = gson.fromJson(pipfileLockText, PipfileLock.class);
-        List<PipfileLockDependency> dependencies = pipfileLockTransformer.transform(pipfileLock);
-        DependencyGraph dependencyGraph = pipfileLockDependencyTransformer.transform(dependencies);
+    public Extraction extract(File requirementsFileObject) throws IOException {
+//        String requirementsFileText = FileUtils.readFileToString(requirementsFileObject, StandardCharsets.UTF_8);
+        List<RequirementsFileDependency> dependencies = requirementsFileTransformer.transform(requirementsFileObject);
+        DependencyGraph dependencyGraph = requirementsFileDependencyTransformer.transform(dependencies);
         CodeLocation codeLocation = new CodeLocation(dependencyGraph);
-        // No project info - hoping git can help with that.
         return Extraction.success(codeLocation);
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileNotFoundDetectableResult.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileNotFoundDetectableResult.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsFileNotFoundDetectableResult {
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileNotFoundDetectableResult.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileNotFoundDetectableResult.java
@@ -1,2 +1,16 @@
-package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsFileNotFoundDetectableResult {
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import com.synopsys.integration.detectable.detectable.result.FailedDetectableResult;
+
+public class RequirementsFileNotFoundDetectableResult extends FailedDetectableResult {
+    private final String directoryPath;
+
+    public RequirementsFileNotFoundDetectableResult(String directoryPath) {
+        this.directoryPath = directoryPath;
+    }
+
+    @Override
+    public String toDescription() {
+        return String.format("A PIP requirements file (example: requirements.txt) was NOT found in %s. Please ensure a requirements file is present at that location and try again.", directoryPath);
+    }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileTransformer.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsTxtTransformer {
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileTransformer.java
@@ -1,2 +1,34 @@
-package com.synopsys.integration.detectable.detectables.pip.parser;public class RequirementsTxtTransformer {
+package com.synopsys.integration.detectable.detectables.pip.parser;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+public class RequirementsFileTransformer {
+    private final RequirementsFileDependencyVersionParser requirementsFileDependencyVersionParser;
+    public RequirementsFileTransformer(
+        RequirementsFileDependencyVersionParser requirementsFileDependencyVersionParser
+    ) {
+        this.requirementsFileDependencyVersionParser = requirementsFileDependencyVersionParser;
+    }
+
+    public List<RequirementsFileDependency> transform(File requirementsFileObject) {
+        List<RequirementsFileDependency> dependencies = new LinkedList<>();
+
+        RequirementsFileDependency requirementsFileDependency = new RequirementsFileDependency("placeholder_dependency", "placeholder_version");
+        for (Integer i = 0; i < 10; i++) {
+            dependencies.add(requirementsFileDependency);
+        }
+        return dependencies;
+    }
+
+
+    private List<RequirementsFileDependency> convertEntriesToDependencyInfo(Map<String, RequirementsFileDependencyEntry> dependencyEntries) {
+        return dependencyEntries.entrySet().stream()
+            .map(entry -> new RequirementsFileDependency(entry.getKey(), requirementsFileDependencyVersionParser.parseRawVersion(entry.getValue().version)))
+            .collect(Collectors.toList());
+    }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -214,6 +214,12 @@ import com.synopsys.integration.detectable.detectables.pip.inspector.PipInspecto
 import com.synopsys.integration.detectable.detectables.pip.inspector.PipInspectorDetectableOptions;
 import com.synopsys.integration.detectable.detectables.pip.inspector.PipInspectorExtractor;
 import com.synopsys.integration.detectable.detectables.pip.inspector.parser.PipInspectorTreeParser;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileDependencyTransformer;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileDependencyVersionParser;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileDetectable;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileDetectableOptions;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileExtractor;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileTransformer;
 import com.synopsys.integration.detectable.detectables.pipenv.build.PipenvDetectable;
 import com.synopsys.integration.detectable.detectables.pipenv.build.PipenvDetectableOptions;
 import com.synopsys.integration.detectable.detectables.pipenv.build.PipenvExtractor;
@@ -599,6 +605,17 @@ public class DetectableFactory {
         PipResolver pipResolver
     ) {
         return new PipInspectorDetectable(environment, fileFinder, pythonResolver, pipResolver, pipInspectorResolver, pipInspectorExtractor(), pipInspectorDetectableOptions);
+    }
+
+    public RequirementsFileDetectable createRequirementsFileDetectable(
+        DetectableEnvironment environment,
+        RequirementsFileDetectableOptions requirementsFileDetectableOptions
+    ) {
+        RequirementsFileDependencyVersionParser requirementsFileDependencyVersionParser = new RequirementsFileDependencyVersionParser();
+        RequirementsFileTransformer requirementsFileTransformer = new RequirementsFileTransformer(requirementsFileDependencyVersionParser);
+        RequirementsFileDependencyTransformer requirementsFileDependencyTransformer = new RequirementsFileDependencyTransformer();
+        RequirementsFileExtractor requirementsFileExtractor = new RequirementsFileExtractor(gson, requirementsFileTransformer, requirementsFileDependencyTransformer);
+        return new RequirementsFileDetectable(environment, fileFinder, requirementsFileExtractor);
     }
 
     public PnpmLockDetectable createPnpmLockDetectable(DetectableEnvironment environment, PnpmLockOptions pnpmLockOptions) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -614,7 +614,7 @@ public class DetectableFactory {
         RequirementsFileDependencyVersionParser requirementsFileDependencyVersionParser = new RequirementsFileDependencyVersionParser();
         RequirementsFileTransformer requirementsFileTransformer = new RequirementsFileTransformer(requirementsFileDependencyVersionParser);
         RequirementsFileDependencyTransformer requirementsFileDependencyTransformer = new RequirementsFileDependencyTransformer();
-        RequirementsFileExtractor requirementsFileExtractor = new RequirementsFileExtractor(gson, requirementsFileTransformer, requirementsFileDependencyTransformer);
+        RequirementsFileExtractor requirementsFileExtractor = new RequirementsFileExtractor(requirementsFileTransformer, requirementsFileDependencyTransformer);
         return new RequirementsFileDetectable(environment, fileFinder, requirementsFileExtractor);
     }
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -40,6 +40,7 @@ import com.synopsys.integration.detectable.detectables.packagist.PackagistDepend
 import com.synopsys.integration.detectable.detectables.pear.PearCliDetectableOptions;
 import com.synopsys.integration.detectable.detectables.pear.PearDependencyType;
 import com.synopsys.integration.detectable.detectables.pip.inspector.PipInspectorDetectableOptions;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileDetectableOptions;
 import com.synopsys.integration.detectable.detectables.pipenv.build.PipenvDetectableOptions;
 import com.synopsys.integration.detectable.detectables.pipenv.parse.PipenvDependencyType;
 import com.synopsys.integration.detectable.detectables.pipenv.parse.PipfileLockDetectableOptions;
@@ -246,6 +247,12 @@ public class DetectableOptionFactory {
         String pipProjectName = detectConfiguration.getNullableValue(DetectProperties.DETECT_PIP_PROJECT_NAME);
         List<Path> requirementsFilePath = detectConfiguration.getPaths(DetectProperties.DETECT_PIP_REQUIREMENTS_PATH);
         return new PipInspectorDetectableOptions(pipProjectName, requirementsFilePath);
+    }
+
+    public RequirementsFileDetectableOptions createRequirementsFileDetectableOptions() {
+        String pipProjectName = detectConfiguration.getNullableValue(DetectProperties.DETECT_PIP_PROJECT_NAME);
+        List<Path> requirementsFilePath = detectConfiguration.getPaths(DetectProperties.DETECT_PIP_REQUIREMENTS_PATH);
+        return new RequirementsFileDetectableOptions(pipProjectName, requirementsFilePath);
     }
 
     public PnpmLockOptions createPnpmLockOptions() {

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/DetectorRuleFactory.java
@@ -38,6 +38,7 @@ import com.synopsys.integration.detectable.detectables.nuget.NugetSolutionDetect
 import com.synopsys.integration.detectable.detectables.packagist.ComposerLockDetectable;
 import com.synopsys.integration.detectable.detectables.pear.PearCliDetectable;
 import com.synopsys.integration.detectable.detectables.pip.inspector.PipInspectorDetectable;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileDetectable;
 import com.synopsys.integration.detectable.detectables.pipenv.build.PipenvDetectable;
 import com.synopsys.integration.detectable.detectables.pipenv.parse.PipfileLockDetectable;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLockDetectable;
@@ -235,6 +236,8 @@ public class DetectorRuleFactory {
                 detector.entryPoint(PipInspectorDetectable.class)
                     .search().defaults();
                 detector.entryPoint(PipfileLockDetectable.class)
+                    .search().defaults();
+                detector.entryPoint(RequirementsFileDetectable.class)
                     .search().defaults();
             })
             .allEntryPointsFallbackToNext()

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
@@ -47,6 +47,7 @@ import com.synopsys.integration.detectable.detectables.nuget.NugetSolutionDetect
 import com.synopsys.integration.detectable.detectables.packagist.ComposerLockDetectable;
 import com.synopsys.integration.detectable.detectables.pear.PearCliDetectable;
 import com.synopsys.integration.detectable.detectables.pip.inspector.PipInspectorDetectable;
+import com.synopsys.integration.detectable.detectables.pip.parser.RequirementsFileDetectable;
 import com.synopsys.integration.detectable.detectables.pipenv.build.PipenvDetectable;
 import com.synopsys.integration.detectable.detectables.pipenv.parse.PipfileLockDetectable;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.PnpmLockDetectable;
@@ -260,6 +261,10 @@ public class DetectDetectableFactory {
             detectExecutableResolver,
             detectExecutableResolver
         );
+    }
+
+    public RequirementsFileDetectable createRequirementsFileDetectable(DetectableEnvironment environment) {
+        return detectableFactory.createRequirementsFileDetectable(environment, detectableOptionFactory.createRequirementsFileDetectableOptions());
     }
 
     public PnpmLockDetectable createPnpmLockDetectable(DetectableEnvironment environment) {


### PR DESCRIPTION
**Description**
The PIP Requirements File detector adds support for extracting dependencies in a buildless environment from a PIP Requirements file (usually named as `requirements.txt`). 
This is a new buildless detector categorized under PIP.

This PR only involves the low-level structure and connection pieces of code to include this detector in Detect's cascading framework.

**JIRA**
IDETECT-4203
Main user story: IDETECT-4141