### PR TITLE
Upgrade method-analyzer-core library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ dependencies {
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.6'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'com.synopsys:method-analyzer-core:0.2.0'
+    implementation 'com.synopsys:method-analyzer-core:0.2.9'
     implementation "${locatorGroup}:${locatorModule}:1.1.6"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/ImpactTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/ImpactTest.java
@@ -11,7 +11,7 @@ import com.synopsys.integration.detect.battery.docker.util.DetectDockerTestRunne
 import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
 import com.synopsys.integration.detect.configuration.DetectProperties;
 
-@Tag("integration")
+//@Tag("integration")
 public class ImpactTest {
     @Test
     void offlineImpact() throws IOException {
@@ -41,6 +41,22 @@ public class ImpactTest {
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.logContains("Vulnerability Impact Analysis generated report at /tmp/external-method-uses.bdmu");
+        }
+    }
+
+    @Test
+    void impactASMErrorMaven() throws IOException {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-impact-asm-error-test", "detect-impact-test:1.1.0")) {
+            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("ImpactAnalysis_ASMErrorMaven.dockerfile"));
+
+            DetectCommandBuilder commandBuilder = DetectCommandBuilder.withOfflineDefaults().defaultDirectories(test);
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, "IMPACT_ANALYSIS");
+            commandBuilder.property(DetectProperties.DETECT_IMPACT_ANALYSIS_ENABLED, "true");
+            DockerAssertions dockerAssertions = test.run(commandBuilder);
+
+            dockerAssertions.successfulTool("IMPACT_ANALYSIS");
+            dockerAssertions.logContainsPattern("Vulnerability Impact Analysis generated report at /opt/results/output/runs/.*/impact-analysis/external-method-uses.bdmu");
+            dockerAssertions.successfulOperation("Generate Impact Analysis File");
         }
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/ImpactTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/ImpactTest.java
@@ -11,7 +11,7 @@ import com.synopsys.integration.detect.battery.docker.util.DetectDockerTestRunne
 import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
 import com.synopsys.integration.detect.configuration.DetectProperties;
 
-//@Tag("integration")
+@Tag("integration")
 public class ImpactTest {
     @Test
     void offlineImpact() throws IOException {

--- a/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
+++ b/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
@@ -1,0 +1,16 @@
+FROM adoptopenjdk/maven-openjdk11
+
+# Do not change SRC_DIR, value is expected by tests
+ENV SRC_DIR=/opt/project/src
+
+# Install git
+RUN apt-get update
+RUN apt-get install -y git
+
+# Set up the test project
+RUN mkdir -p ${SRC_DIR}
+
+RUN git clone --depth 1 https://github.com/webgoat/webgoat.git ${SRC_DIR}
+
+RUN cd ${SRC_DIR} \
+   && mvn clean compile -DskipTests

--- a/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
+++ b/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/maven-openjdk11
+FROM maven:3-eclipse-temurin-17
 
 # Do not change SRC_DIR, value is expected by tests
 ENV SRC_DIR=/opt/project/src
@@ -11,4 +11,4 @@ RUN apt-get install -y git
 RUN mkdir -p ${SRC_DIR}
 RUN git clone --depth 1 https://github.com/webgoat/webgoat.git ${SRC_DIR}
 RUN cd ${SRC_DIR} \
-   && mvn compile clean -DskipTests
+   && mvn clean compile -DskipTests

--- a/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
+++ b/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
@@ -10,7 +10,5 @@ RUN apt-get install -y git
 # Set up the test project
 RUN mkdir -p ${SRC_DIR}
 RUN git clone --depth 1 https://github.com/webgoat/webgoat.git ${SRC_DIR}
-RUN cd ${SRC_DIR}
-RUN pwd
-RUN ls
-RUN mvn clean compile -DskipTests
+RUN cd ${SRC_DIR} \
+   && mvn compile clean -DskoipTests

--- a/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
+++ b/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
@@ -11,4 +11,6 @@ RUN apt-get install -y git
 RUN mkdir -p ${SRC_DIR}
 RUN git clone --depth 1 https://github.com/webgoat/webgoat.git ${SRC_DIR}
 RUN cd ${SRC_DIR}
+RUN pwd
+RUN ls
 RUN mvn clean compile -DskipTests

--- a/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
+++ b/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
@@ -11,4 +11,4 @@ RUN apt-get install -y git
 RUN mkdir -p ${SRC_DIR}
 RUN git clone --depth 1 https://github.com/webgoat/webgoat.git ${SRC_DIR}
 RUN cd ${SRC_DIR} \
-   && mvn compile clean -DskoipTests
+   && mvn compile clean -DskipTests

--- a/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
+++ b/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
@@ -9,7 +9,6 @@ RUN apt-get install -y git
 
 # Set up the test project
 RUN mkdir -p ${SRC_DIR}
-WORKDIR ${SRC_DIR}
 RUN git clone --depth 1 https://github.com/webgoat/webgoat.git ${SRC_DIR}
-WORKDIR ${SRC_DIR}
+RUN cd ${SRC_DIR}
 RUN mvn clean compile -DskipTests

--- a/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
+++ b/src/test/resources/docker/ImpactAnalysis_ASMErrorMaven.dockerfile
@@ -9,8 +9,7 @@ RUN apt-get install -y git
 
 # Set up the test project
 RUN mkdir -p ${SRC_DIR}
-
+WORKDIR ${SRC_DIR}
 RUN git clone --depth 1 https://github.com/webgoat/webgoat.git ${SRC_DIR}
-
-RUN cd ${SRC_DIR} \
-   && mvn clean compile -DskipTests
+WORKDIR ${SRC_DIR}
+RUN mvn clean compile -DskipTests


### PR DESCRIPTION
This PR resolves the issue mentioned in IDETECT-3909. There was a new version of method-analyzer-core library released with latest ASM library version and also latest ASM Opcode which that version accepts. Also, I have added one simple integration test case to track this ASM Opcode issue in future since it is a dependency for us on method-analyzer-core. We can easily track if there is new Opcode released in case of a build failure. 
