### PR TITLE
Update doc for Nuget Dependency Type Exclusion.

### DIFF
--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -24,6 +24,7 @@ The detectors run a platform dependent self-contained executable that is current
 ## Excluding dependency types
 [solution_name] offers the ability to exclude package manager specific dependency types from the BOM.
 Nuget dependency types can be filtered with the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property.
+This property will support exclusion of dependencies in projects that uses PackageReference and packages.config for listing the dependencies. As the support for Json files to store dependencies has been deprecated by Nuget, we will not be enhancing them to exclude dependency types. 
 
 ### [solution_name] NuGet Inspector downloads
 

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -24,7 +24,8 @@ The detectors run a platform dependent self-contained executable that is current
 ## Excluding dependency types
 [solution_name] offers the ability to exclude package manager specific dependency types from the BOM.
 Nuget dependency types can be filtered with the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property.
-This property will support exclusion of dependencies in projects that uses PackageReference and packages.config for listing the dependencies. As the support for Json files to store dependencies has been deprecated by Nuget, we will not be enhancing them to exclude dependency types. 
+This property supports exclusion of dependencies in projects that use PackageReference, and packages.config for listing dependencies.
+Support for storing dependencies in Json files has been deprecated by Nuget, and will not be enhancing the properties to exclude dependency types in this manner.
 
 ### [solution_name] NuGet Inspector downloads
 

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -25,7 +25,10 @@ The detectors run a platform dependent self-contained executable that is current
 [solution_name] offers the ability to exclude package manager specific dependency types from the BOM.
 Nuget dependency types can be filtered with the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property.
 This property supports exclusion of dependencies in projects that use PackageReference, and packages.config for listing dependencies.
-Support for storing dependencies in Json files has been deprecated by Nuget. We will not be enhancing the properties to exclude dependency types in this manner.
+<note type="note">Support for storing dependencies in Json files has been deprecated by Nuget. As such we will not be enhancing the properties to exclude dependency types in this manner.</note>
+
+A project might be using a dependency purely as a development harness and you might not want to expose that to projects that will consume the package. You can use the PrivateAssets metadata to control this behavior. [solution_name] looks for the PrivateAssets attribute used within PackageReference tags to identify a development dependency. [solution_name] will ignore the contents of the tag and only observe the presence of these PrivateAssets to exclude those development related dependencies.
+For packages.config file, [solution_name] will look for developmentDependency tags to determine whether to include or exclude a dependency.
 
 ### [solution_name] NuGet Inspector downloads
 

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -25,7 +25,7 @@ The detectors run a platform dependent self-contained executable that is current
 [solution_name] offers the ability to exclude package manager specific dependency types from the BOM.
 Nuget dependency types can be filtered with the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property.
 This property supports exclusion of dependencies in projects that use PackageReference, and packages.config for listing dependencies.
-Support for storing dependencies in Json files has been deprecated by Nuget, and will not be enhancing the properties to exclude dependency types in this manner.
+Support for storing dependencies in Json files has been deprecated by Nuget. We will not be enhancing the properties to exclude dependency types in this manner.
 
 ### [solution_name] NuGet Inspector downloads
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1160,7 +1160,7 @@ public class DetectProperties {
     public static final NoneEnumListProperty<NugetDependencyType> DETECT_NUGET_DEPENDENCY_TYPES_EXCLUDED =
             NoneEnumListProperty.newBuilder("detect.nuget.dependency.types.excluded", NoneEnum.NONE, NugetDependencyType.class)
                     .setInfo("Nuget Dependency Types Excluded", DetectPropertyFromVersion.VERSION_9_4_0)
-                    .setHelp(createTypeFilterHelpText("Nuget dependency types"))
+                    .setHelp(createTypeFilterHelpText("Nuget dependency types"), "This property will support exclusion of dependencies in projects that uses PackageReference and packages.config for listing the dependencies. As the support for Json files to store dependencies has been deprecated by Nuget, we will not be enhancing them to exclude dependency types.")
                     .setExample(String.format("%s", NugetDependencyType.DEV.name()))
                     .setGroups(DetectGroup.NUGET, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN)
                     .build();

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1160,7 +1160,7 @@ public class DetectProperties {
     public static final NoneEnumListProperty<NugetDependencyType> DETECT_NUGET_DEPENDENCY_TYPES_EXCLUDED =
             NoneEnumListProperty.newBuilder("detect.nuget.dependency.types.excluded", NoneEnum.NONE, NugetDependencyType.class)
                     .setInfo("Nuget Dependency Types Excluded", DetectPropertyFromVersion.VERSION_9_4_0)
-                    .setHelp(createTypeFilterHelpText("Nuget dependency types"), "This property will support exclusion of dependencies in projects that uses PackageReference and packages.config for listing the dependencies. As the support for Json files to store dependencies has been deprecated by Nuget, we will not be enhancing them to exclude dependency types.")
+                    .setHelp(createTypeFilterHelpText("Nuget dependency types"), "This property supports exclusion of dependencies in projects that use PackageReference, and packages.config for listing dependencies that are not stored in Json files.")
                     .setExample(String.format("%s", NugetDependencyType.DEV.name()))
                     .setGroups(DetectGroup.NUGET, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN)
                     .build();


### PR DESCRIPTION
This PR adds message to notify users of not enhancing the support for dependency type exclusion for Nuget in json files as those are deprecated by Nuget and also the types of files we support this exclusion in.
