### PR TITLE
Fetch ga4 secret from GCP IDETECT-4189

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,12 +94,13 @@ allprojects {
     dependencies {
         implementation "com.google.guava:guava:32.1.2-jre"
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'
+        implementation 'org.mockito:mockito-core:2.+'
 
         implementation 'org.freemarker:freemarker:2.3.31'
         implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
 
         testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
-        testImplementation 'org.mockito:mockito-core:2.+'
+//        testImplementation 'org.mockito:mockito-core:2.+'
     }
 }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/ProductBootFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/ProductBootFactory.java
@@ -14,6 +14,7 @@ import com.synopsys.integration.detect.configuration.connection.BlackDuckConnect
 import com.synopsys.integration.detect.workflow.event.EventSystem;
 import com.synopsys.integration.detect.workflow.phonehome.OnlinePhoneHomeManager;
 import com.synopsys.integration.detect.workflow.phonehome.PhoneHomeManager;
+import com.synopsys.integration.detect.workflow.phonehome.PhoneHomeSecrets;
 import com.synopsys.integration.log.SilentIntLogger;
 
 public class ProductBootFactory {
@@ -27,8 +28,9 @@ public class ProductBootFactory {
         this.detectConfigurationFactory = detectConfigurationFactory;
     }
 
-    public PhoneHomeManager createPhoneHomeManager(BlackDuckServicesFactory blackDuckServicesFactory) {
+    public PhoneHomeManager createPhoneHomeManager(BlackDuckServicesFactory blackDuckServicesFactory, PhoneHomeSecrets phoneHomeSecrets) {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
+        // TODO: use phoneHomeSecrets to create BlackDuckPhoneHomeHelper
         BlackDuckPhoneHomeHelper blackDuckPhoneHomeHelper = BlackDuckPhoneHomeHelper.createAsynchronousPhoneHomeHelper(blackDuckServicesFactory, executorService);
         PhoneHomeManager phoneHomeManager = new OnlinePhoneHomeManager(
             detectConfigurationFactory.createPhoneHomeOptions().getPassthrough(),

--- a/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
@@ -47,9 +47,6 @@ public class PhoneHomeSecrets {
 
     public static String getFileCheckSum(String filePath) throws NoSuchAlgorithmException, IOException {
         byte[] data = Files.readAllBytes(Paths.get(filePath));
-//        byte[] data = Files.readAllBytes(Paths.get(filePath+"\\com\\synopsys\\integration\\detect\\Application.class"));
-//        byte[] data = Files.readAllBytes(Paths.get("C:\\Users\\basim\\Desktop\\synopsys-detect\\build\\libs\\synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar\\BOOT-INF\\classes\\com\\synopsys\\integration\\detect\\Application.class"));
-//        byte[] data = Files.readAllBytes(Paths.get(filePath.substring(6)));
         byte[] hash = MessageDigest.getInstance("SHA-256").digest(data);
         return new BigInteger(1, hash).toString(16);
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
@@ -12,7 +12,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -38,12 +38,12 @@ public class PhoneHomeSecrets {
     }
 
     public static String getDetectJarCheckSum() throws NoSuchAlgorithmException, IOException {
-        String filePath = formatFilePath(Application.class.getProtectionDomain().getCodeSource().getLocation().getPath());
-        return getFileCheckSum(filePath);
+        String fileUri = formatFileUri(Application.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+        return getFileCheckSum(fileUri);
     }
 
-    public static String getFileCheckSum(String filePath) throws NoSuchAlgorithmException, IOException {
-        byte[] data = Files.readAllBytes(Paths.get(filePath));
+    public static String getFileCheckSum(String fileUri) throws NoSuchAlgorithmException, IOException {
+        byte[] data = Files.readAllBytes(Path.of(URI.create(fileUri)));
         byte[] hash = MessageDigest.getInstance("SHA-256").digest(data);
         return new BigInteger(1, hash).toString(16);
     }
@@ -63,27 +63,10 @@ public class PhoneHomeSecrets {
         return gson.fromJson(responseBody, PhoneHomeSecrets.class);
     }
 
-    public static String formatFilePath(String filePath) {
-        // filePath at this point
-        // windows = "file:/C:/Users/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar!/BOOT-INF/classes!/"
-        // linux = "file:/home/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar!/BOOT-INF/classes!/"
-
-        if (filePath.contains(".jar"))
-            filePath = filePath.substring(0, filePath.lastIndexOf(".jar") + ".jar".length());
-        // windows = "file:/C:/Users/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
-        // linux = "file:/home/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
-
-        if (filePath.startsWith("file:"))
-            filePath = filePath.substring("file:".length());
-        // windows = "/C:/Users/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
-        // linux = "/home/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
-
-        if(filePath.startsWith("/") && System.getProperty("os.name").toLowerCase().contains("windows"))
-            filePath = filePath.substring(1);
-        // windows = "C:/Users/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
-        // linux = "/home/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
-
-        return filePath;
+    public static String formatFileUri(String fileUri) {
+        if (fileUri.contains(".jar"))
+            fileUri = fileUri.substring(0, fileUri.lastIndexOf(".jar") + ".jar".length());
+        return fileUri;
     }
 
     public String getApiSecret() {

--- a/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
@@ -1,0 +1,93 @@
+package com.synopsys.integration.detect.workflow.phonehome;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import com.synopsys.integration.detect.Application;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+
+public class PhoneHomeSecrets {
+    public static String API_SECRET_NAME = "api_secret";
+    public static String MEASUREMENT_ID_NAME = "measurement_id";
+
+    @SerializedName("api_secret")
+    private String apiSecret;
+    @SerializedName("measurement_id")
+    private String measurementId;
+
+    public PhoneHomeSecrets(String apiSecret, String measurementId) {
+        this.apiSecret = apiSecret;
+        this.measurementId = measurementId;
+    }
+
+    public static PhoneHomeSecrets getGa4Credentials() throws NoSuchAlgorithmException, IOException, InterruptedException {
+        String detectHash = getDetectJarCheckSum();
+//        String modifiedHash = com.synopsys.integration.componentlocator.utils.StringModifier.modify(detectHash); // actual code to be when CLL repo is updated.
+        String modifiedHash = detectHash;  // mock code
+        return getGa4CredentialsFromGcp(modifiedHash);
+    }
+
+    public static String getDetectJarCheckSum() throws NoSuchAlgorithmException, IOException {
+        String filePath = formatFilePath(Application.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+        return getFileCheckSum(filePath);
+    }
+
+    public static String getFileCheckSum(String filePath) throws NoSuchAlgorithmException, IOException {
+        byte[] data = Files.readAllBytes(Paths.get(filePath));
+//        byte[] data = Files.readAllBytes(Paths.get(filePath+"\\com\\synopsys\\integration\\detect\\Application.class"));
+//        byte[] data = Files.readAllBytes(Paths.get("C:\\Users\\basim\\Desktop\\synopsys-detect\\build\\libs\\synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar\\BOOT-INF\\classes\\com\\synopsys\\integration\\detect\\Application.class"));
+//        byte[] data = Files.readAllBytes(Paths.get(filePath.substring(6)));
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(data);
+        return new BigInteger(1, hash).toString(16);
+    }
+
+    private static PhoneHomeSecrets getGa4CredentialsFromGcp(String modifiedHash) throws IOException, InterruptedException {
+        // Mocking an api call until the GCP service is ready.
+        HttpClient httpClient = Mockito.mock(HttpClient.class);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://my.gcp.uri"))
+                .build();
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        String responseBody = "{" +
+                "\""+API_SECRET_NAME+"\": \"my_aPi_SEcRet\"," +
+                "\""+MEASUREMENT_ID_NAME+"\": \"G-1452334585\"" +
+                "}";
+        Gson gson = new Gson();
+        return gson.fromJson(responseBody, PhoneHomeSecrets.class);
+    }
+
+    public static String formatFilePath(String filePath) {
+        filePath = filePath.substring(0, filePath.lastIndexOf(".jar") + 4 );
+
+        if (filePath.startsWith("/"))
+            filePath = filePath.substring(1);
+
+        if (filePath.startsWith("file:/")) {
+            filePath = filePath.substring(5);
+            if(System.getProperty("os.name").toLowerCase().contains("windows"))
+                filePath = filePath.substring(1);
+        }
+        return filePath;
+    }
+
+    public String getApiSecret() {
+        return apiSecret;
+    }
+
+    public String getMeasurementId() {
+        return measurementId;
+    }
+}

--- a/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
@@ -5,11 +5,9 @@ import com.google.gson.annotations.SerializedName;
 import com.synopsys.integration.detect.Application;
 import org.mockito.Mockito;
 
-import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -17,7 +15,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Objects;
 
 public class PhoneHomeSecrets {
     public static String API_SECRET_NAME = "api_secret";

--- a/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeSecrets.java
@@ -67,16 +67,25 @@ public class PhoneHomeSecrets {
     }
 
     public static String formatFilePath(String filePath) {
-        filePath = filePath.substring(0, filePath.lastIndexOf(".jar") + 4 );
+        // filePath at this point
+        // windows = "file:/C:/Users/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar!/BOOT-INF/classes!/"
+        // linux = "file:/home/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar!/BOOT-INF/classes!/"
 
-        if (filePath.startsWith("/"))
+        if (filePath.contains(".jar"))
+            filePath = filePath.substring(0, filePath.lastIndexOf(".jar") + ".jar".length());
+        // windows = "file:/C:/Users/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
+        // linux = "file:/home/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
+
+        if (filePath.startsWith("file:"))
+            filePath = filePath.substring("file:".length());
+        // windows = "/C:/Users/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
+        // linux = "/home/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
+
+        if(filePath.startsWith("/") && System.getProperty("os.name").toLowerCase().contains("windows"))
             filePath = filePath.substring(1);
+        // windows = "C:/Users/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
+        // linux = "/home/<username>/synopsys-detect-9.4.0-SIGQA6-SNAPSHOT.jar"
 
-        if (filePath.startsWith("file:/")) {
-            filePath = filePath.substring(5);
-            if(System.getProperty("os.name").toLowerCase().contains("windows"))
-                filePath = filePath.substring(1);
-        }
         return filePath;
     }
 

--- a/src/test/java/com/synopsys/integration/detect/boot/ProductBootTest.java
+++ b/src/test/java/com/synopsys/integration/detect/boot/ProductBootTest.java
@@ -1,7 +1,13 @@
 package com.synopsys.integration.detect.boot;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 
+import com.synopsys.integration.detect.Application;
+import com.synopsys.integration.detect.workflow.phonehome.PhoneHomeSecrets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -91,7 +97,7 @@ public class ProductBootTest {
     private ProductRunData testBoot(BlackDuckDecision blackDuckDecision, ProductBootOptions productBootOptions, BlackDuckConnectivityResult blackDuckconnectivityResult)
         throws DetectUserFriendlyException, IOException, IntegrationException {
         ProductBootFactory productBootFactory = Mockito.mock(ProductBootFactory.class);
-        Mockito.when(productBootFactory.createPhoneHomeManager(Mockito.any())).thenReturn(null);
+        Mockito.when(productBootFactory.createPhoneHomeManager(Mockito.any(), Mockito.any())).thenReturn(null);
 
         BlackDuckVersionChecker blackDuckVersionChecker = Mockito.mock(BlackDuckVersionChecker.class);
         Mockito.when(blackDuckVersionChecker.check(Mockito.anyString())).thenReturn(BlackDuckVersionCheckerResult.passed());

--- a/src/test/java/com/synopsys/integration/detect/boot/ProductBootTest.java
+++ b/src/test/java/com/synopsys/integration/detect/boot/ProductBootTest.java
@@ -1,13 +1,7 @@
 package com.synopsys.integration.detect.boot;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.NoSuchAlgorithmException;
 
-import com.synopsys.integration.detect.Application;
-import com.synopsys.integration.detect.workflow.phonehome.PhoneHomeSecrets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
This pull request includes changes required to pull the GA4 credentials from GCP service.

- Currently, the function for hash modification, GCP service, and BlackduckCommonHelper are not yet changed to reflect the new functionality. So, parts where they are needed are replaced with soe mock code. However, the changes should still give a clear idea of the new control flow after the changes. A short summary of the changes is as follows:
![pr](https://github.com/blackducksoftware/synopsys-detect/assets/149692312/5b04b327-3879-499c-9098-384d38da1a88)


- The Mockito dependency is added to mock the GCP http behavior. It will be reverted in the final version.

- Also, Detect should not stop for any phone-home related failure. I tried to make sure all phone-home related exceptions are properly handled. Still, give it a look to see whether there are any case whether phone-home failure inhibits detect from proceeding.