### PR TITLE
Update release notes to indicate that Yocto 4.3.2 is now supported

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ dependencies {
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.6'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
     implementation 'com.synopsys:method-analyzer-core:0.2.9'
-    implementation "${locatorGroup}:${locatorModule}:1.1.7"
+    implementation "${locatorGroup}:${locatorModule}:1.1.8"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
     implementation "org.springframework.boot:spring-boot"

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Nuget Inspector now supports the exclusion of user-specified dependency types from the Bill of Materials (BOM) via the [solution_name] property --detect.nuget.dependency.types.excluded. See the [detect.nuget.dependency.types.excluded](properties/detectors/nuget.md#nuget-dependency-types-excluded) property for more information.
+* Support for BitBake is now extended to 2.6 (Yocto 4.3.2).
 
 ### Changed features
 


### PR DESCRIPTION
# Description

Update release notes to indicate that Yocto 4.3.2 is now supported.
