### PR TITLE
IDETECT-4212 - Update README and ubi version to 9.3

### DIFF
--- a/platform-1/Dockerfile.template
+++ b/platform-1/Dockerfile.template
@@ -1,5 +1,5 @@
 ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
 ARG BASE_TAG=UBI_VERSION
 
 ARG VERSION="RELEASE_VERSION"

--- a/platform-1/README.md
+++ b/platform-1/README.md
@@ -2,5 +2,27 @@
 
 ## Using the Image
 
-Image contains Blackduck client zip file under /opt
+blackduck-client is a wrapper of Synopsys Detect, in which an air-gap .zip file (containing the latest version of Detect) is stored under the **\/opt/** directory.
 
+After running this image as a container, users may extract the .zip file onto their local machine for use. However, please note that this image is not intended to be used as a persistently running container nor for running Detect from within a Docker container.
+
+This image can be pulled by running either of the following Docker commands:
+- `docker pull blackducksoftware/blackduck-client:{tag}`
+- `docker pull registry1.dso.mil/ironbank/synopsys/blackduck/blackduck-client:{tag}`
+
+Tag example: 9.3.0_ubi8.8
+
+## Documentation
+ 
+For details on how to run Detect, please see our documentation below: 
+- [Introduction to Synopsys Detect](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/introduction.html)
+ - [Running Synopsys Detect in air gap mode](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/runningdetect/runningairgap.html)
+
+## Example of running the image and copying the air-gap .zip to an existing local directory
+
+1) The following command runs the blackduck-client image as a container in detached mode with the name "detect", and keeps the container running indefinitely (with the tail command) until it is manually stopped (replace the image tag as needed): `docker run --rm --name detect -d blackducksoftware/blackduck-client:9.3.0_ubi8.8 tail -f /dev/null`
+
+2) Copy the file into an existing directory on your local machine (replace the version as needed): 
+`docker cp detect:/opt/synopsys-detect-9.3.0-air-gap.zip /tmp/detect-zip`
+
+3) Stop the running container: `docker stop detect`

--- a/platform-1/README.md
+++ b/platform-1/README.md
@@ -2,21 +2,21 @@
 
 ## Using the Image
 
-blackduck-client is a wrapper of Synopsys Detect, in which an air-gap .zip file (containing the latest version of Detect) is stored under the **\/opt/** directory.
+blackduck-client is a wrapper of Synopsys Detect, in which an air-gap `.zip` file (containing the latest version of Detect) is stored under the `/opt/` directory.
 
-After running this image as a container, users may extract the .zip file onto their local machine for use. However, please note that this image is not intended to be used as a persistently running container nor for running Detect from within a Docker container.
+While running this image as a container, extract the `.zip` file onto your local machine for use. Note that this image is not intended to be used as a persistently running container, nor for running Detect.
 
 This image can be pulled by running either of the following Docker commands:
 - `docker pull blackducksoftware/blackduck-client:{tag}`
 - `docker pull registry1.dso.mil/ironbank/synopsys/blackduck/blackduck-client:{tag}`
 
-Tag example: 9.3.0_ubi8.8
+Tag example: `9.3.0_ubi8.8`
 
 ## Documentation
  
 For details on how to run Detect, please see our documentation below: 
 - [Introduction to Synopsys Detect](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/introduction.html)
- - [Running Synopsys Detect in air gap mode](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/runningdetect/runningairgap.html)
+- [Running Synopsys Detect in air gap mode](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/runningdetect/runningairgap.html)
 
 ## Example of running the image and copying the air-gap .zip to an existing local directory
 

--- a/platform-1/build.sh
+++ b/platform-1/build.sh
@@ -13,7 +13,7 @@ sed -e "s/RELEASE_VERSION/$RELEASE_VERSION/g" -e "s/UBI_VERSION/$UBI_VERSION/g" 
 
 FULL_IMAGE_NAME="${TARGET_REPO}/${TARGET_IMAGE}:${TARGET_IMAGE_TAG}"
 REGISTRY=registry.access.redhat.com
-IMAGE=ubi8/ubi
+IMAGE=ubi9/ubi
 TAG="${UBI_VERSION}"
 
 docker build --pull -t "${FULL_IMAGE_NAME}"  \

--- a/platform-1/config.env
+++ b/platform-1/config.env
@@ -2,7 +2,7 @@ export TARGET_REPO=blackducksoftware
 export TARGET_IMAGE=blackduck-client
 export TARGET_VERSION=$RELEASE_VERSION
 
-export UBI_VERSION=8.8
+export UBI_VERSION=9.3
 export IMAGE_SUFFIX=_ubi
 
 export TARGET_IMAGE_TAG=${TARGET_VERSION}${IMAGE_SUFFIX}${UBI_VERSION}

--- a/platform-1/hardening_manifest.yaml.template
+++ b/platform-1/hardening_manifest.yaml.template
@@ -12,7 +12,7 @@ tags:
 
 # Build args passed to Dockerfile ARGs
 args:
-  BASE_IMAGE: "redhat/ubi/ubi8"
+  BASE_IMAGE: "redhat/ubi/ubi9"
   BASE_TAG: "UBI_VERSION"
 
 # Docker image labels


### PR DESCRIPTION
# Description

IDETECT-4212 - Update platform1 README with blackduck-client image details and usage. Also upgrade UBI version to 9.3.
