### PR TITLE
Use latest blackduck-common and related doc updates.

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -9,7 +9,7 @@
 
 ### Changed features
 
-* 
+* Key-value pairs specified as part of the `detect.blackduck.signature.scanner.arguments` property are now treated as replacements rather than additions.
 
 ### Resolved issues
 

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.12'
+gradle.ext.blackDuckCommonVersion='66.2.13'
 gradle.ext.springBootVersion='2.7.12'

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -372,7 +372,7 @@ public class DetectProperties {
         NullableStringProperty.newBuilder("detect.blackduck.signature.scanner.arguments")
             .setInfo("Signature Scanner Arguments", DetectPropertyFromVersion.VERSION_4_2_0)
             .setHelp(
-                "A space-separated list of additional arguments to use when running the Black Duck signature scanner.",
+                "A space-separated list of additional arguments to use when running the Black Duck signature scanner. Key-value pairs are treated as replacements.",
                 "For example: Suppose you are running in bash on Linux and want to use the signature scanner's ability to read a list of directories to exclude from a file (using the signature scanner --exclude-from option). You tell the signature scanner read excluded directories from a file named excludes.txt in the current working directory with: --detect.blackduck.signature.scanner.arguments='--exclude-from ./excludes.txt'"
             )
             .setGroups(DetectGroup.SIGNATURE_SCANNER, DetectGroup.GLOBAL)


### PR DESCRIPTION
Use latest blackduck-common to treat key-value pairs form detect.blackduck.signature.scanner.arguments as replacements.