### PR TITLE
Bump up blackduck-common version to ensure signature scanner proxy settings are set correctly

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.13'
+gradle.ext.blackDuckCommonVersion='66.2.14'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
Bump up blackduck-common version to ensure signature scanner proxy settings are set correctly.