### PR TITLE
Spring Framework - Upgrade related transitive dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,11 +139,13 @@ dependencies {
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 
+    // Below exclusions of transitive dependencies and inclusions of corresponding direct dependencies
+    // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
+    // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
     implementation "org.springframework:spring-jcl:5.3.32"
     implementation("org.springframework:spring-core:5.3.32") {
         exclude group: 'org.springframework', module: 'spring-jcl'
     }
-
     implementation "org.springframework:spring-aop:5.3.32"
     implementation "org.springframework:spring-beans:5.3.32"
     implementation "org.springframework:spring-expression:5.3.32"
@@ -152,7 +154,6 @@ dependencies {
         exclude group: 'org.springframework', module: 'spring-beans'
         exclude group: 'org.springframework', module: 'spring-expression'
     }
-
     implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
         exclude group: 'org.springframework', module: 'spring-context'

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     implementation "${locatorGroup}:${locatorModule}:1.1.8"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
-    implementation "org.springframework.boot:spring-boot" {
+    implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
     }
     implementation "org.springframework:spring-core:5.3.32"

--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,19 @@ dependencies {
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 
-    implementation "org.springframework:spring-core:5.3.32"
-    implementation "org.springframework:spring-context:5.3.32"
+    implementation "org.springframework:spring-jcl:5.3.32"
+    implementation("org.springframework:spring-core:5.3.32") {
+        exclude group: 'org.springframework', module: 'spring-jcl'
+    }
+
+    implementation "org.springframework:spring-aop:5.3.32"
+    implementation "org.springframework:spring-beans:5.3.32"
+    implementation "org.springframework:spring-expression:5.3.32"
+    implementation("org.springframework:spring-context:5.3.32") {
+        exclude group: 'org.springframework', module: 'spring-aop'
+        exclude group: 'org.springframework', module: 'spring-beans'
+        exclude group: 'org.springframework', module: 'spring-expression'
+    }
 
     implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'

--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot" {
         exclude group: 'org.springframework', module: 'spring-core'
     }
+    implementation "org.springframework:spring-core:5.3.32"
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.zeroturnaround:zt-zip:1.13'
     implementation 'org.apache.pdfbox:pdfbox:2.0.27'

--- a/build.gradle
+++ b/build.gradle
@@ -140,8 +140,10 @@ dependencies {
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
     implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
+        exclude group: 'org.springframework', module: 'spring-context'
     }
     implementation "org.springframework:spring-core:5.3.32"
+    implementation "org.springframework:spring-context:5.3.32"
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.zeroturnaround:zt-zip:1.13'
     implementation 'org.apache.pdfbox:pdfbox:2.0.27'

--- a/build.gradle
+++ b/build.gradle
@@ -138,12 +138,15 @@ dependencies {
     implementation "${locatorGroup}:${locatorModule}:1.1.8"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
+
+    implementation "org.springframework:spring-core:5.3.32"
+    implementation "org.springframework:spring-context:5.3.32"
+
     implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
         exclude group: 'org.springframework', module: 'spring-context'
     }
-    implementation "org.springframework:spring-core:5.3.32"
-    implementation "org.springframework:spring-context:5.3.32"
+
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.zeroturnaround:zt-zip:1.13'
     implementation 'org.apache.pdfbox:pdfbox:2.0.27'

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,9 @@ dependencies {
     implementation "${locatorGroup}:${locatorModule}:1.1.8"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
-    implementation "org.springframework.boot:spring-boot"
+    implementation "org.springframework.boot:spring-boot" {
+        exclude group: 'org.springframework', module: 'spring-core'
+    }
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.zeroturnaround:zt-zip:1.13'
     implementation 'org.apache.pdfbox:pdfbox:2.0.27'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -33,6 +33,6 @@ dependencies {
         exclude group: 'org.springframework', module: 'spring-core'
     }
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'org.springframework:spring-core'
+    implementation 'org.springframework:spring-core:5.3.32'
     implementation gradleApi()
 }

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -9,7 +9,10 @@ dependencyManagement {
 dependencies {
     implementation project(":common")
 
-    implementation "org.springframework:spring-core:5.3.32"
+    implementation "org.springframework:spring-jcl:5.3.32"
+    implementation("org.springframework:spring-core:5.3.32") {
+        exclude group: 'org.springframework', module: 'spring-jcl'
+    }
 
     implementation "org.springframework:spring-aop:5.3.32"
     implementation "org.springframework:spring-beans:5.3.32"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -9,11 +9,13 @@ dependencyManagement {
 dependencies {
     implementation project(":common")
 
+    // Below exclusions of transitive dependencies and inclusions of corresponding direct dependencies
+    // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
+    // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
     implementation "org.springframework:spring-jcl:5.3.32"
     implementation("org.springframework:spring-core:5.3.32") {
         exclude group: 'org.springframework', module: 'spring-jcl'
     }
-
     implementation "org.springframework:spring-aop:5.3.32"
     implementation "org.springframework:spring-beans:5.3.32"
     implementation "org.springframework:spring-expression:5.3.32"
@@ -22,13 +24,10 @@ dependencies {
         exclude group: 'org.springframework', module: 'spring-beans'
         exclude group: 'org.springframework', module: 'spring-expression'
     }
-
     implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
         exclude group: 'org.springframework', module: 'spring-context'
     }
-
-
 
     testImplementation "org.springframework:spring-test"
     testImplementation "org.apache.commons:commons-collections4:4.2"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -8,7 +8,9 @@ dependencyManagement {
 
 dependencies {
     implementation project(":common")
-    implementation "org.springframework.boot:spring-boot"
+    implementation "org.springframework.boot:spring-boot" {
+        exclude group: 'org.springframework', module: 'spring-core'
+    }
     implementation "org.springframework:spring-core:5.3.32"
 
     testImplementation "org.springframework:spring-test"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -8,12 +8,14 @@ dependencyManagement {
 
 dependencies {
     implementation project(":common")
+
+    implementation "org.springframework:spring-core:5.3.32"
+    implementation "org.springframework:spring-context:5.3.32"
     implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
         exclude group: 'org.springframework', module: 'spring-context'
     }
-    implementation "org.springframework:spring-core:5.3.32"
-    implementation "org.springframework:spring-context:5.3.32"
+
 
 
     testImplementation "org.springframework:spring-test"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -10,7 +10,16 @@ dependencies {
     implementation project(":common")
 
     implementation "org.springframework:spring-core:5.3.32"
-    implementation "org.springframework:spring-context:5.3.32"
+
+    implementation "org.springframework:spring-aop:5.3.32"
+    implementation "org.springframework:spring-beans:5.3.32"
+    implementation "org.springframework:spring-expression:5.3.32"
+    implementation("org.springframework:spring-context:5.3.32") {
+        exclude group: 'org.springframework', module: 'spring-aop'
+        exclude group: 'org.springframework', module: 'spring-beans'
+        exclude group: 'org.springframework', module: 'spring-expression'
+    }
+
     implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
         exclude group: 'org.springframework', module: 'spring-context'

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -10,8 +10,11 @@ dependencies {
     implementation project(":common")
     implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
+        exclude group: 'org.springframework', module: 'spring-context'
     }
     implementation "org.springframework:spring-core:5.3.32"
+    implementation "org.springframework:spring-context:5.3.32"
+
 
     testImplementation "org.springframework:spring-test"
     testImplementation "org.apache.commons:commons-collections4:4.2"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -9,7 +9,7 @@ dependencyManagement {
 dependencies {
     implementation project(":common")
     implementation "org.springframework.boot:spring-boot"
-    implementation "org.springframework:spring-core"
+    implementation "org.springframework:spring-core:5.3.32"
 
     testImplementation "org.springframework:spring-test"
     testImplementation "org.apache.commons:commons-collections4:4.2"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -8,7 +8,7 @@ dependencyManagement {
 
 dependencies {
     implementation project(":common")
-    implementation "org.springframework.boot:spring-boot" {
+    implementation("org.springframework.boot:spring-boot") {
         exclude group: 'org.springframework', module: 'spring-core'
     }
     implementation "org.springframework:spring-core:5.3.32"

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
 gradle.ext.blackDuckCommonVersion='66.2.13'
-gradle.ext.springBootVersion='3.1.9'
+gradle.ext.springBootVersion='2.7.12'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
 gradle.ext.blackDuckCommonVersion='66.2.13'
-gradle.ext.springBootVersion='2.7.12'
+gradle.ext.springBootVersion='2.7.18'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
 gradle.ext.blackDuckCommonVersion='66.2.13'
-gradle.ext.springBootVersion='2.7.18'
+gradle.ext.springBootVersion='3.1.9'


### PR DESCRIPTION
The exclusions of transitive dependencies and inclusions of corresponding direct dependencies were added to resolve `CVE-2024-22243` appearing in 5.3.27 of springframework libraries. 