### PR TITLE
PIP Requirements Parser - Include parsed files in diagnostic zip

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectable.java
@@ -13,6 +13,7 @@ import com.synopsys.integration.common.util.finder.FileFinder;
 import com.synopsys.integration.detectable.Detectable;
 import com.synopsys.integration.detectable.DetectableEnvironment;
 import com.synopsys.integration.detectable.detectable.DetectableAccuracyType;
+import com.synopsys.integration.detectable.detectable.Requirements;
 import com.synopsys.integration.detectable.detectable.annotation.DetectableInfo;
 import com.synopsys.integration.detectable.detectable.result.DetectableResult;
 import com.synopsys.integration.detectable.detectable.result.ExceptionDetectableResult;
@@ -58,7 +59,11 @@ public class RequirementsFileDetectable extends Detectable {
             }
             boolean requirementFilesPresent = CollectionUtils.isNotEmpty(requirementsFiles);
             if (requirementFilesPresent) {
-                return new PassedDetectableResult();
+                Requirements requirements = new Requirements(fileFinder, environment);
+                for (File requirementFile : requirementsFiles) {
+                    requirements.explainFile(requirementFile);
+                }
+                return requirements.result();
             } else {
                 return new FilesNotFoundDetectableResult(REQUIREMENTS_DEFAULT_FILE_NAME);
             }}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileDetectable.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.common.util.finder.FileFinder;
 import com.synopsys.integration.detectable.Detectable;
@@ -29,6 +31,7 @@ public class RequirementsFileDetectable extends Detectable {
     private final FileFinder fileFinder;
     private final RequirementsFileExtractor requirementsFileExtractor;
     private final RequirementsFileDetectableOptions requirementsFileDetectableOptions;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private Set<File> requirementsFiles;
     private List<Path> requirementsFilePathsOverride;
@@ -88,13 +91,15 @@ public class RequirementsFileDetectable extends Detectable {
         }
     }
 
-    private void processRequirementsFileOverrides() throws IOException {
+    private void processRequirementsFileOverrides() {
         Set<File> requirementsFilesOverrides = new HashSet<>();
         File currentRequirementsFileOverride;
         for (Path requirementsFilePath : requirementsFilePathsOverride) {
             currentRequirementsFileOverride = requirementsFilePath.toFile();
             if (currentRequirementsFileOverride.exists()) {
                 requirementsFilesOverrides.add(currentRequirementsFileOverride);
+            } else {
+                logger.warn("Could not locate the requirements file provided via detect.pip.requirements.path at {}. This file will not be included.", requirementsFilePath);
             }
         }
         requirementsFiles = requirementsFilesOverrides;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pip/parser/RequirementsFileTransformer.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class RequirementsFileTransformer {
 
     private static final List<String> OPERATORS_IN_PRIORITY_ORDER = Arrays.asList("==", ">=", "~=", "<=", ">", "<");
-    private static final List<String> IGNORE_AFTER_CHARACTERS = Arrays.asList("#", ";", ",");
+    private static final List<String> IGNORE_AFTER_CHARACTERS = Arrays.asList("#", ";");
     private static final List<String> TOKEN_CLEANUP_CHARS = Arrays.asList("==", ",", "\"", "'");
 
     public List<RequirementsFileDependency> transform(File requirementsFile) throws IOException {

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pip/parser/unit/RequirementsFileTransformerTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pip/parser/unit/RequirementsFileTransformerTest.java
@@ -79,7 +79,7 @@ public class RequirementsFileTransformerTest {
     @Test
     void testFormatLineForRawLineWithCommas() {
         String rawInputLine = "requests == 12.3.3, < 14.0";
-        String expectedLine = "requests == 12.3.3";
+        String expectedLine = "requests == 12.3.3, < 14.0";
 
         String formattedLine = requirementsFileTransformer.formatLine(rawInputLine);
         Assertions.assertEquals(expectedLine, formattedLine);


### PR DESCRIPTION
### Description
- Adds the fix to include the parsed PIP requirements file(s) to the "relevant" folder of the diagnostic zip. ([commit](https://github.com/blackducksoftware/synopsys-detect/commit/63c2f58518f911a8551feaf2b90fc0d4422e929e))
- Remove comma from ignore after characters list. In cases like `package_name < 10.1.1, >= 8.1.1`, where the lower version appears after a comma, we prioritize extraction of the lower version in the range. Hence, characters after a comma should not be ignored early.
- Added logger warning if file provided via override property isn't found.

### JIRA
IDETECT-4232 (Diagnostic zip issue)
IDETECT-4204 (Comma related parsing edge case)

