### PR TITLE
IDETECT-4242-Rename property --detect.yarn.monorepo.mode to --detect.yarn.ignore.all.workspaces

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -7,7 +7,7 @@
 * Nuget Inspector now supports the exclusion of user-specified dependency types from the Bill of Materials (BOM) via the [solution_name] property --detect.nuget.dependency.types.excluded. See the [detect.nuget.dependency.types.excluded](properties/detectors/nuget.md#nuget-dependency-types-excluded) property for more information.
 * A new detector for Python packages has been added. The PIP Requirements File Parse is a buildless detector that acts as a LOW accuracy fallback for the PIP Native Inspector. This detector is triggered for PIP projects that contain one or more requirements.txt files if [solution_name] does not have access to a PIP executable in the environment where the scan is run.
 	* See [PIP Requirements File Parse](packagemgrs/python.md).
-* To improve Yarn detector performance a new parameter is now available. The `--detect.yarn.monorepo.mode` parameter enables monorepo mode to build the dependency graph without analysis of workspaces. The default setting for this parameter is false and must be set to true to be enabled.
+* To improve Yarn detector performance a new parameter is now available. The `--detect.yarn.ignore.all.workspaces` parameter enables the Yarn detector to build the dependency graph without analysis of workspaces. The default setting for this parameter is false and must be set to true to be enabled.
 	* See [Yarn support](packagemgrs/yarn.md).
 * Support for BitBake is now extended to 2.6 (Yocto 4.3.2).
 * Support for Yarn extended to include Yarn 3 and Yarn 4.

--- a/documentation/src/main/markdown/packagemgrs/yarn.md
+++ b/documentation/src/main/markdown/packagemgrs/yarn.md
@@ -64,10 +64,12 @@ referencing guidelines described above. You can also use
 filename globbing-style wildcards and specify multiple values separated
 by commas.
 
-### Enable monorepo mode
+### Enable workspace ignore
 
 To speed up scanning by building the dependency graph without analysis of workspaces, set the parameter`--detect.yarn.ignore.all.workspaces=true`.   
 The default setting for this parameter is false and must be set to true to enable.
+
+Dependencies in workspaces that are not in the Yarn lock file will not be included in the Bill of Materials.
 
 <note type="note">The properties `detect.yarn.excluded.workspaces` and `detect.yarn.included.workspaces` do not apply if `detect.yarn.ignore.all.workspaces=true`.</note>
 

--- a/documentation/src/main/markdown/packagemgrs/yarn.md
+++ b/documentation/src/main/markdown/packagemgrs/yarn.md
@@ -66,9 +66,9 @@ by commas.
 
 ### Enable monorepo mode
 
-To speed up scanning by building the dependency graph without analysis of workspaces, set the parameter`--detect.yarn.monorepo.mode=true` to enable monorepo mode.   
+To speed up scanning by building the dependency graph without analysis of workspaces, set the parameter`--detect.yarn.ignore.all.workspaces=true`.   
 The default setting for this parameter is false and must be set to true to enable.
 
-<note type="note">The properties `detect.yarn.excluded.workspaces` and `detect.yarn.included.workspaces` do not apply if `detect.yarn.monorepo.mode=true`.</note>
+<note type="note">The properties `detect.yarn.excluded.workspaces` and `detect.yarn.included.workspaces` do not apply if `detect.yarn.ignore.all.workspaces=true`.</note>
 
 See [Yarn monorepo](https://yarnpkg.com/advanced/lexicon#monorepo) for further information about workspaces and monorepo configuration.

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1664,8 +1664,8 @@ public class DetectProperties {
 
     public static final BooleanProperty DETECT_YARN_MONOREPO_MODE =
         BooleanProperty.newBuilder("detect.yarn.ignore.all.workspaces", false)
-            .setInfo("Yarn Monorepo Mode Enabled", DetectPropertyFromVersion.VERSION_9_4_0)
-            .setHelp("Enable monorepo mode of the Yarn detector for increased performance and precision to scan a massive codebase.")
+            .setInfo("Ignore All Workspaces", DetectPropertyFromVersion.VERSION_9_4_0)
+            .setHelp("All workspaces are ignored by the Yarn detector for increased performance and precision to scan a massive codebase.")
             .setGroups(DetectGroup.YARN, DetectGroup.SOURCE_SCAN)
             .build();
     

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1663,7 +1663,7 @@ public class DetectProperties {
             .build();
 
     public static final BooleanProperty DETECT_YARN_MONOREPO_MODE =
-        BooleanProperty.newBuilder("detect.yarn.monorepo.mode", false)
+        BooleanProperty.newBuilder("detect.yarn.ignore.all.workspaces", false)
             .setInfo("Yarn Monorepo Mode Enabled", DetectPropertyFromVersion.VERSION_9_4_0)
             .setHelp("Enable monorepo mode of the Yarn detector for increased performance and precision to scan a massive codebase.")
             .setGroups(DetectGroup.YARN, DetectGroup.SOURCE_SCAN)

--- a/src/test/java/com/synopsys/integration/detect/battery/detector/YarnBattery.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/detector/YarnBattery.java
@@ -174,7 +174,7 @@ public class YarnBattery {
         test.sourceFileFromResource("workspace-a/package.json");
         test.sourceFileFromResource("workspace-a/child-workspace/package.json");
         test.sourceFileFromResource("nondep-workspace/package.json");
-        test.property("detect.yarn.monorepo.mode", "true");
+        test.property("detect.yarn.ignore.all.workspaces", "true");
         test.expectBdioResources();
         test.run();
     }


### PR DESCRIPTION
# Description

Renamed property --detect.yarn.monorepo.mode to --detect.yarn.ignore.all.workspaces.

# Github Issues

IDETECT-4242
