### PR TITLE
encode filename in header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.synopsys.integration'
 
-version = '9.5.0-SNAPSHOT'
+version = '9.6.0-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RlScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RlScanStepRunner.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.detect.lifecycle.run.step;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
@@ -93,7 +94,9 @@ public class RlScanStepRunner {
         logger.debug("Uploading ReversingLabs file to storage endpoint: {}", storageServiceEndpoint);
         
         Map<String, String> headers = new HashMap<>();
-        headers.put("fileName", fileToUpload.getName());
+
+        String encodedName = URLEncoder.encode(fileToUpload.getName(), "UTF-8");
+        headers.put("X-Filename", encodedName);
         
         try (Response response = operationRunner.uploadFileToStorageServiceWithHeaders(
                 blackDuckRunData,


### PR DESCRIPTION
If we put multibyte characters in an HTTP header it gets rejected in various places. We need to encode it first. The X-* header is a naming convention so the nginx server doesn't put weird rules on the header. The storage service knows we are encoding it and is properly setup to decode it.