### PR TITLE
Include Maven Shaded Dependencies in BOM

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
@@ -58,7 +58,7 @@ public class MavenCliExtractor {
                 Extraction extraction = mavenProjectInspectorDetectable.extract(extractionEnvironment);
                 shadedDependencies = mavenProjectInspectorDetectable.getShadedDependencies();
             } catch (Exception e) {
-                throw new RuntimeException();
+               throw new RuntimeException("There was an error extracting the shaded dependencies from Project Inspector. Please ensure that you have the latest version of Project Inspector 2024.2.0",e);
             }
         }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
@@ -1,9 +1,11 @@
 package com.synopsys.integration.detectable.detectables.maven.cli;
 
 import java.io.File;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
+import com.synopsys.integration.bdio.model.dependency.Dependency;
+import com.synopsys.integration.detectable.detectables.maven.parsing.MavenProjectInspectorDetectable;
+import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 import org.apache.commons.lang3.StringUtils;
 
 import com.synopsys.integration.common.util.Bds;
@@ -22,6 +24,7 @@ public class MavenCliExtractor {
     private final MavenCodeLocationPackager mavenCodeLocationPackager;
     private final CommandParser commandParser;
     private final ToolVersionLogger toolVersionLogger;
+    private Map<String, Set<String>> shadedDependencies = new HashMap<>();
 
     public MavenCliExtractor(
         DetectableExecutableRunner executableRunner,
@@ -35,7 +38,7 @@ public class MavenCliExtractor {
         this.toolVersionLogger = toolVersionLogger;
     }
 
-    public Extraction extract(File directory, ExecutableTarget mavenExe, MavenCliExtractorOptions mavenCliExtractorOptions) throws ExecutableFailedException {
+    public Extraction extract(File directory, ExecutableTarget mavenExe, MavenCliExtractorOptions mavenCliExtractorOptions, MavenProjectInspectorDetectable mavenProjectInspectorDetectable, ExtractionEnvironment extractionEnvironment) throws ExecutableFailedException {
         toolVersionLogger.log(directory, mavenExe);
         List<String> commandArguments = mavenCliExtractorOptions.buildCliArguments(commandParser);
 
@@ -46,13 +49,27 @@ public class MavenCliExtractor {
         List<String> includedScopes = mavenCliExtractorOptions.getMavenIncludedScopes();
         List<String> excludedModules = mavenCliExtractorOptions.getMavenExcludedModules();
         List<String> includedModules = mavenCliExtractorOptions.getMavenIncludedModules();
+        Boolean includeShadedDependencies = mavenCliExtractorOptions.getMavenIncludeShadedDependencies();
+
+        if(includeShadedDependencies) {
+            try {
+                mavenProjectInspectorDetectable.includeShadedDependencies = "include_shaded_dependencies";
+                mavenProjectInspectorDetectable.extractable();
+                Extraction extraction = mavenProjectInspectorDetectable.extract(extractionEnvironment);
+                shadedDependencies = mavenProjectInspectorDetectable.getShadedDependencies();
+            } catch (Exception e) {
+                throw new RuntimeException();
+            }
+        }
+
         List<MavenParseResult> mavenResults = mavenCodeLocationPackager.extractCodeLocations(
             directory.toString(),
             mavenOutput,
             excludedScopes,
             includedScopes,
             excludedModules,
-            includedModules
+            includedModules,
+            shadedDependencies
         );
 
         List<CodeLocation> codeLocations = Bds.of(mavenResults)

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
@@ -1,9 +1,12 @@
 package com.synopsys.integration.detectable.detectables.maven.cli;
 
 import java.io.File;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.Optional;
 
-import com.synopsys.integration.bdio.model.dependency.Dependency;
 import com.synopsys.integration.detectable.detectables.maven.parsing.MavenProjectInspectorDetectable;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 import org.apache.commons.lang3.StringUtils;
@@ -58,7 +61,7 @@ public class MavenCliExtractor {
                 Extraction extraction = mavenProjectInspectorDetectable.extract(extractionEnvironment);
                 shadedDependencies = mavenProjectInspectorDetectable.getShadedDependencies();
             } catch (Exception e) {
-               throw new RuntimeException("There was an error extracting the shaded dependencies from Project Inspector. Please ensure that you have the latest version of Project Inspector 2024.2.0",e);
+               throw new RuntimeException("There was an error extracting the shaded dependencies from Project Inspector. There might be version mismatch between Detect and Project Inspector, confirm that compatible versions of them are in use.",e);
             }
         }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
@@ -53,7 +53,7 @@ public class MavenCliExtractor {
 
         if(includeShadedDependencies) {
             try {
-                mavenProjectInspectorDetectable.includeShadedDependencies = "include_shaded_dependencies";
+                mavenProjectInspectorDetectable.setIncludeShadedDependencies(true);
                 mavenProjectInspectorDetectable.extractable();
                 Extraction extraction = mavenProjectInspectorDetectable.extract(extractionEnvironment);
                 shadedDependencies = mavenProjectInspectorDetectable.getShadedDependencies();

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractorOptions.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractorOptions.java
@@ -22,6 +22,7 @@ public class MavenCliExtractorOptions {
     private final List<String> mavenIncludedScopes;
     private final List<String> mavenExcludedModules;
     private final List<String> mavenIncludedModules;
+    private final Boolean mavenIncludeShadedDependencies;
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -30,13 +31,15 @@ public class MavenCliExtractorOptions {
         List<String> mavenExcludedScopes,
         List<String> mavenIncludedScopes,
         List<String> mavenExcludedModules,
-        List<String> mavenIncludedModules
+        List<String> mavenIncludedModules,
+        Boolean mavenIncludeShadedDependencies
     ) {
         this.mavenBuildCommand = mavenBuildCommand;
         this.mavenExcludedScopes = mavenExcludedScopes;
         this.mavenIncludedScopes = mavenIncludedScopes;
         this.mavenExcludedModules = mavenExcludedModules;
         this.mavenIncludedModules = mavenIncludedModules;
+        this.mavenIncludeShadedDependencies = mavenIncludeShadedDependencies;
     }
 
     public Optional<String> getMavenBuildCommand() {
@@ -95,5 +98,9 @@ public class MavenCliExtractorOptions {
 
     public List<String> getMavenIncludedModules() {
         return mavenIncludedModules;
+    }
+
+    public Boolean getMavenIncludeShadedDependencies() {
+        return mavenIncludeShadedDependencies;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCodeLocationPackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCodeLocationPackager.java
@@ -220,11 +220,11 @@ public class MavenCodeLocationPackager {
                 logger.trace(String.format("adding orphan: %s", dependency.getExternalId().toString()));
                 graph.addParentWithChild(orphanListParent, dependency);
             }
-            addShadedDependenciesToGraph(graph, orphanListParent);
+            addOrphanShadedDependenciesToGraph(graph, orphanListParent);
         }
     }
 
-    private void addShadedDependenciesToGraph(DependencyGraph graph, Dependency orphanParent) {
+    private void addOrphanShadedDependenciesToGraph(DependencyGraph graph, Dependency orphanParent) {
         shadedDependenciesConverted.forEach((dependency, shadedDependency) -> {
             ScopedDependency parentDependency = new ScopedDependency(dependency.getName(), dependency.getVersion(), dependency, null);
             graph.addParentWithChild(orphanParent, parentDependency);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCodeLocationPackager.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCodeLocationPackager.java
@@ -1,12 +1,10 @@
 package com.synopsys.integration.detectable.detectables.maven.cli;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Stack;
+import java.util.*;
 import java.util.regex.Pattern;
 
+import com.synopsys.integration.detectable.detectables.projectinspector.ProjectInspectorParser;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +40,8 @@ public class MavenCodeLocationPackager {
     private boolean inOutOfScopeTree = false;
     private DependencyGraph currentGraph = null;
 
+    private Map<ExternalId, Set<Dependency>> shadedDependenciesConverted = new HashMap<>();
+
     public MavenCodeLocationPackager(ExternalIdFactory externalIdFactory) {
         this.externalIdFactory = externalIdFactory;
     }
@@ -53,7 +53,8 @@ public class MavenCodeLocationPackager {
         List<String> excludedScopes,
         List<String> includedScopes,
         List<String> excludedModules,
-        List<String> includedModules
+        List<String> includedModules,
+        Map<String, Set<String>> shadedDependencies
     ) {
         ExcludedIncludedWildcardFilter modulesFilter = ExcludedIncludedWildcardFilter.fromCollections(excludedModules, includedModules);
         ExcludedIncludedWildcardFilter scopeFilter = ExcludedIncludedWildcardFilter.fromCollections(excludedScopes, includedScopes);
@@ -62,6 +63,20 @@ public class MavenCodeLocationPackager {
         dependencyParentStack = new Stack<>();
         parsingProjectSection = false;
         currentGraph = new BasicDependencyGraph();
+
+        if(!shadedDependencies.isEmpty()) {
+            shadedDependencies.forEach((dependency, shadedDependency) -> {
+                String[] gavParts = dependency.split(":");
+                String group = gavParts[0];
+                String artifact = gavParts[1];
+                String version = gavParts[2];
+                ExternalId dependencyId = externalIdFactory.createMavenExternalId(group, artifact, version);
+                shadedDependenciesConverted.put(dependencyId, new HashSet<>());
+                shadedDependency.forEach(childDependencyString -> {
+                    shadedDependenciesConverted.get(dependencyId).add(textToDependency(childDependencyString));
+                });
+            });
+        }
 
         level = 0;
         for (String currentLine : mavenOutput) {
@@ -187,11 +202,17 @@ public class MavenCodeLocationPackager {
                 dependencyParentStack.push(dependency);
             }
         }
+        if(!shadedDependenciesConverted.isEmpty() && shadedDependenciesConverted.containsKey(dependency.getExternalId())) {
+            for(Dependency childDependency: shadedDependenciesConverted.get(dependency.getExternalId())) {
+                currentGraph.addParentWithChild(dependency, childDependency);
+            }
+            shadedDependenciesConverted.remove(dependency.getExternalId());
+        }
     }
 
     private void addOrphansToGraph(DependencyGraph graph, List<Dependency> orphans) {
         logger.trace(String.format("# orphans: %d", orphans.size()));
-        if (orphans.size() > 0) {
+        if (!orphans.isEmpty() || !shadedDependenciesConverted.isEmpty()) {
             Dependency orphanListParent = createOrphanListParentDependency();
             logger.trace(String.format("adding orphan list parent dependency: %s", orphanListParent.getExternalId().toString()));
             graph.addChildToRoot(orphanListParent);
@@ -199,7 +220,18 @@ public class MavenCodeLocationPackager {
                 logger.trace(String.format("adding orphan: %s", dependency.getExternalId().toString()));
                 graph.addParentWithChild(orphanListParent, dependency);
             }
+            addShadedDependenciesToGraph(graph, orphanListParent);
         }
+    }
+
+    private void addShadedDependenciesToGraph(DependencyGraph graph, Dependency orphanParent) {
+        shadedDependenciesConverted.forEach((dependency, shadedDependency) -> {
+            ScopedDependency parentDependency = new ScopedDependency(dependency.getName(), dependency.getVersion(), dependency, null);
+            graph.addParentWithChild(orphanParent, parentDependency);
+            shadedDependency.forEach(childDependency -> {
+                graph.addParentWithChild(parentDependency, childDependency);
+            });
+        });
     }
 
     private void addDependencyIfInScope(
@@ -269,10 +301,10 @@ public class MavenCodeLocationPackager {
         if (!isGav(componentText)) {
             return null;
         }
-        
+
         // This is a GAV line.
         componentText = removeGroupArtifactPipedSuffixIfExists(componentText);
-        
+
         String[] gavParts = componentText.split(":");
         String group = gavParts[0];
         String artifact = gavParts[1];
@@ -313,13 +345,13 @@ public class MavenCodeLocationPackager {
         if (!isGav(componentText)) {
             return null;
         }
-        
+
         // This is a GAV line.
         componentText = removeGroupArtifactPipedSuffixIfExists(componentText);
-        
+
         String[] gavParts = componentText.split(":");
         String group = gavParts[0];
-        String artifact = gavParts[1];        
+        String artifact = gavParts[1];
         String version;
         if (gavParts.length == 4) {
             // Dependency does not include the classifier

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenPomDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenPomDetectable.java
@@ -39,8 +39,8 @@ public class MavenPomDetectable extends Detectable {
         this.fileFinder = fileFinder;
         this.mavenResolver = mavenResolver;
         this.mavenCliExtractor = mavenCliExtractor;
-        this.mavenCliExtractorOptions = mavenCliExtractorOptions;
-        this.mavenProjectInspectorDetectable = mavenProjectInspectorDetectable; //TODO: Should this be wrapped in a detectables options? -jp
+        this.mavenCliExtractorOptions = mavenCliExtractorOptions; //TODO: Should this be wrapped in a detectables options? -jp
+        this.mavenProjectInspectorDetectable = mavenProjectInspectorDetectable;
     }
 
     @Override

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenPomDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenPomDetectable.java
@@ -11,6 +11,7 @@ import com.synopsys.integration.detectable.detectable.exception.DetectableExcept
 import com.synopsys.integration.detectable.detectable.executable.ExecutableFailedException;
 import com.synopsys.integration.detectable.detectable.executable.resolver.MavenResolver;
 import com.synopsys.integration.detectable.detectable.result.DetectableResult;
+import com.synopsys.integration.detectable.detectables.maven.parsing.MavenProjectInspectorDetectable;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 
@@ -22,6 +23,7 @@ public class MavenPomDetectable extends Detectable {
     private final MavenResolver mavenResolver;
     private final MavenCliExtractor mavenCliExtractor;
     private final MavenCliExtractorOptions mavenCliExtractorOptions;
+    private final MavenProjectInspectorDetectable mavenProjectInspectorDetectable;
 
     private ExecutableTarget mavenExe;
 
@@ -30,13 +32,15 @@ public class MavenPomDetectable extends Detectable {
         FileFinder fileFinder,
         MavenResolver mavenResolver,
         MavenCliExtractor mavenCliExtractor,
-        MavenCliExtractorOptions mavenCliExtractorOptions
+        MavenCliExtractorOptions mavenCliExtractorOptions,
+        MavenProjectInspectorDetectable mavenProjectInspectorDetectable
     ) {
         super(environment);
         this.fileFinder = fileFinder;
         this.mavenResolver = mavenResolver;
         this.mavenCliExtractor = mavenCliExtractor;
-        this.mavenCliExtractorOptions = mavenCliExtractorOptions; //TODO: Should this be wrapped in a detectables options? -jp
+        this.mavenCliExtractorOptions = mavenCliExtractorOptions;
+        this.mavenProjectInspectorDetectable = mavenProjectInspectorDetectable; //TODO: Should this be wrapped in a detectables options? -jp
     }
 
     @Override
@@ -55,7 +59,7 @@ public class MavenPomDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) throws ExecutableFailedException {
-        return mavenCliExtractor.extract(environment.getDirectory(), mavenExe, mavenCliExtractorOptions);
+        return mavenCliExtractor.extract(environment.getDirectory(), mavenExe, mavenCliExtractorOptions, mavenProjectInspectorDetectable, extractionEnvironment);
     }
 
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenPomWrapperDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenPomWrapperDetectable.java
@@ -15,6 +15,7 @@ import com.synopsys.integration.detectable.detectable.result.DetectableResult;
 import com.synopsys.integration.detectable.detectable.result.ExecutableNotFoundDetectableResult;
 import com.synopsys.integration.detectable.detectable.result.FileNotFoundDetectableResult;
 import com.synopsys.integration.detectable.detectable.result.PassedDetectableResult;
+import com.synopsys.integration.detectable.detectables.maven.parsing.MavenProjectInspectorDetectable;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 
@@ -26,6 +27,7 @@ public class MavenPomWrapperDetectable extends Detectable {
     private final MavenResolver mavenResolver;
     private final MavenCliExtractor mavenCliExtractor;
     private final MavenCliExtractorOptions mavenCliExtractorOptions;
+    private final MavenProjectInspectorDetectable mavenProjectInspectorDetectable;
 
     private ExecutableTarget mavenExe;
 
@@ -34,13 +36,15 @@ public class MavenPomWrapperDetectable extends Detectable {
         FileFinder fileFinder,
         MavenResolver mavenResolver,
         MavenCliExtractor mavenCliExtractor,
-        MavenCliExtractorOptions mavenCliExtractorOptions
+        MavenCliExtractorOptions mavenCliExtractorOptions,
+        MavenProjectInspectorDetectable mavenProjectInspectorDetectable
     ) {
         super(environment);
         this.fileFinder = fileFinder;
         this.mavenResolver = mavenResolver;
         this.mavenCliExtractor = mavenCliExtractor;
         this.mavenCliExtractorOptions = mavenCliExtractorOptions; //TODO: Should this be wrapped in a detectable options? - jp
+        this.mavenProjectInspectorDetectable = mavenProjectInspectorDetectable;
     }
 
     @Override
@@ -67,7 +71,7 @@ public class MavenPomWrapperDetectable extends Detectable {
 
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) throws ExecutableFailedException {
-        return mavenCliExtractor.extract(environment.getDirectory(), mavenExe, mavenCliExtractorOptions);
+        return mavenCliExtractor.extract(environment.getDirectory(), mavenExe, mavenCliExtractorOptions, mavenProjectInspectorDetectable, extractionEnvironment);
     }
 
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/parsing/MavenProjectInspectorDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/parsing/MavenProjectInspectorDetectable.java
@@ -2,6 +2,8 @@ package com.synopsys.integration.detectable.detectables.maven.parsing;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 import com.synopsys.integration.common.util.finder.FileFinder;
 import com.synopsys.integration.detectable.Detectable;
@@ -27,6 +29,7 @@ public class MavenProjectInspectorDetectable extends Detectable {
     private final ProjectInspectorResolver projectInspectorResolver;
     private final ProjectInspectorExtractor projectInspectorExtractor;
     private final ProjectInspectorOptions projectInspectorOptions; // TODO: Options don't belong here
+    public String includeShadedDependencies = "";
 
     private ExecutableTarget inspector;
 
@@ -62,11 +65,15 @@ public class MavenProjectInspectorDetectable extends Detectable {
     public Extraction extract(ExtractionEnvironment extractionEnvironment) throws ExecutableFailedException, IOException {
         return projectInspectorExtractor.extract(
             projectInspectorOptions,
-            Collections.emptyList(),
+            includeShadedDependencies.equals("") ? Collections.emptyList() : Collections.singletonList(includeShadedDependencies),
             environment.getDirectory(),
             extractionEnvironment.getOutputDirectory(),
             inspector
         );
+    }
+
+    public Map<String, Set<String>> getShadedDependencies() {
+        return projectInspectorExtractor.getShadedDependencies();
     }
 
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/parsing/MavenProjectInspectorDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/parsing/MavenProjectInspectorDetectable.java
@@ -24,12 +24,13 @@ import com.synopsys.integration.detectable.extraction.ExtractionEnvironment;
 @DetectableInfo(name = "Maven Project Inspector", language = "various", forge = "Maven Central", accuracy = DetectableAccuracyType.LOW, requirementsMarkdown = "File: pom.xml.")
 public class MavenProjectInspectorDetectable extends Detectable {
     private static final String POM_XML_FILENAME = "pom.xml";
-
+    private static final String INCLUDE_SHADED_DEPENDENCIES = "include_shaded_dependencies";
     private final FileFinder fileFinder;
     private final ProjectInspectorResolver projectInspectorResolver;
     private final ProjectInspectorExtractor projectInspectorExtractor;
     private final ProjectInspectorOptions projectInspectorOptions; // TODO: Options don't belong here
-    public String includeShadedDependencies = "";
+    private boolean includeShadedDependencies = false;
+
 
     private ExecutableTarget inspector;
 
@@ -65,11 +66,15 @@ public class MavenProjectInspectorDetectable extends Detectable {
     public Extraction extract(ExtractionEnvironment extractionEnvironment) throws ExecutableFailedException, IOException {
         return projectInspectorExtractor.extract(
             projectInspectorOptions,
-            includeShadedDependencies.equals("") ? Collections.emptyList() : Collections.singletonList(includeShadedDependencies),
+            includeShadedDependencies ? Collections.singletonList(INCLUDE_SHADED_DEPENDENCIES) : Collections.emptyList(),
             environment.getDirectory(),
             extractionEnvironment.getOutputDirectory(),
             inspector
         );
+    }
+
+    public void setIncludeShadedDependencies(boolean includeShadedDependencies) {
+        this.includeShadedDependencies = includeShadedDependencies;
     }
 
     public Map<String, Set<String>> getShadedDependencies() {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorExtractor.java
@@ -2,10 +2,7 @@ package com.synopsys.integration.detectable.detectables.projectinspector;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import com.synopsys.integration.detectable.ExecutableTarget;
 import com.synopsys.integration.detectable.ExecutableUtils;
@@ -31,6 +28,12 @@ public class ProjectInspectorExtractor {
         ExecutableTarget inspector
     ) throws ExecutableFailedException {
         File outputFile = new File(outputDirectory, "inspection.json");
+        boolean includeShadedDependencies = false;
+
+        if(extra.contains("include_shaded_dependencies")) {
+            includeShadedDependencies = true;
+            extra = Collections.emptyList();
+        }
 
         // TODO: Could use a command runner
         List<String> arguments = new LinkedList<>();
@@ -50,8 +53,12 @@ public class ProjectInspectorExtractor {
 
         executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(targetDirectory, inspector, arguments));
 
-        List<CodeLocation> codeLocations = projectInspectorParser.parse(outputFile);
+        List<CodeLocation> codeLocations = projectInspectorParser.parse(outputFile, includeShadedDependencies);
 
         return new Extraction.Builder().success(codeLocations).build();
+    }
+
+    public Map<String, Set<String>> getShadedDependencies() {
+        return projectInspectorParser.getShadedDependencies();
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorExtractor.java
@@ -12,6 +12,8 @@ import com.synopsys.integration.detectable.detectable.executable.ExecutableFaile
 import com.synopsys.integration.detectable.extraction.Extraction;
 
 public class ProjectInspectorExtractor {
+
+    private static final String INCLUDE_SHADED_DEPENDENCIES = "include_shaded_dependencies";
     private final DetectableExecutableRunner executableRunner;
     private final ProjectInspectorParser projectInspectorParser;
 
@@ -30,7 +32,7 @@ public class ProjectInspectorExtractor {
         File outputFile = new File(outputDirectory, "inspection.json");
         boolean includeShadedDependencies = false;
 
-        if(extra.contains("include_shaded_dependencies")) {
+        if(extra.contains(INCLUDE_SHADED_DEPENDENCIES)) {
             includeShadedDependencies = true;
             extra = Collections.emptyList();
         }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
@@ -122,25 +122,29 @@ public class ProjectInspectorParser {
     }
 
     public void processShadedDependencies(ProjectInspectorModule module) {
-        module.components.forEach((dependencyId, component) -> {
-            if(component.shadedBy != null) {
-                String[] gavParts = component.shadedBy.description.split(":");
-                String group = gavParts[0];
-                String artifact = gavParts[1];
-                String version;
-                if (gavParts.length > 4) {
-                    version = gavParts[gavParts.length - 2];
-                } else {
-                    version = gavParts[gavParts.length - 1];
+        if(module.components != null) {
+            module.components.forEach((dependencyId, component) -> {
+                if (component.shadedBy != null) {
+                    String[] gavParts = component.shadedBy.description.split(":");
+                    String group = gavParts[0];
+                    String artifact = gavParts[1];
+                    String version;
+                    if (gavParts.length > 4) {
+                        version = gavParts[gavParts.length - 2];
+                    } else {
+                        version = gavParts[gavParts.length - 1];
+                    }
+                    String gav = String.join(":", group, artifact, version);
+                    if (shadedDependencies.containsKey(gav)) {
+                        shadedDependencies.get(gav).add(component.name);
+                    } else {
+                        shadedDependencies.put(gav, new HashSet<>(Arrays.asList(component.name)));
+                    }
                 }
-                String gav = String.join(":",group,artifact,version);
-                if(shadedDependencies.containsKey(gav)) {
-                    shadedDependencies.get(gav).add(component.name);
-                } else {
-                    shadedDependencies.put(gav, new HashSet<>(Arrays.asList(component.name)));
-                }
-            }
-        });
+            });
+        } else {
+            logger.info("From Detect 9.5.0 and onwards, we will support the latest version of Project Inspector i.e. 2024.2.0. If you are using the detect.project.inspector.path property, please use the latest version mentioned.");
+        }
     }
 
     public Dependency convertProjectInspectorDependency(ProjectInspectorComponent component) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
+import com.synopsys.integration.detectable.detectables.maven.cli.MavenCodeLocationPackager;
 import com.synopsys.integration.detectable.detectables.projectinspector.model.ProjectInspectorComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,13 +31,14 @@ public class ProjectInspectorParser {
     private final Gson gson;
     private final ExternalIdFactory externalIdFactory;
     private static final String MODULES_KEY = "Modules";
+    private final Map<String,Set<String>> shadedDependencies = new HashMap<>();
 
     public ProjectInspectorParser(Gson gson, ExternalIdFactory externalIdFactory) {
         this.gson = gson;
         this.externalIdFactory = externalIdFactory;
     }
 
-    public List<CodeLocation> parse(File outputFile) {
+    public List<CodeLocation> parse(File outputFile, boolean includeShadedDependencies) {
         List<CodeLocation> codeLocations = new ArrayList<>();
 
         if (outputFile == null || !outputFile.exists() || !outputFile.isFile()) {
@@ -51,7 +53,7 @@ public class ProjectInspectorParser {
             while (reader.hasNext()) {
                 String modulesObject = reader.nextName();
                 if (modulesObject != null && modulesObject.equals(MODULES_KEY)) {
-                    codeLocations = processModules(reader);
+                    codeLocations = processModules(reader, includeShadedDependencies);
                 } else {
                     reader.skipValue();
                 }
@@ -63,7 +65,7 @@ public class ProjectInspectorParser {
         return codeLocations;
     }
 
-    public List<CodeLocation> processModules(JsonReader reader) throws IOException {
+    public List<CodeLocation> processModules(JsonReader reader, boolean includeShadedDependencies) throws IOException {
         List<CodeLocation> codeLocations = new ArrayList<>();
 
         reader.beginObject();
@@ -72,8 +74,12 @@ public class ProjectInspectorParser {
             if (moduleId != null) {
                 JsonObject module = JsonParser.parseReader(reader).getAsJsonObject();
                 ProjectInspectorModule projectInspectorModule = gson.fromJson(module, ProjectInspectorModule.class);
-                CodeLocation codeLocation = codeLocationFromModule(projectInspectorModule);
-                codeLocations.add(codeLocation);
+                if(includeShadedDependencies) {
+                    processShadedDependencies(projectInspectorModule);
+                } else {
+                    CodeLocation codeLocation = codeLocationFromModule(projectInspectorModule);
+                    codeLocations.add(codeLocation);
+                }
             }
         }
         reader.endObject();
@@ -85,29 +91,56 @@ public class ProjectInspectorParser {
     public CodeLocation codeLocationFromModule(ProjectInspectorModule module) {
         Map<String, Dependency> lookup = new HashMap<>();
 
-        //build the map of all external ids
-        module.components.forEach((dependencyId, component) -> {
-            lookup.computeIfAbsent(dependencyId, missingId -> convertProjectInspectorDependency(component));
-        });
+        if(module.components != null) {
+            //build the map of all external ids
+            module.components.forEach((dependencyId, component) -> {
+                lookup.computeIfAbsent(dependencyId, missingId -> convertProjectInspectorDependency(component));
+            });
 
-        //and add them to the graph
-        DependencyGraph mutableDependencyGraph = new BasicDependencyGraph();
-        module.components.forEach((moduleDependencyId, moduleDependency) -> {
-            Dependency dependency = lookup.get(moduleDependencyId);
-            if(moduleDependency.inclusionType.equals("DIRECT")){
-                mutableDependencyGraph.addDirectDependency(dependency);
-            } else if (moduleDependency.inclusionType.equals("TRANSITIVE")) {
-                moduleDependency.includedBy.forEach(includedBy -> {
-                    if (lookup.containsKey(includedBy.id)) {
-                        mutableDependencyGraph.addChildWithParent(dependency, lookup.get(includedBy.id));
-                    } else { //Theoretically should not happen according to PI devs. -jp
-                        throw new RuntimeException("An error occurred reading the project inspector output." +
-                                " An unknown parent dependency was encountered '" + includedBy.id + "' while including dependency '" + moduleDependency.name + "'.");
-                    }
-                });
+            //and add them to the graph
+            DependencyGraph mutableDependencyGraph = new BasicDependencyGraph();
+            module.components.forEach((moduleDependencyId, moduleDependency) -> {
+                Dependency dependency = lookup.get(moduleDependencyId);
+                if (moduleDependency.inclusionType.equals("DIRECT")) {
+                    mutableDependencyGraph.addDirectDependency(dependency);
+                } else if (moduleDependency.inclusionType.equals("TRANSITIVE")) {
+                    moduleDependency.includedBy.forEach(includedBy -> {
+                        if (lookup.containsKey(includedBy.id)) {
+                            mutableDependencyGraph.addChildWithParent(dependency, lookup.get(includedBy.id));
+                        } else { //Theoretically should not happen according to PI devs. -jp
+                            throw new RuntimeException("An error occurred reading the project inspector output." +
+                                    " An unknown parent dependency was encountered '" + includedBy.id + "' while including dependency '" + moduleDependency.name + "'.");
+                        }
+                    });
+                }
+            });
+            return new CodeLocation(mutableDependencyGraph, new File(module.moduleFile));
+        } else {
+            logger.info("From Detect 9.5.0 and onwards, we will support the latest version of Project Inspector i.e. 2024.2.0. If you are using the detect.project.inspector.path property, please use the latest version mentioned.");
+        }
+        return null;
+    }
+
+    public void processShadedDependencies(ProjectInspectorModule module) {
+        module.components.forEach((dependencyId, component) -> {
+            if(component.shadedBy != null) {
+                String[] gavParts = component.shadedBy.description.split(":");
+                String group = gavParts[0];
+                String artifact = gavParts[1];
+                String version;
+                if (gavParts.length > 4) {
+                    version = gavParts[gavParts.length - 2];
+                } else {
+                    version = gavParts[gavParts.length - 1];
+                }
+                String gav = String.join(":",group,artifact,version);
+                if(shadedDependencies.containsKey(gav)) {
+                    shadedDependencies.get(gav).add(component.name);
+                } else {
+                    shadedDependencies.put(gav, new HashSet<>(Arrays.asList(component.name)));
+                }
             }
         });
-        return new CodeLocation(mutableDependencyGraph, new File(module.moduleFile));
     }
 
     public Dependency convertProjectInspectorDependency(ProjectInspectorComponent component) {
@@ -122,5 +155,9 @@ public class ProjectInspectorParser {
         } else {
             throw new RuntimeException("Unknown Project Inspector dependency type: " + component.dependencyType);
         }
+    }
+
+    public Map<String, Set<String>> getShadedDependencies() {
+        return shadedDependencies;
     }
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
@@ -90,7 +90,7 @@ public class ProjectInspectorParser {
         reader.endObject();
 
         if(versionMismatch) {
-            logger.info("From Detect 9.5.0 and onwards, we will support the latest version of Project Inspector i.e. 2024.2.0. If you are using the detect.project.inspector.path property, please use the latest version mentioned.");
+            logger.info("Detect and Project Inspector version mismatch, confirm that compatible versions of Detect and Project Inspector are in use.");
         }
 
         return codeLocations;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/model/ProjectInspectorComponent.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/model/ProjectInspectorComponent.java
@@ -14,6 +14,17 @@ public class ProjectInspectorComponent {
         public String description;
     }
 
+    public static class ShadedBy {
+        @SerializedName("Id")
+        public String id;
+
+        @SerializedName("Description")
+        public String description;
+    }
+
+    @SerializedName("ShadedBy")
+    public ShadedBy shadedBy;
+
     @SerializedName("IncludedBy")
     public List<IncludedBy> includedBy;
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -477,16 +477,18 @@ public class DetectableFactory {
         return new IvyParseDetectable(environment, fileFinder, ivyParseExtractor());
     }
 
-    public MavenPomDetectable createMavenPomDetectable(DetectableEnvironment environment, MavenResolver mavenResolver, MavenCliExtractorOptions mavenCliExtractorOptions) {
-        return new MavenPomDetectable(environment, fileFinder, mavenResolver, mavenCliExtractor(), mavenCliExtractorOptions);
+    public MavenPomDetectable createMavenPomDetectable(DetectableEnvironment environment, MavenResolver mavenResolver, MavenCliExtractorOptions mavenCliExtractorOptions, ProjectInspectorOptions projectInspectorOptions, ProjectInspectorResolver projectInspectorResolver) {
+        return new MavenPomDetectable(environment, fileFinder, mavenResolver, mavenCliExtractor(), mavenCliExtractorOptions, createMavenProjectInspectorDetectable(environment,projectInspectorResolver,projectInspectorOptions));
     }
 
     public MavenPomWrapperDetectable createMavenPomWrapperDetectable(
         DetectableEnvironment environment,
         MavenResolver mavenResolver,
-        MavenCliExtractorOptions mavenCliExtractorOptions
+        MavenCliExtractorOptions mavenCliExtractorOptions,
+        ProjectInspectorOptions projectInspectorOptions,
+        ProjectInspectorResolver projectInspectorResolver
     ) {
-        return new MavenPomWrapperDetectable(environment, fileFinder, mavenResolver, mavenCliExtractor(), mavenCliExtractorOptions);
+        return new MavenPomWrapperDetectable(environment, fileFinder, mavenResolver, mavenCliExtractor(), mavenCliExtractorOptions, createMavenProjectInspectorDetectable(environment,projectInspectorResolver,projectInspectorOptions ));
     }
 
     public MavenProjectInspectorDetectable createMavenProjectInspectorDetectable(

--- a/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/factory/DetectableFactory.java
@@ -478,7 +478,7 @@ public class DetectableFactory {
     }
 
     public MavenPomDetectable createMavenPomDetectable(DetectableEnvironment environment, MavenResolver mavenResolver, MavenCliExtractorOptions mavenCliExtractorOptions, ProjectInspectorOptions projectInspectorOptions, ProjectInspectorResolver projectInspectorResolver) {
-        return new MavenPomDetectable(environment, fileFinder, mavenResolver, mavenCliExtractor(), mavenCliExtractorOptions, createMavenProjectInspectorDetectable(environment,projectInspectorResolver,projectInspectorOptions));
+        return new MavenPomDetectable(environment, fileFinder, mavenResolver, mavenCliExtractor(), mavenCliExtractorOptions, createMavenProjectInspectorDetectable(environment, projectInspectorResolver, projectInspectorOptions));
     }
 
     public MavenPomWrapperDetectable createMavenPomWrapperDetectable(
@@ -488,7 +488,7 @@ public class DetectableFactory {
         ProjectInspectorOptions projectInspectorOptions,
         ProjectInspectorResolver projectInspectorResolver
     ) {
-        return new MavenPomWrapperDetectable(environment, fileFinder, mavenResolver, mavenCliExtractor(), mavenCliExtractorOptions, createMavenProjectInspectorDetectable(environment,projectInspectorResolver,projectInspectorOptions ));
+        return new MavenPomWrapperDetectable(environment, fileFinder, mavenResolver, mavenCliExtractor(), mavenCliExtractorOptions, createMavenProjectInspectorDetectable(environment, projectInspectorResolver, projectInspectorOptions));
     }
 
     public MavenProjectInspectorDetectable createMavenProjectInspectorDetectable(

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/maven/functional/MavenPomDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/maven/functional/MavenPomDetectableTest.java
@@ -70,8 +70,11 @@ public class MavenPomDetectableTest extends DetectableFunctionalTest {
                     Collections.emptyList(),
                     Collections.emptyList(),
                     Collections.emptyList(),
-                    Collections.emptyList()
-                )
+                    Collections.emptyList(),
+false
+                ),
+                    null,
+                    null
             );
     }
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/maven/unit/MavenComplexOutputTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/maven/unit/MavenComplexOutputTest.java
@@ -110,7 +110,8 @@ public class MavenComplexOutputTest {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
-                Collections.emptyList()
+                Collections.emptyList(),
+                null
         );
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.MAVEN, results.get(0).getCodeLocation().getDependencyGraph());
         graphAssert.hasRootSize(1);

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/maven/unit/MavenCorruptOutputTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/maven/unit/MavenCorruptOutputTest.java
@@ -37,7 +37,8 @@ public class MavenCorruptOutputTest {
             Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList(),
-            Collections.emptyList()
+            Collections.emptyList(),
+                null
         );
 
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.MAVEN, results.get(0).getCodeLocation().getDependencyGraph());

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/maven/unit/cli/MavenCliExtractorOptionsTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/maven/unit/cli/MavenCliExtractorOptionsTest.java
@@ -18,7 +18,7 @@ public class MavenCliExtractorOptionsTest {
     @MethodSource("provideTestCasesForBuildCliArguments")
     public void testBuildCliArguments(String mavenBuildCommand, List<String> expected) {
         CommandParser commandParser = new CommandParser();
-        MavenCliExtractorOptions options = new MavenCliExtractorOptions(mavenBuildCommand, null, null, null, null);
+        MavenCliExtractorOptions options = new MavenCliExtractorOptions(mavenBuildCommand, null, null, null, null, false);
         assertEquals(
             expected,
             options.buildCliArguments(commandParser)

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/nuget/functional/NugetProjectInspectorParseTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/nuget/functional/NugetProjectInspectorParseTest.java
@@ -18,7 +18,7 @@ public class NugetProjectInspectorParseTest {
     @Test
     void checkParse() {
         String inspectorOutputPath = FunctionalTestFiles.resolvePath("/nuget/project_inspector/ConsoleApp.json");
-        List<CodeLocation> codeLocations = new ProjectInspectorParser(new Gson(), new ExternalIdFactory()).parse(new File(inspectorOutputPath));
+        List<CodeLocation> codeLocations = new ProjectInspectorParser(new Gson(), new ExternalIdFactory()).parse(new File(inspectorOutputPath), false);
 
         Assertions.assertEquals(2, codeLocations.size());
         Assertions.assertEquals(new File("/Users/devmehta/Desktop/p2p/p2pconn/FILE-0-myfile.csproj"), codeLocations.get(0).getSourcePath().orElse(null));
@@ -38,7 +38,7 @@ public class NugetProjectInspectorParseTest {
     @Test
     void checkParsingWithNoResults() {
         String inspectorOutputPath = FunctionalTestFiles.resolvePath("/nuget/project_inspector/ProjectInspectorNoResults.json");
-        List<CodeLocation> codeLocations = new ProjectInspectorParser(new Gson(), new ExternalIdFactory()).parse(new File(inspectorOutputPath));
+        List<CodeLocation> codeLocations = new ProjectInspectorParser(new Gson(), new ExternalIdFactory()).parse(new File(inspectorOutputPath), false);
 
         Assertions.assertEquals(0, codeLocations.size());
     }

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1079,7 +1079,7 @@ public class DetectProperties {
                     .setInfo("Include Shaded Dependencies", DetectPropertyFromVersion.VERSION_9_5_0)
                     .setHelp(
                             "If set to true, Detect will include shaded dependencies as part of BOM.",
-                            "A shaded dependency is packaged inside the uber jar of the direct or transitive dependency referenced in the project. Detect will find the use of maven-shade-plugin from original POM file and based on that will derive information for these dependencies. This property will only be supported in build mode just like all other MAVEN properties. "
+                            "A shaded dependency is packaged inside the uber jar of the direct or transitive dependency referenced in the project. Detect will find the use of maven-shade-plugin from original POM file and based on that will derive information for these dependencies. This property will only be supported in build mode just like all other MAVEN properties."
                     )
                     .setGroups(DetectGroup.MAVEN, DetectGroup.SOURCE_SCAN)
                     .build();

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1074,6 +1074,16 @@ public class DetectProperties {
             .setGroups(DetectGroup.MAVEN, DetectGroup.SOURCE_SCAN)
             .build();
 
+    public static final BooleanProperty DETECT_MAVEN_INCLUDE_SHADED_DEPENDENCIES =
+            BooleanProperty.newBuilder("detect.maven.include.shaded.dependencies",false)
+                    .setInfo("Include Shaded Dependencies", DetectPropertyFromVersion.VERSION_9_5_0)
+                    .setHelp(
+                            "If set to true, Detect will include shaded dependencies as part of BOM.",
+                            "A shaded dependency is packaged inside the uber jar of the direct or transitive dependency referenced in the project. Detect will find the use of maven-shade-plugin from original POM file and based on that will derive information for these dependencies. This property will only be supported in build mode just like all other MAVEN properties. "
+                    )
+                    .setGroups(DetectGroup.MAVEN, DetectGroup.SOURCE_SCAN)
+                    .build();
+
     public static final BooleanProperty DETECT_NOTICES_REPORT =
         BooleanProperty.newBuilder("detect.notices.report", false)
             .setInfo("Generate Notices Report", DetectPropertyFromVersion.VERSION_3_0_0)

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -183,7 +183,8 @@ public class DetectableOptionFactory {
         List<String> mavenIncludedScopes = detectConfiguration.getValue(DetectProperties.DETECT_MAVEN_INCLUDED_SCOPES);
         List<String> mavenExcludedModules = detectConfiguration.getValue(DetectProperties.DETECT_MAVEN_EXCLUDED_MODULES);
         List<String> mavenIncludedModules = detectConfiguration.getValue(DetectProperties.DETECT_MAVEN_INCLUDED_MODULES);
-        return new MavenCliExtractorOptions(mavenBuildCommand, mavenExcludedScopes, mavenIncludedScopes, mavenExcludedModules, mavenIncludedModules);
+        Boolean includeShadedDependencies = detectConfiguration.getValue(DetectProperties.DETECT_MAVEN_INCLUDE_SHADED_DEPENDENCIES);
+        return new MavenCliExtractorOptions(mavenBuildCommand, mavenExcludedScopes, mavenIncludedScopes, mavenExcludedModules, mavenIncludedModules, includeShadedDependencies);
     }
 
     public ConanCliOptions createConanCliOptions() {

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/factory/DetectDetectableFactory.java
@@ -194,11 +194,11 @@ public class DetectDetectableFactory {
     }
 
     public MavenPomDetectable createMavenPomDetectable(DetectableEnvironment environment) {
-        return detectableFactory.createMavenPomDetectable(environment, detectExecutableResolver, detectableOptionFactory.createMavenCliOptions());
+        return detectableFactory.createMavenPomDetectable(environment, detectExecutableResolver, detectableOptionFactory.createMavenCliOptions(), detectableOptionFactory.createProjectInspectorOptions(), projectInspectorResolver);
     }
 
     public MavenPomWrapperDetectable createMavenPomWrapperDetectable(DetectableEnvironment environment) {
-        return detectableFactory.createMavenPomWrapperDetectable(environment, detectExecutableResolver, detectableOptionFactory.createMavenCliOptions());
+        return detectableFactory.createMavenPomWrapperDetectable(environment, detectExecutableResolver, detectableOptionFactory.createMavenCliOptions(), detectableOptionFactory.createProjectInspectorOptions(), projectInspectorResolver);
     }
 
     public Conan1CliDetectable createConanCliDetectable(DetectableEnvironment environment) {

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -1,0 +1,53 @@
+package com.synopsys.integration.detect.battery.docker;
+
+import java.io.IOException;
+
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckAssertions;
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckTestConnection;
+import com.synopsys.integration.exception.IntegrationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detect.battery.docker.provider.BuildDockerImageProvider;
+import com.synopsys.integration.detect.battery.docker.util.DetectCommandBuilder;
+import com.synopsys.integration.detect.battery.docker.util.DetectDockerTestRunner;
+import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
+import com.synopsys.integration.detect.configuration.DetectProperties;
+import com.synopsys.integration.detector.base.DetectorType;
+
+//@Tag("integration")
+public class MavenShadedDependenciesTest {
+
+    private static final String PROJECT_NAME = "maven-shaded-dependency";
+
+//    @Test
+//    void mavenShadedDependencyTest() throws IOException,IntegrationException {
+//        try(DetectDockerTestRunner test = new DetectDockerTestRunner("detect-maven-shaded-dependency", "detect-maven:1.0.0")) {
+//            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("MavenShadedDependencies.dockerfile"));
+//
+//            String projectVersion = PROJECT_NAME + "-PI";
+//            BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+//            BlackDuckAssertions blackduckAssertions = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, projectVersion);
+//            blackduckAssertions.emptyOnBlackDuck();
+//
+//            DetectCommandBuilder commandBuilder = new DetectCommandBuilder().defaults().defaultDirectories(test);
+//            commandBuilder.connectToBlackDuck(blackDuckTestConnection);
+//            commandBuilder.projectNameVersion(blackduckAssertions);
+//            commandBuilder.waitForResults();
+//
+//            commandBuilder.property(DetectProperties.DETECT_TOOLS, "DETECTOR");
+//            commandBuilder.property(DetectProperties.DETECT_INCLUDED_DETECTOR_TYPES, DetectorType.MAVEN.toString());
+//            commandBuilder.property(DetectProperties.DETECT_MAVEN_INCLUDE_SHADED_DEPENDENCIES, String.valueOf(true));
+//            DockerAssertions dockerAssertions = test.run(commandBuilder);
+//
+//            dockerAssertions.logContains("Maven CLI: SUCCESS");
+//            dockerAssertions.atLeastOneBdioFile();
+//
+//            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
+//            blackduckAssertions.hasComponents("ASM");
+//            blackduckAssertions.hasComponents("Java Concurrency Tools Core Library");
+//            blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
+//        }
+//    }
+
+}

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/provider/BuildDockerImageProvider.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/provider/BuildDockerImageProvider.java
@@ -39,6 +39,7 @@ public class BuildDockerImageProvider implements DockerImageProvider {
 
         try (BuildImageCmd buildImageCmd = dockerClient.buildImageCmd(imageDockerFile)) {
 
+            // If the parent test has provided Dockerfile args, pass them to the image build command
             for (Map.Entry<String, String> entry : buildArgs.entrySet()) {
                 buildImageCmd.withBuildArg(entry.getKey(), entry.getValue());
             }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/provider/BuildDockerImageProvider.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/provider/BuildDockerImageProvider.java
@@ -39,7 +39,7 @@ public class BuildDockerImageProvider implements DockerImageProvider {
 
         try (BuildImageCmd buildImageCmd = dockerClient.buildImageCmd(imageDockerFile)) {
 
-            // If the parent test has provided Dockerfile args, pass them to the image build command
+            // If the parent test has provided MavenShadedDependencies.dockerfile args, pass them to the image build command
             for (Map.Entry<String, String> entry : buildArgs.entrySet()) {
                 buildImageCmd.withBuildArg(entry.getKey(), entry.getValue());
             }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/provider/BuildDockerImageProvider.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/provider/BuildDockerImageProvider.java
@@ -39,7 +39,6 @@ public class BuildDockerImageProvider implements DockerImageProvider {
 
         try (BuildImageCmd buildImageCmd = dockerClient.buildImageCmd(imageDockerFile)) {
 
-            // If the parent test has provided MavenShadedDependencies.dockerfile args, pass them to the image build command
             for (Map.Entry<String, String> entry : buildArgs.entrySet()) {
                 buildImageCmd.withBuildArg(entry.getKey(), entry.getValue());
             }

--- a/src/test/resources/docker/MavenShadedDependencies.dockerfile
+++ b/src/test/resources/docker/MavenShadedDependencies.dockerfile
@@ -1,0 +1,15 @@
+FROM maven:3-eclipse-temurin-17
+
+# Do not change SRC_DIR, value is expected by tests
+ENV SRC_DIR=/opt/project/src
+
+# Install git
+RUN apt-get update
+RUN apt-get install -y git
+
+# Set up the test project
+RUN mkdir -p ${SRC_DIR}
+
+RUN git clone --depth 1 https://github.com/crate/crate.git ${SRC_DIR}
+
+RUN cd ${SRC_DIR}


### PR DESCRIPTION
This PR is an enhancement for the request in IDETECT-3587. 

- The solution here is to invoke Project Inspector during build mode for Maven CLI to get the shaded dependencies and report them in the BOM. 
- The constructors and interface for Maven Detectables have been changed to include the Project Inspector Detectable in it for invoking PI during build mode.
- A new method has been added to Project Inspector Parser just to process the shaded Dependencies when this below property is set to true in order to speed up the process. 
- A new property has also been added named `--detect.maven.include.shaded.dependencies` for users to be able to add shaded dependencies. Also, integration test has been added for the same functionality.  
- All the doc changes will be tracked in a separate ticket and PR.

This PR will get merged in another feature branch for which I have a PR already open ( since I needed the output format changes to test things out ) [PR#1061](https://github.com/blackducksoftware/synopsys-detect/pull/1061). I will merge that feature branch into master at the end when PI is released.