### PR TITLE
Add documentation for Detect 9.5.0 release

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -4,16 +4,10 @@
 
 ### New features
 
-* 
-
-### Changed features
-
-* 
-
-### Resolved issues
-
-* 
+* [company_name] [solution_name] now includes the maven embedded or shaded dependencies as part of the Bill of Materials (BOM) via the property --detect.maven.include.shaded.dependencies. See the [detect.maven.include.shaded.dependencies](properties/detectors/maven.md#maven-include-shaded-dependencies) property for more information.
+* [company_name] [solution_name] buildless mode now supports the exclusion of maven dependencies having "\<exclude\>" tags in the pom file and honours effects of dependency scope during Maven Dependency Resolution.
 
 ### Dependency updates
 
-* 
+* Upgraded Project Inspector to version 2024.2.0. Please refer to [maven](packagemgrs/maven.md), [gradle](packagemgrs/gradle.md) and [nuget](packagemgrs/nuget.md) for more information on the changes.
+  <note type="information"> From [company_name][solution_name] 9.5.0, we will only support and be compatible with the mentioned version of Project Inspector.</note>

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -5,9 +5,10 @@
 ### New features
 
 * [company_name] [solution_name] now includes the maven embedded or shaded dependencies as part of the Bill of Materials (BOM) via the property --detect.maven.include.shaded.dependencies. See the [detect.maven.include.shaded.dependencies](properties/detectors/maven.md#maven-include-shaded-dependencies) property for more information.
-* [company_name] [solution_name] buildless mode now supports the exclusion of maven dependencies having "\<exclude\>" tags in the pom file and honours effects of dependency scope during Maven Dependency Resolution.
+* [company_name] [solution_name] Maven Project Inspector now supports the exclusion of maven dependencies having "\<exclude\>" tags in the pom file.
+* [company_name] [solution_name] Maven Project Inspector and Gradle Project Inspector honours effects of dependency scopes during dependency resolution.
 
 ### Dependency updates
 
-* Upgraded Project Inspector to version 2024.2.0. Please refer to [maven](packagemgrs/maven.md), [gradle](packagemgrs/gradle.md) and [nuget](packagemgrs/nuget.md) for more information on the changes.
-  <note type="information"> From [company_name][solution_name] 9.5.0, we will only support and be compatible with the mentioned version of Project Inspector.</note>
+* Upgraded Project Inspector to version 2024.2.0. Please refer to [Maven](packagemgrs/maven.md), [Gradle](packagemgrs/gradle.md) and [Nuget](packagemgrs/nuget.md) documentation for more information on the changes.
+  As of version 9.5.0 [company_name][solution_name] will only be compatible with, and support, Project Inspector 2024.2.0 or later.

--- a/documentation/src/main/markdown/packagemgrs/gradle.md
+++ b/documentation/src/main/markdown/packagemgrs/gradle.md
@@ -45,6 +45,5 @@ The buildless gradle detector uses Project Inspector to find dependencies and do
 
 It currently supports "build.gradle" and does not support Kotlin build files.
 
-[company_name] [solution_name] 9.5.0 now uses the latest version of Project Inspector i.e. 2024.2.0 in which support certain arguments have been removed. 
-Support for `--strategy GRADLE` argument has been removed in the current release and changed to `--build-system GRADLE`. 
-`--force-gradle-repos "url"` will be removed from support in the next [company_name][solution_name] major release 10.0.0 and it will be changed to `--conf "maven.repo:url"`.
+As of [company_name] [solution_name] 9.5.0 the version of Project Inspector in use supports the `--build-system GRADLE` argument in place of `--strategy GRADLE`.
+The `--force-gradle-repos "url"` argument will be removed from support in the next [company_name][solution_name] major release and replaced with the `--conf "maven.repo:url"` argument.

--- a/documentation/src/main/markdown/packagemgrs/gradle.md
+++ b/documentation/src/main/markdown/packagemgrs/gradle.md
@@ -44,3 +44,7 @@ The init-detect.gradle script configures each project with the custom 'gatherDep
 The buildless gradle detector uses Project Inspector to find dependencies and does not support dependency exclusions.
 
 It currently supports "build.gradle" and does not support Kotlin build files.
+
+[company_name] [solution_name] 9.5.0 now uses the latest version of Project Inspector i.e. 2024.2.0 in which support certain arguments have been removed. 
+Support for `--strategy GRADLE` argument has been removed in the current release and changed to `--build-system GRADLE`. 
+`--force-gradle-repos "url"` will be removed from support in the next [company_name][solution_name] major release 10.0.0 and it will be changed to `--conf "maven.repo:url"`.

--- a/documentation/src/main/markdown/packagemgrs/maven.md
+++ b/documentation/src/main/markdown/packagemgrs/maven.md
@@ -72,6 +72,5 @@ The Maven Wrapper CLI detector attempts to run on your project if it finds a pom
 The Maven Project Inspector detector uses Project Inspector, which currently does not support plugins.
 The Maven Project Inspector includes the shaded dependencies as part of the BOM.
 
-[company_name] [solution_name] 9.5.0 now uses the latest version of Project Inspector i.e. 2024.2.0 in which support certain arguments have been removed.
-Support for `--strategy MAVEN` argument has been removed in the current release and changed to `--build-system MAVEN`. 
-`--force-maven-repos "url"` will be removed from support in the next [company_name][solution_name] major release 10.0.0 and it will be changed to `--conf "maven.repo:url"`.
+As of [company_name] [solution_name] 9.5.0 the version of Project Inspector in use supports the `--build-system MAVEN` argument in place of `--strategy MAVEN`.
+The `--force-maven-repos "url"` argument will be removed from support in the next [company_name][solution_name] major release and replaced with the `--conf "maven.repo:url"` argument.

--- a/documentation/src/main/markdown/packagemgrs/maven.md
+++ b/documentation/src/main/markdown/packagemgrs/maven.md
@@ -70,3 +70,8 @@ The Maven Wrapper CLI detector attempts to run on your project if it finds a pom
 ### Maven Project Inspector
 
 The Maven Project Inspector detector uses Project Inspector, which currently does not support plugins.
+The Maven Project Inspector includes the shaded dependencies as part of the BOM.
+
+[company_name] [solution_name] 9.5.0 now uses the latest version of Project Inspector i.e. 2024.2.0 in which support certain arguments have been removed.
+Support for `--strategy MAVEN` argument has been removed in the current release and changed to `--build-system MAVEN`. 
+`--force-maven-repos "url"` will be removed from support in the next [company_name][solution_name] major release 10.0.0 and it will be changed to `--conf "maven.repo:url"`.

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -77,9 +77,8 @@ After discovering dependencies, NuGet client libraries are used to collect furth
 
 In buildless mode, [company_name] [solution_name] uses Project Inspector to find dependencies and only supports `.csproj` and `.sln` files.
 
-[company_name] [solution_name] 9.5.0 now uses the latest version of Project Inspector i.e. 2024.2.0 in which support certain arguments have been removed.
-Support for `--strategy MSBUILD` argument has been removed in the current release and changed to `--build-system MSBUILD`.
-`--force-nuget-repos "url"` will be removed from support in the next [company_name][solution_name] major release 10.0.0 and it will be changed to `--conf "nuget.repo:url"`.
+As of [company_name] [solution_name] 9.5.0 the version of Project Inspector in use supports the `--build-system MSBUILD` argument in place of `--strategy MSBUILD`.
+The `--force-nuget-repos "url"` argument will be removed from support in the next [company_name][solution_name] major release and replaced with the `--conf "nuget.repo:url"` argument.
 
 ### [company_name] [solution_name] NuGet Inspector on Alpine
 

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -77,6 +77,10 @@ After discovering dependencies, NuGet client libraries are used to collect furth
 
 In buildless mode, [company_name] [solution_name] uses Project Inspector to find dependencies and only supports `.csproj` and `.sln` files.
 
+[company_name] [solution_name] 9.5.0 now uses the latest version of Project Inspector i.e. 2024.2.0 in which support certain arguments have been removed.
+Support for `--strategy MSBUILD` argument has been removed in the current release and changed to `--build-system MSBUILD`.
+`--force-nuget-repos "url"` will be removed from support in the next [company_name][solution_name] major release 10.0.0 and it will be changed to `--conf "nuget.repo:url"`.
+
 ### [company_name] [solution_name] NuGet Inspector on Alpine
 
 The [company_name] [solution_name] NuGet Inspectors depend on packages not installed by default on Alpine systems, such as the dynamic loader for DLLs.


### PR DESCRIPTION
This PR adds the release notes for Detect 9.5.0. It also highlights the explicit changes which are made to the Project Inspector that can impact our customers who are using older versions. This would resolve IDETECT-4258.