### PR TITLE
Filter Out Module Dependencies from PI output

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/maven/cli/MavenCliExtractor.java
@@ -55,13 +55,20 @@ public class MavenCliExtractor {
         Boolean includeShadedDependencies = mavenCliExtractorOptions.getMavenIncludeShadedDependencies();
 
         if(includeShadedDependencies) {
+            Extraction extraction;
+            mavenProjectInspectorDetectable.setIncludeShadedDependencies(true);
+
             try {
-                mavenProjectInspectorDetectable.setIncludeShadedDependencies(true);
                 mavenProjectInspectorDetectable.extractable();
-                Extraction extraction = mavenProjectInspectorDetectable.extract(extractionEnvironment);
-                shadedDependencies = mavenProjectInspectorDetectable.getShadedDependencies();
+                extraction = mavenProjectInspectorDetectable.extract(extractionEnvironment);
             } catch (Exception e) {
-               throw new RuntimeException("There was an error extracting the shaded dependencies from Project Inspector. There might be version mismatch between Detect and Project Inspector, confirm that compatible versions of them are in use.",e);
+               throw new RuntimeException("There was an error extracting the shaded dependencies from Project Inspector. There might be version mismatch between Detect and Project Inspector, confirm that compatible versions of them are in use.", e);
+            }
+
+            if(extraction.isSuccess()) {
+                shadedDependencies = mavenProjectInspectorDetectable.getShadedDependencies();
+            } else {
+                return new Extraction.Builder().exception(extraction.getError()).build();
             }
         }
 

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorExtractor.java
@@ -54,8 +54,12 @@ public class ProjectInspectorExtractor {
             .ifPresent(additionalArguments -> arguments.addAll(Arrays.asList(additionalArguments)));
 
         executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(targetDirectory, inspector, arguments));
-
-        List<CodeLocation> codeLocations = projectInspectorParser.parse(outputFile, includeShadedDependencies);
+        List<CodeLocation> codeLocations;
+        try {
+            codeLocations = projectInspectorParser.parse(outputFile, includeShadedDependencies);
+        } catch (Exception e) {
+            return new Extraction.Builder().exception(e).build();
+        }
 
         return new Extraction.Builder().success(codeLocations).build();
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
@@ -39,7 +39,7 @@ public class ProjectInspectorParser {
         this.externalIdFactory = externalIdFactory;
     }
 
-    public List<CodeLocation> parse(File outputFile, boolean includeShadedDependencies) {
+    public List<CodeLocation> parse(File outputFile, boolean includeShadedDependencies) throws Exception {
         List<CodeLocation> codeLocations = new ArrayList<>();
 
         if (outputFile == null || !outputFile.exists() || !outputFile.isFile()) {
@@ -61,7 +61,7 @@ public class ProjectInspectorParser {
             }
             reader.endObject();
         } catch (Exception e) {
-            logger.error("An error occurred while reading inspection.json file", e);
+            throw new RuntimeException(e);
         }
         return codeLocations;
     }
@@ -90,7 +90,7 @@ public class ProjectInspectorParser {
         reader.endObject();
 
         if(versionMismatch) {
-            logger.info("Detect and Project Inspector version mismatch, confirm that compatible versions of Detect and Project Inspector are in use.");
+            throw new RuntimeException("Detect and Project Inspector version mismatch, confirm that compatible versions of Detect and Project Inspector are in use.");
         }
 
         return codeLocations;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
@@ -99,23 +99,28 @@ public class ProjectInspectorParser {
 
     public CodeLocation codeLocationFromModule(ProjectInspectorModule module) {
         Map<String, Dependency> lookup = new HashMap<>();
+        Map<String, Dependency> modules = new HashMap<>();
 
             //build the map of all external ids
         module.components.forEach((dependencyId, component) -> {
-            lookup.computeIfAbsent(dependencyId, missingId -> convertProjectInspectorDependency(component));
+            if(!component.dependencySource.equals("MODULE")) {
+                lookup.computeIfAbsent(dependencyId, missingId -> convertProjectInspectorDependency(component));
+            } else {
+                modules.computeIfAbsent(dependencyId, missingId -> convertProjectInspectorDependency(component));
+            }
         });
 
         //and add them to the graph
         DependencyGraph mutableDependencyGraph = new BasicDependencyGraph();
         module.components.forEach((moduleDependencyId, moduleDependency) -> {
-            Dependency dependency = lookup.get(moduleDependencyId);
-            if (moduleDependency.inclusionType.equals("DIRECT")) {
+            Dependency dependency = lookup.getOrDefault(moduleDependencyId, null);
+            if (dependency != null && moduleDependency.inclusionType.equals("DIRECT")) {
                 mutableDependencyGraph.addDirectDependency(dependency);
-            } else if (moduleDependency.inclusionType.equals("TRANSITIVE")) {
+            } else if (dependency != null && moduleDependency.inclusionType.equals("TRANSITIVE")) {
                 moduleDependency.includedBy.forEach(includedBy -> {
                     if (lookup.containsKey(includedBy.id)) {
                         mutableDependencyGraph.addChildWithParent(dependency, lookup.get(includedBy.id));
-                    } else { //Theoretically should not happen according to PI devs. -jp
+                    } else if (!modules.containsKey(includedBy.id)) { //Theoretically should not happen according to PI devs. -jp
                         throw new RuntimeException("An error occurred reading the project inspector output." +
                                 " An unknown parent dependency was encountered '" + includedBy.id + "' while including dependency '" + moduleDependency.name + "'.");
                     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
@@ -61,7 +61,7 @@ public class ProjectInspectorParser {
             }
             reader.endObject();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("An error occurred while reading inspection.json file", e);
         }
         return codeLocations;
     }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/projectinspector/ProjectInspectorParser.java
@@ -61,7 +61,7 @@ public class ProjectInspectorParser {
             }
             reader.endObject();
         } catch (Exception e) {
-            throw new RuntimeException("An error occurred while reading inspection.json file", e);
+            throw new RuntimeException(e);
         }
         return codeLocations;
     }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/nuget/functional/NugetProjectInspectorParseTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/nuget/functional/NugetProjectInspectorParseTest.java
@@ -16,7 +16,7 @@ import com.synopsys.integration.detectable.util.graph.NameVersionGraphAssert;
 
 public class NugetProjectInspectorParseTest {
     @Test
-    void checkParse() {
+    void checkParse() throws Exception {
         String inspectorOutputPath = FunctionalTestFiles.resolvePath("/nuget/project_inspector/ConsoleApp.json");
         List<CodeLocation> codeLocations = new ProjectInspectorParser(new Gson(), new ExternalIdFactory()).parse(new File(inspectorOutputPath), false);
 
@@ -36,7 +36,7 @@ public class NugetProjectInspectorParseTest {
     }
 
     @Test
-    void checkParsingWithNoResults() {
+    void checkParsingWithNoResults() throws Exception {
         String inspectorOutputPath = FunctionalTestFiles.resolvePath("/nuget/project_inspector/ProjectInspectorNoResults.json");
         List<CodeLocation> codeLocations = new ProjectInspectorParser(new Gson(), new ExternalIdFactory()).parse(new File(inspectorOutputPath), false);
 


### PR DESCRIPTION
After discussing with QA, we decided to fail Detect when there is a version mismatch between earlier and new version for Detect and Project Inspector. Here are the changes to throw an exception instead of throwing just an info dialog when the same happens. Also we are ensuring to have the same consistent behavior when PI is invoked during Maven CLI build mode.

As decided in the call with Edwin, we would filtering out modules from the output file that we receive from PI to lower the number of unmatched components that we report in BOM. Module dependencies in PI are project or gradle files which are inherited in other gradle files ( like inheriting other gradle file as dependency ) which is not technically a dependency for Blackduck and just a module which results in unmatched component. We filter out those module dependencies from our output which results in less unmatched components.
