### PR TITLE
Update spring version to 5.3.33

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     // Below direct inclusions of corresponding transitive dependencies
     // were added to resolve CVE-2024-22259 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
-    implementation "org.springframework:spring-jcl:5.3.32"
+    implementation "org.springframework:spring-jcl:5.3.33"
     implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"

--- a/build.gradle
+++ b/build.gradle
@@ -140,8 +140,9 @@ dependencies {
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 
     // Below direct inclusions of corresponding transitive dependencies
-    // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
+    // were added to resolve CVE-2024-22259 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
+    implementation "org.springframework:spring-jcl:5.3.32"
     implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"

--- a/build.gradle
+++ b/build.gradle
@@ -139,10 +139,9 @@ dependencies {
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 
-    // Below exclusions of transitive dependencies and inclusions of corresponding direct dependencies
+    // Below direct inclusions of corresponding transitive dependencies
     // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
-//    implementation "org.springframework:spring-jcl:5.3.33"
     implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"

--- a/build.gradle
+++ b/build.gradle
@@ -142,14 +142,14 @@ dependencies {
     // Below exclusions of transitive dependencies and inclusions of corresponding direct dependencies
     // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
-    implementation "org.springframework:spring-jcl:5.3.32"
-    implementation("org.springframework:spring-core:5.3.32") {
+    implementation "org.springframework:spring-jcl:5.3.33"
+    implementation("org.springframework:spring-core:5.3.33") {
         exclude group: 'org.springframework', module: 'spring-jcl'
     }
-    implementation "org.springframework:spring-aop:5.3.32"
-    implementation "org.springframework:spring-beans:5.3.32"
-    implementation "org.springframework:spring-expression:5.3.32"
-    implementation("org.springframework:spring-context:5.3.32") {
+    implementation "org.springframework:spring-aop:5.3.33"
+    implementation "org.springframework:spring-beans:5.3.33"
+    implementation "org.springframework:spring-expression:5.3.33"
+    implementation("org.springframework:spring-context:5.3.33") {
         exclude group: 'org.springframework', module: 'spring-aop'
         exclude group: 'org.springframework', module: 'spring-beans'
         exclude group: 'org.springframework', module: 'spring-expression'

--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     // Below exclusions of transitive dependencies and inclusions of corresponding direct dependencies
     // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
-    implementation "org.springframework:spring-jcl:5.3.33"
+//    implementation "org.springframework:spring-jcl:5.3.33"
     implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"

--- a/build.gradle
+++ b/build.gradle
@@ -143,21 +143,12 @@ dependencies {
     // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
     implementation "org.springframework:spring-jcl:5.3.33"
-    implementation("org.springframework:spring-core:5.3.33") {
-        exclude group: 'org.springframework', module: 'spring-jcl'
-    }
+    implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"
     implementation "org.springframework:spring-expression:5.3.33"
-    implementation("org.springframework:spring-context:5.3.33") {
-        exclude group: 'org.springframework', module: 'spring-aop'
-        exclude group: 'org.springframework', module: 'spring-beans'
-        exclude group: 'org.springframework', module: 'spring-expression'
-    }
-    implementation("org.springframework.boot:spring-boot") {
-        exclude group: 'org.springframework', module: 'spring-core'
-        exclude group: 'org.springframework', module: 'spring-context'
-    }
+    implementation("org.springframework:spring-context:5.3.33")
+    implementation("org.springframework.boot:spring-boot")
 
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.zeroturnaround:zt-zip:1.13'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -33,6 +33,6 @@ dependencies {
         exclude group: 'org.springframework', module: 'spring-core'
     }
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'org.springframework:spring-core:5.3.32'
+    implementation 'org.springframework:spring-core:5.3.33'
     implementation gradleApi()
 }

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -9,10 +9,9 @@ dependencyManagement {
 dependencies {
     implementation project(":common")
 
-    // Below exclusions of transitive dependencies and inclusions of corresponding direct dependencies
+    // Below direct inclusions of corresponding transitive dependencies
     // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
-//    implementation "org.springframework:spring-jcl:5.3.33"
     implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -13,21 +13,12 @@ dependencies {
     // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
     implementation "org.springframework:spring-jcl:5.3.33"
-    implementation("org.springframework:spring-core:5.3.33") {
-        exclude group: 'org.springframework', module: 'spring-jcl'
-    }
+    implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"
     implementation "org.springframework:spring-expression:5.3.33"
-    implementation("org.springframework:spring-context:5.3.33") {
-        exclude group: 'org.springframework', module: 'spring-aop'
-        exclude group: 'org.springframework', module: 'spring-beans'
-        exclude group: 'org.springframework', module: 'spring-expression'
-    }
-    implementation("org.springframework.boot:spring-boot") {
-        exclude group: 'org.springframework', module: 'spring-core'
-        exclude group: 'org.springframework', module: 'spring-context'
-    }
+    implementation("org.springframework:spring-context:5.3.33")
+    implementation("org.springframework.boot:spring-boot")
 
     testImplementation "org.springframework:spring-test"
     testImplementation "org.apache.commons:commons-collections4:4.2"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     // Below exclusions of transitive dependencies and inclusions of corresponding direct dependencies
     // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
-    implementation "org.springframework:spring-jcl:5.3.33"
+//    implementation "org.springframework:spring-jcl:5.3.33"
     implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -10,8 +10,9 @@ dependencies {
     implementation project(":common")
 
     // Below direct inclusions of corresponding transitive dependencies
-    // were added to resolve CVE-2024-22243 appearing in 5.3.27 of springframework libraries.
+    // were added to resolve CVE-2024-22259 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
+    implementation "org.springframework:spring-jcl:5.3.33"
     implementation("org.springframework:spring-core:5.3.33")
     implementation "org.springframework:spring-aop:5.3.33"
     implementation "org.springframework:spring-beans:5.3.33"


### PR DESCRIPTION
Update Spring dependency to 5.3.33 from 5.3.32 to address
[CVE-2024-22259](https://github.com/advisories/GHSA-hgjh-9rj2-g67j) 

Kept the same direct inclusions to override transitive dependencies as done here for our 9.4.0 release (removed the "exclusions" part since the version is overwritten anyways so it is a no-op): https://github.com/blackducksoftware/synopsys-detect/pull/1053