### PR TITLE
Add Go 1.21 and 1.22 to the list of tested versions

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/battery/docker/GoModTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/GoModTest.java
@@ -30,7 +30,9 @@ public class GoModTest {
         "1.17.13",
         "1.18.10",
         "1.19.12",
-        "1.20.4"
+        "1.20.4",
+        "1.21.9",
+        "1.22.2"
     };
 
     private static final String PROJECT_NAME = "go-mod-docker";

--- a/src/test/resources/docker/GoModExecutables.dockerfile
+++ b/src/test/resources/docker/GoModExecutables.dockerfile
@@ -8,7 +8,7 @@ ENV SRC_DIR=/opt/project/src
 
 # Install git
 RUN apt-get update -y
-RUN apt-get install -y git bash
+RUN apt-get install -y git bash wget
 
 ## Install Go
 WORKDIR /usr/local


### PR DESCRIPTION
# Description

Add Go 1.21 and 1.22 to the list of tested versions.
