### PR TITLE
fix (blackduck-common): Bump blackduck-common version to 66.2.16(IDETECT-4211)

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.14'
+gradle.ext.blackDuckCommonVersion='66.2.16'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
Bump blackduck-common version to include 409 as a non-retryable exit code

Pulls in this commit from 66.2.16: https://github.com/blackducksoftware/blackduck-common/commit/645684991b4bdfee8d0151112f2b3a67ad7cd3bd

Also pulls in this commit from 66.2.15: https://github.com/blackducksoftware/blackduck-common/commit/e438ab69271063731c53860a7d32c949c7ee9b83
