### PR TITLE
Upgrade Springframework dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,14 +152,14 @@ dependencies {
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 
     // Below direct inclusions of corresponding transitive dependencies
-    // were added to resolve CVE-2024-22259 appearing in 5.3.27 of springframework libraries.
+    // were added to resolve CVE-2024-22259 appearing in 5.3.33 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
-    implementation "org.springframework:spring-jcl:5.3.33"
-    implementation("org.springframework:spring-core:5.3.33")
-    implementation "org.springframework:spring-aop:5.3.33"
-    implementation "org.springframework:spring-beans:5.3.33"
-    implementation "org.springframework:spring-expression:5.3.33"
-    implementation("org.springframework:spring-context:5.3.33")
+    implementation "org.springframework:spring-jcl:5.3.34"
+    implementation("org.springframework:spring-core:5.3.34")
+    implementation "org.springframework:spring-aop:5.3.34"
+    implementation "org.springframework:spring-beans:5.3.34"
+    implementation "org.springframework:spring-expression:5.3.34"
+    implementation("org.springframework:spring-context:5.3.34")
     implementation("org.springframework.boot:spring-boot")
 
     implementation 'org.yaml:snakeyaml:2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ dependencies {
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 
     // Below direct inclusions of corresponding transitive dependencies
-    // were added to resolve CVE-2024-22259 appearing in 5.3.33 of springframework libraries.
+    // were added to resolve CVE-2024-22259 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
     implementation "org.springframework:spring-jcl:5.3.34"
     implementation("org.springframework:spring-core:5.3.34")

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -33,6 +33,6 @@ dependencies {
         exclude group: 'org.springframework', module: 'spring-core'
     }
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'org.springframework:spring-core:5.3.33'
+    implementation 'org.springframework:spring-core:5.3.34'
     implementation gradleApi()
 }

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -10,14 +10,14 @@ dependencies {
     implementation project(":common")
 
     // Below direct inclusions of corresponding transitive dependencies
-    // were added to resolve CVE-2024-22259 appearing in 5.3.27 of springframework libraries.
+    // were added to resolve CVE-2024-22259 appearing in 5.3.33 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
-    implementation "org.springframework:spring-jcl:5.3.33"
-    implementation("org.springframework:spring-core:5.3.33")
-    implementation "org.springframework:spring-aop:5.3.33"
-    implementation "org.springframework:spring-beans:5.3.33"
-    implementation "org.springframework:spring-expression:5.3.33"
-    implementation("org.springframework:spring-context:5.3.33")
+    implementation "org.springframework:spring-jcl:5.3.34"
+    implementation("org.springframework:spring-core:5.3.34")
+    implementation "org.springframework:spring-aop:5.3.34"
+    implementation "org.springframework:spring-beans:5.3.34"
+    implementation "org.springframework:spring-expression:5.3.34"
+    implementation("org.springframework:spring-context:5.3.34")
     implementation("org.springframework.boot:spring-boot")
 
     testImplementation "org.springframework:spring-test"

--- a/configuration/build.gradle
+++ b/configuration/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(":common")
 
     // Below direct inclusions of corresponding transitive dependencies
-    // were added to resolve CVE-2024-22259 appearing in 5.3.33 of springframework libraries.
+    // were added to resolve CVE-2024-22259 appearing in 5.3.27 of springframework libraries.
     // The below changes can be reverted in the future after comprehensively testing with an updated spring boot version
     implementation "org.springframework:spring-jcl:5.3.34"
     implementation("org.springframework:spring-core:5.3.34")


### PR DESCRIPTION
Upgraded Spring Dependency Framework to the latest patch to remove the vulnerability reported in Blackduck.
