### PR TITLE
Allow Multiple Dependencies to declare Rich Versions

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
@@ -137,13 +137,18 @@ public class GradleReportLineParser {
 
     private boolean checkParentRichVersion(String rootProjectName, String projectParent, String dependencyGroupName) {
         if(!projectParent.equals("null")) {
-            String currentProject = projectParent.substring(projectParent.lastIndexOf(":") + 1, projectParent.lastIndexOf("'"));
-            while (!currentProject.equals(rootProjectName)) {
-                if (gradleRichVersions.containsKey(currentProject) && gradleRichVersions.get(currentProject).containsKey(dependencyGroupName)) {
-                    foundParentProject = currentProject;
-                    return true;
+            String currentProject;
+            try {
+                currentProject = projectParent.substring(projectParent.lastIndexOf(":") + 1, projectParent.lastIndexOf("'"));
+                while (!currentProject.equals(rootProjectName)) {
+                    if (gradleRichVersions.containsKey(currentProject) && gradleRichVersions.get(currentProject).containsKey(dependencyGroupName)) {
+                        foundParentProject = currentProject;
+                        return true;
+                    }
+                    currentProject = relationsMap.getOrDefault(currentProject, rootProjectName);
                 }
-                currentProject = relationsMap.getOrDefault(currentProject, rootProjectName);
+            } catch (Exception e) {
+                logger.error("The project parent is not analogous to the structure expected: " + projectParent);
             }
         }
        return false;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
@@ -137,9 +137,8 @@ public class GradleReportLineParser {
 
     private boolean checkParentRichVersion(String rootProjectName, String projectParent, String dependencyGroupName) {
         if(!projectParent.equals("null")) {
-            String currentProject;
             try {
-                currentProject = projectParent.substring(projectParent.lastIndexOf(":") + 1, projectParent.lastIndexOf("'"));
+                String currentProject = projectParent.substring(projectParent.lastIndexOf(":") + 1, projectParent.lastIndexOf("'"));
                 while (!currentProject.equals(rootProjectName)) {
                     if (gradleRichVersions.containsKey(currentProject) && gradleRichVersions.get(currentProject).containsKey(dependencyGroupName)) {
                         foundParentProject = currentProject;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportParser.java
@@ -32,7 +32,7 @@ public class GradleReportParser {
     public static final String ROOT_PROJECT_VERSION_PREFIX = "rootProjectVersion:";
     public static final String DETECT_META_DATA_HEADER = "DETECT META DATA START";
     public static final String DETECT_META_DATA_FOOTER = "DETECT META DATA END";
-    public static Map<String, String> metadata = new HashMap<>();
+    private final Map<String, String> metadata = new HashMap<>();
     private final GradleReportConfigurationParser gradleReportConfigurationParser = new GradleReportConfigurationParser();
 
     public Optional<GradleReport> parseReport(File reportFile) {


### PR DESCRIPTION
This PR would address a bug for the gradle rich versions where if there were multiple projects attempting to declare rich versions for the same dependency then based on the earlier approach the version would not have been updated. Now instead of using single Map, we are using Map of Map so that we allow scenarios where same dependency is being used for rich version declarations in multiple projects and as a result we are not loosing different versions for the same dependency in the BOM or forcing version change.

Let me know if there are any questions around the same.
