### PR TITLE
Bump up blackduck-common version

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,3 +1,3 @@
 // ALSO CHANGE integration-common version in src/main/resources/create-gradle-airgap-script.ft
-gradle.ext.blackDuckCommonVersion='66.2.3'
+gradle.ext.blackDuckCommonVersion='66.2.5'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
Bump up blackduck-common version in order to ensure that put requests set the content type header

# Description

This is to ensure that the following change is present in Detect 8.11: https://github.com/blackducksoftware/blackduck-common/commit/045fae5f391454caddac136d4feeeaf191172796

This allows Detect to interact with Blackduck when the `--detect.project.version.update=true` property is being used