### PR TITLE
Support Transitive Dependencies for Rich Version Declarations 

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportConfigurationParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportConfigurationParser.java
@@ -3,7 +3,6 @@ package com.synopsys.integration.detectable.detectables.gradle.inspection.parse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.synopsys.integration.detectable.detectables.gradle.inspection.model.GradleTreeNode;
 import org.apache.commons.lang3.StringUtils;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
@@ -32,6 +32,10 @@ public class GradleReportLineParser {
     // module will have its own nested map.
     private final Map<String, Map<String, String>> gradleRichVersions = new HashMap<>();
 
+    // This map handles all the transitives whose parent uses rich version
+    // declarations with the respect to the project they are declared in.
+    // The nested map has dependencies with their versions and each
+    // module will have its own nested map.
     private final Map<String, Map<String, String>> transitiveRichVersions = new HashMap<>();
 
     // This map is handling all the child-parent relationships which are found in the entire project

--- a/documentation/src/main/markdown/packagemgrs/gradle.md
+++ b/documentation/src/main/markdown/packagemgrs/gradle.md
@@ -38,7 +38,7 @@ The init-detect.gradle script configures each project with the custom 'gatherDep
 ### Rich version declaration support
 
 Rich version declarations allow a user to define rules around which version of a given direct or transitive dependency are resolved when Gradle performs its dependency conflict resolution. Typically, these are set in a parent build.gradle file, and because these rich version declarations set a specific requirement that conflict resolution must respect, the subsequent child modules will pull dependencies according to the rich version declaration.
-[company_name] [solution_name] derives this information from dependency graph that Gradle Native Inspector generates as described above. If the information is not mentioned in the graph then [company_name] [solution_name] will not support those declarations.
+[company_name] [solution_name] derives this information from the dependency graph that Gradle Native Inspector generates as described above. If the information is not mentioned in the graph then [company_name] [solution_name] will not support those declarations.
 See Gradle documentation: [Rich Version Declaration](https://docs.gradle.org/current/userguide/rich_versions.html).
 
 ### Running the Gradle inspector with a proxy

--- a/documentation/src/main/markdown/packagemgrs/gradle.md
+++ b/documentation/src/main/markdown/packagemgrs/gradle.md
@@ -37,8 +37,7 @@ The init-detect.gradle script configures each project with the custom 'gatherDep
 
 ### Rich version declaration support
 
-Rich version declarations allow a user to define rules around which version of a given direct or transitive dependency are resolved when Gradle performs its dependency conflict resolution. 
-Typically, these are set in a parent build.gradle file, and because these rich version declarations set a specific requirement that conflict resolution must respect, the subsequent child modules will pull dependencies according to the rich version declaration.
+Rich version declarations allow a user to define rules around which version of a given direct or transitive dependency are resolved when Gradle performs its dependency conflict resolution. Typically, these are set in a parent build.gradle file, and because these rich version declarations set a specific requirement that conflict resolution must respect, the subsequent child modules will pull dependencies according to the rich version declaration.
 [company_name] [solution_name] derives this information from dependency graph that Gradle Native Inspector generates as described above. If the information is not mentioned in the graph then [company_name] [solution_name] will not support those declarations.
 See Gradle documentation: [Rich Version Declaration](https://docs.gradle.org/current/userguide/rich_versions.html).
 

--- a/documentation/src/main/markdown/packagemgrs/gradle.md
+++ b/documentation/src/main/markdown/packagemgrs/gradle.md
@@ -37,7 +37,10 @@ The init-detect.gradle script configures each project with the custom 'gatherDep
 
 ### Rich version declaration support
 
-Rich version declarations allow a user to define rules around which version of a given direct or transitive dependency are resolved when Gradle performs its dependency conflict resolution. Typically, these are set in a parent build.gradle file, and because these rich version declarations set a specific requirement that conflict resolution must respect, the subsequent child modules will pull dependencies according to the rich version declaration. See Gradle documentation: [Rich Version Declaration](https://docs.gradle.org/current/userguide/rich_versions.html).
+Rich version declarations allow a user to define rules around which version of a given direct or transitive dependency are resolved when Gradle performs its dependency conflict resolution. 
+Typically, these are set in a parent build.gradle file, and because these rich version declarations set a specific requirement that conflict resolution must respect, the subsequent child modules will pull dependencies according to the rich version declaration.
+[company_name] [solution_name] derives this information from dependency graph that Gradle Native Inspector generates as described above. If the information is not mentioned in the graph then [company_name] [solution_name] will not support those declarations.
+See Gradle documentation: [Rich Version Declaration](https://docs.gradle.org/current/userguide/rich_versions.html).
 
 ### Running the Gradle inspector with a proxy
 

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/GradleNativeInspectorTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/GradleNativeInspectorTests.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-@Tag("integration")
+//@Tag("integration")
 public class GradleNativeInspectorTests {
 
     public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
@@ -96,6 +96,7 @@ public class GradleNativeInspectorTests {
             blackduckAssertions.checkComponentVersionExists("graphql-java", "18.2");
             blackduckAssertions.checkComponentVersionNotExists("SLF4J API Module", "2.0.4");
             blackduckAssertions.checkComponentVersionExists("google-guava", "v29.0");
+            blackduckAssertions.checkComponentVersionNotExists("Apache Log4J API", "2.22.1");
 
         }
     }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/GradleNativeInspectorTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/GradleNativeInspectorTests.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-//@Tag("integration")
+@Tag("integration")
 public class GradleNativeInspectorTests {
 
     public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";


### PR DESCRIPTION
This PR updates the approach to change version of all transitive dependencies whose parent dependencies use rich versions. The approach creates one other Map of Map that stores the transitives if their parent was found using rich version and checks if those dependencies are present in the Map and updates their version accordingly. The same approach is applied while storing them. We use a String as toggle here because we need to get the information of the project in which the rich version is defined. 
