### PR TITLE
Cll updates 9.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ dependencies {
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.10'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
     implementation 'com.synopsys:method-analyzer-core:0.2.9'
-    implementation "${locatorGroup}:${locatorModule}:1.1.10"
+    implementation "${locatorGroup}:${locatorModule}:1.1.11"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 

--- a/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/BdioToComponentListTransformer.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/BdioToComponentListTransformer.java
@@ -75,7 +75,7 @@ public class BdioToComponentListTransformer {
             if (gav.getName()!=null && gav.getVersion()!=null) {
                 componentSet.add(new Component(gav.getGroup(), gav.getName(), gav.getVersion(), new JsonObject()));
             } else {
-                logger.info("Invalid component entry {} from BDIO is not included for component location analysis.", gav.toString());
+                logger.warn("Invalid component entry {} from BDIO is not included for component location analysis.", gav.toString());
             }
         }
         return componentSet;

--- a/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/BdioToComponentListTransformer.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/BdioToComponentListTransformer.java
@@ -13,6 +13,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Transforms {@link BdioResult} to list of {@link Component}s, which will then be used to assemble the input to
@@ -20,6 +22,8 @@ import java.util.stream.Collectors;
  *
  */
 public class BdioToComponentListTransformer {
+    
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     
     /**
      * Given a BDIO, creates a set containing each detected component's corresponding {@link Component} representation.
@@ -70,6 +74,8 @@ public class BdioToComponentListTransformer {
         for (ExternalId gav : gavs) {
             if (gav.getName()!=null && gav.getVersion()!=null) {
                 componentSet.add(new Component(gav.getGroup(), gav.getName(), gav.getVersion(), new JsonObject()));
+            } else {
+                logger.info("Invalid component entry {} from BDIO is not included for component location analysis.", gav.toString());
             }
         }
         return componentSet;


### PR DESCRIPTION
Bump to CLL version.
Added a warning LOG when skipping invalid BDIO component entries for CLL.
