### PR TITLE
Log component location analysis file path in the Detect Result section

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -647,7 +647,7 @@ public class OperationRunner {
                 } else {
                     auditLog.namedPublic(
                             OPERATION_NAME,
-                            () -> new GenerateComponentLocationAnalysisOperation().locateComponents(componentsSet, directoryManager.getScanOutputDirectory(), directoryManager.getSourceDirectory())
+                            () -> publishResult(new GenerateComponentLocationAnalysisOperation().locateComponents(componentsSet, directoryManager.getScanOutputDirectory(), directoryManager.getSourceDirectory()))
                     );
                 }
             }
@@ -673,7 +673,7 @@ public class OperationRunner {
                 } else {
                     auditLog.namedPublic(
                             OPERATION_NAME,
-                            () -> (new GenerateComponentLocationAnalysisOperation()).locateComponents(componentsSet, directoryManager.getScanOutputDirectory(), directoryManager.getSourceDirectory())
+                            () -> publishResult(new GenerateComponentLocationAnalysisOperation().locateComponents(componentsSet, directoryManager.getScanOutputDirectory(), directoryManager.getSourceDirectory()))
                     );
                 }
             }
@@ -707,7 +707,7 @@ public class OperationRunner {
         if (detectConfigurationFactory.isComponentLocationAnalysisEnabled()) {
             auditLog.namedPublic(
                     OPERATION_NAME,
-                    () -> (new GenerateComponentLocationAnalysisOperation()).locateComponentsForOnlineIntelligentScan()
+                    () -> publishResult(new GenerateComponentLocationAnalysisOperation().locateComponentsForOnlineIntelligentScan())
             );
         }
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperation.java
@@ -11,6 +11,8 @@ import com.synopsys.integration.detect.configuration.DetectUserFriendlyException
 import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 import com.synopsys.integration.detect.workflow.file.DetectFileUtils;
 import com.synopsys.integration.detect.workflow.report.util.ReportConstants;
+import com.synopsys.integration.detect.workflow.result.ComponentLocatorResult;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +41,7 @@ public class GenerateComponentLocationAnalysisOperation {
      * @throws com.synopsys.integration.detect.workflow.componentlocationanalysis.ComponentLocatorException
      * @throws DetectUserFriendlyException
      */
-    public void locateComponents(Set<Component> componentsSet, File scanOutputFolder, File projectSrcDir) throws ComponentLocatorException, DetectUserFriendlyException {
+    public ComponentLocatorResult locateComponents(Set<Component> componentsSet, File scanOutputFolder, File projectSrcDir) throws ComponentLocatorException, DetectUserFriendlyException {
         Input componentLocatorInput = new Input(projectSrcDir.getAbsolutePath(), new JsonObject(), componentsSet);
         String outputFilepath = scanOutputFolder + "/" + LOCATOR_OUTPUT_FILE_NAME;
         if (logger.isDebugEnabled()) {
@@ -54,12 +56,16 @@ public class GenerateComponentLocationAnalysisOperation {
         }
         logger.info("Component Location Analysis file saved at: {}", outputFilepath);
         logger.info(ReportConstants.RUN_SEPARATOR);
+        return new ComponentLocatorResult(outputFilepath);
     }
 
-    public void locateComponentsForOnlineIntelligentScan() throws ComponentLocatorException {
+    public ComponentLocatorResult locateComponentsForOnlineIntelligentScan() throws ComponentLocatorException {
         logger.info(ReportConstants.RUN_SEPARATOR);
         logger.info("Intelligent Scan mode does not support Component Location Analysis.");
         failComponentLocationAnalysisOperation();
+
+        // unreachable statement, mainly here so we don't forget to log a result if this function is ever implemented
+        return new ComponentLocatorResult("change me");
     }
 
     /**

--- a/src/main/java/com/synopsys/integration/detect/workflow/result/ComponentLocatorResult.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/result/ComponentLocatorResult.java
@@ -1,0 +1,33 @@
+package com.synopsys.integration.detect.workflow.result;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ComponentLocatorResult implements DetectResult {
+    private final String resultFilePath;
+
+    public ComponentLocatorResult(String resultFilePath) {
+        this.resultFilePath = resultFilePath;
+    }
+
+    @Override
+    public String getResultLocation() {
+        return resultFilePath;
+    }
+
+    @Override
+    public String getResultMessage() {
+        return String.format("Component Location Analysis File: %s", resultFilePath);
+    }
+
+    @Override
+    public List<String> getResultSubMessages() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getTransitiveUpgradeGuidanceSubMessages() {
+        return Collections.emptyList();
+    }
+    
+}

--- a/src/test/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperationIT.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperationIT.java
@@ -28,6 +28,7 @@ public class GenerateComponentLocationAnalysisOperationIT {
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.successfulOperation("Generating Component Location Analysis File for All Components");
+            dockerAssertions.logContainsPattern("Component Location Analysis File: .*components-with-locations\\.json");
         }
     }
     @Test
@@ -42,6 +43,7 @@ public class GenerateComponentLocationAnalysisOperationIT {
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.successfulOperation("Generating Component Location Analysis File for Reported Components");
+            dockerAssertions.logContainsPattern("Component Location Analysis File: .*components-with-locations\\.json");
         }
     }
 }


### PR DESCRIPTION
# Description
Log component location analysis file path in the Detect Result section

Example output:

```
2024-04-26 14:27:46 MDT INFO  [main] --- ======== Detect Result ========
2024-04-26 14:27:46 MDT INFO  [main] --- 
2024-04-26 14:27:46 MDT INFO  [main] --- Component Location Analysis File: /blackduck/runs/2024-04-26-20-27-44-814/scan/components-with-locations.json
2024-04-26 14:27:46 MDT INFO  [main] --- 
2024-04-26 14:27:46 MDT INFO  [main] --- ======== Detect Status ========
2024-04-26 14:27:46 MDT INFO  [main] --- 
2024-04-26 14:27:46 MDT INFO  [main] --- GIT: SUCCESS
2024-04-26 14:27:46 MDT INFO  [main] --- MAVEN: SUCCESS
2024-04-26 14:27:46 MDT INFO  [main] --- Overall Status: SUCCESS - Detect exited successfully.
2024-04-26 14:27:46 MDT INFO  [main] --- 
2024-04-26 14:27:46 MDT INFO  [main] --- ===============================
2024-04-26 14:27:46 MDT INFO  [main] --- 
2024-04-26 14:27:46 MDT INFO  [main] --- Detect duration: 00h 00m 02s 456ms
```

Additionally, the `status.json` file now has the following entry when CLL runs successfully:

```
  "results": [
    {
      "location": "/blackduck/runs/2024-04-26-20-27-44-814/scan/components-with-locations.json",
      "message": "Component Location Analysis File: /blackduck/runs/2024-04-26-20-27-44-814/scan/components-with-locations.json",
      "sub_messages": []
    }
  ],
```