### PR TITLE
Remove Unmatched Go Component from Graph

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/parse/GoModuleDependencyHelper.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/go/gomod/parse/GoModuleDependencyHelper.java
@@ -38,6 +38,10 @@ public class GoModuleDependencyHelper {
             
             // Splitting here allows matching with less effort
             String[] splitLine = grphLine.split(" ");
+
+            if(splitLine[1].startsWith("go@")) {
+                continue;
+            }
             
             // anything that falls in here isn't a direct dependency of main
             boolean needsRedux = !containsDirect && splitLine[0].equals(main);


### PR DESCRIPTION
This PR fixes the issue mentioned in IDETECT-4353 where we are reporting Go as unmatched component in BOM. The output of go mod graph gives GO and its version as output of the graph and Detect is parsing it as it should. In the fix, we are skipping the go component when we encounter it. 