### PR TITLE
improve Setuptools applicable detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.synopsys.integration'
 
-version = '9.8.0-SNAPSHOT'
+version = '9.7.0-SIGQA7-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/setuptools/build/SetupToolsBuildDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/setuptools/build/SetupToolsBuildDetectable.java
@@ -43,7 +43,6 @@ public class SetupToolsBuildDetectable extends Detectable {
     private final SetupToolsExtractor setupToolsExtractor;
     private final PipResolver pipResolver;
 
-    private File projectToml;
     private TomlParseResult parsedToml;
     
     private ExecutableTarget pipExe;
@@ -59,10 +58,26 @@ public class SetupToolsBuildDetectable extends Detectable {
 
     @Override
     public DetectableResult applicable() {
+        // Ensure there is a pyproject.toml
         Requirements fileResolver = new Requirements(fileFinder, environment);
-        projectToml = fileResolver.file(PY_PROJECT_TOML);
+        File projectToml = fileResolver.file(PY_PROJECT_TOML);
         
-        return fileResolver.result();
+        if (fileResolver.isAlreadyFailed()) {
+            return fileResolver.result();
+        }
+        
+        try {
+            parsedToml = SetupToolsExtractUtils.extractToml(projectToml);
+
+            // Ensure the pyproject.toml file has a requires setuptools line.
+            if (parsedToml == null || !SetupToolsExtractUtils.checkTomlRequiresSetupTools(parsedToml)) {
+                return new SetupToolsRequiresNotFoundDetectableResult();
+            }
+        } catch (IOException e){
+            return new ExceptionDetectableResult(e);
+        }
+        
+        return new PassedDetectableResult();
     }
 
     @Override
@@ -72,13 +87,6 @@ public class SetupToolsBuildDetectable extends Detectable {
             pipExe = pipResolver.resolvePip();
             if (pipExe == null) {
                 return new ExecutableNotFoundDetectableResult("pip");
-            }
-        
-            parsedToml = SetupToolsExtractUtils.extractToml(projectToml);
-
-            // Ensure an existing pyproject.toml with a requires setuptools line.
-            if (parsedToml == null || !SetupToolsExtractUtils.checkTomlRequiresSetupTools(parsedToml)) {
-                return new SetupToolsRequiresNotFoundDetectableResult();
             }
             
             // Ensure dependencies/requirements are specified in a toml, cfg, or py file.


### PR DESCRIPTION
Currently the Setuptools check to see if a pyproject.toml exists and then attempt to run. They will fail at a later point if they don't detect a requires = ["setuptools"] line but this results in log statements about Setuptools running when it really shouldn't, as in the case of a Poetry project.

This moves the check for the requires line to the earlier applicable method so the Setuptools detectors won't run on such projects.