### PR TITLE
Poetry package name normalization accross pyproject.toml and poetry.lock

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/poetry/parser/PoetryLockParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/poetry/parser/PoetryLockParser.java
@@ -76,7 +76,7 @@ public class PoetryLockParser {
     }
 
     private String normalizePackageName(String packageName) {
-        return packageName.replaceAll("[_.]", "-").toLowerCase();
+        return packageName.replaceAll("[_.-]+", "-").toLowerCase();
     }
 
     private void populateDirectDependencies(DependencyGraph graph, Set<String> rootPackages) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/poetry/parser/PoetryLockParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/poetry/parser/PoetryLockParser.java
@@ -42,6 +42,8 @@ public class PoetryLockParser {
         Set<String> lockFileRootPackages = populatePackageMapAndGetRootPackages(lockPackages);
         if (rootPackages == null) {
             rootPackages = lockFileRootPackages;
+        } else {
+            rootPackages = normalizePackageNames(rootPackages);
         }
 
         populateDirectDependencies(graph, rootPackages);
@@ -64,6 +66,19 @@ public class PoetryLockParser {
         return graph;
     }
 
+    private Set<String> normalizePackageNames(Set<String> packages) {
+        Set<String> normalized = new HashSet<>();
+
+        for (String name : packages) {
+            normalized.add(normalizePackageName(name));
+        }
+        return normalized;
+    }
+
+    private String normalizePackageName(String packageName) {
+        return packageName.replaceAll("[_.]", "-").toLowerCase();
+    }
+
     private void populateDirectDependencies(DependencyGraph graph, Set<String> rootPackages) {
         for (String rootPackage : rootPackages) {
             Dependency dependency = getPackage(rootPackage);
@@ -84,11 +99,11 @@ public class PoetryLockParser {
             TomlTable lockPackage = lockPackages.getTable(i);
 
             if (lockPackage != null) {
-                String projectName = lockPackage.getString(NAME_KEY);
+                String projectName = normalizePackageName(lockPackage.getString(NAME_KEY));
                 String projectVersion = lockPackage.getString(VERSION_KEY);
 
                 putPackage(projectName, Dependency.FACTORY.createNameVersionDependency(Forge.PYPI, projectName, projectVersion));
-                rootPackages.add(projectName.toLowerCase());
+                rootPackages.add(projectName);
 
                 if (lockPackage.getTable(DEPENDENCIES_KEY) != null) {
                     List<String> dependencies = extractFromDependencyList(lockPackage.getTable(DEPENDENCIES_KEY));
@@ -103,11 +118,11 @@ public class PoetryLockParser {
     }
 
     private void putPackage(String name, Dependency dependency) {
-        packageMap.put(name.toLowerCase(), dependency);
+        packageMap.put(normalizePackageName(name), dependency);
     }
 
     private Dependency getPackage(String name) {
-        return packageMap.get(name.toLowerCase());
+        return packageMap.get(normalizePackageName(name));
     }
 
     private List<String> extractFromDependencyList(@Nullable TomlTable dependencyList) {

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/poetry/parser/ToolPoetrySectionParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/poetry/parser/ToolPoetrySectionParser.java
@@ -93,7 +93,9 @@ public class ToolPoetrySectionParser {
             if (dotIndex == -1) {
                 set.add(key);
             } else {
-                // remove the ".extras" part
+                // when an entry such as `fastapi = {version="^0.92.0", extras=["all"]}` is encountered, it results in two keys:
+                //   "fastapi.version", and "fastapi.extras"
+                // here we address this by removing the "version" and "extras" parts
                 set.add(key.substring(0, dotIndex));
             }
         }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/poetry/parser/ToolPoetrySectionParser.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/poetry/parser/ToolPoetrySectionParser.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.detectable.detectables.poetry.parser;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.jetbrains.annotations.Nullable;
@@ -70,34 +71,28 @@ public class ToolPoetrySectionParser {
         TomlTable table = parseResult.getTable(key);
 
         if (key.equals(MAIN_DEPENDENCY_GROUP_KEY)) {
-            addAllTableKeysToSet(result, table);
+            addAllPackageNamesToSet(result, table);
         } else if (key.equals(LEGACY_DEV_DEPENDENCY_GROUP_KEY)) { // in Poetry 1.0 to 1.2 this was the way of specifying dev dependencies
             if (!options.getExcludedGroups().contains(DEFAULT_DEV_GROUP_NAME)) {
-                addAllTableKeysToSet(result, table);
+                addAllPackageNamesToSet(result, table);
             }
         } else if (key.startsWith(DEPENDENCY_GROUP_KEY_PREFIX) && key.endsWith(DEPENDENCY_GROUP_KEY_SUFFIX)) {
             String group = key.substring(DEPENDENCY_GROUP_KEY_PREFIX.length(), key.length() - DEPENDENCY_GROUP_KEY_SUFFIX.length());
 
             if (!options.getExcludedGroups().contains(group)) {
-                addAllTableKeysToSet(result, table);
+                addAllPackageNamesToSet(result, table);
             }
         }
     }
 
-    private void addAllTableKeysToSet(Set<String> set, TomlTable table) {
-        for (String key : table.dottedKeySet()) {
-            if (key.equalsIgnoreCase(PYTHON_COMPONENT_NAME))
+    private void addAllPackageNamesToSet(Set<String> set, TomlTable table) {
+        for (List<String> key : table.keyPathSet()) {
+            String packageName = key.get(0);
+
+            if (packageName.equalsIgnoreCase(PYTHON_COMPONENT_NAME))
                 continue;
 
-            int dotIndex = key.indexOf('.', 0);
-            if (dotIndex == -1) {
-                set.add(key);
-            } else {
-                // when an entry such as `fastapi = {version="^0.92.0", extras=["all"]}` is encountered, it results in two keys:
-                //   "fastapi.version", and "fastapi.extras"
-                // here we address this by removing the "version" and "extras" parts
-                set.add(key.substring(0, dotIndex));
-            }
+            set.add(packageName);
         }
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/functional/PoetryDetectableExcludeDevTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/functional/PoetryDetectableExcludeDevTest.java
@@ -35,10 +35,10 @@ public class PoetryDetectableExcludeDevTest extends DetectableFunctionalTest {
             "\n" + //
             "[tool.poetry.dependencies]\n" + //
             "Python = \"^3.11\"\n" + //
-            "\"PENDULUM.XYZ\" = \"^3.0.0\"\n" + //
+            "\"PENDULUM._-XYZ\" = \"^3.0.0\"\n" + //
             "\n" + //
             "[tool.poetry.group.dev.dependencies]\n" + //
-            "boost-histogram = \"^1.4.0\"\n" + //
+            "\"boost-_--.histogram\" = \"^1.4.0\"\n" + //
             "\n" + //
             "[build-system]\n" + //
             "requires = [\"poetry-core\"]\n" + //
@@ -72,7 +72,7 @@ public class PoetryDetectableExcludeDevTest extends DetectableFunctionalTest {
             "python-versions = \">=3.8\"\n" + //
             "\n" + //
             "[package.dependencies]\n" + //
-            "PYTHON-dateutil = \">=2.6\"\n" + //
+            "\"PYTHON---.dateutil\" = \">=2.6\"\n" + //
             "TZData = \">=2020.1\"\n" + //
             "\n" + //
             "[[package]]\n" + //

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/functional/PoetryDetectableExcludeDevTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/functional/PoetryDetectableExcludeDevTest.java
@@ -35,7 +35,7 @@ public class PoetryDetectableExcludeDevTest extends DetectableFunctionalTest {
             "\n" + //
             "[tool.poetry.dependencies]\n" + //
             "Python = \"^3.11\"\n" + //
-            "PENDULUM = \"^3.0.0\"\n" + //
+            "\"PENDULUM.XYZ\" = \"^3.0.0\"\n" + //
             "\n" + //
             "[tool.poetry.group.dev.dependencies]\n" + //
             "boost-histogram = \"^1.4.0\"\n" + //
@@ -65,18 +65,18 @@ public class PoetryDetectableExcludeDevTest extends DetectableFunctionalTest {
             "python-versions = \">=3.9\"\n" + //
             "\n" + //
             "[[package]]\n" + //
-            "name = \"pendulum\"\n" + //
+            "name = \"pendulum_XYZ\"\n" + //
             "version = \"3.0.0\"\n" + //
             "description = \"Python datetimes made easy\"\n" + //
             "optional = false\n" + //
             "python-versions = \">=3.8\"\n" + //
             "\n" + //
             "[package.dependencies]\n" + //
-            "python-dateutil = \">=2.6\"\n" + //
+            "PYTHON-dateutil = \">=2.6\"\n" + //
             "TZData = \">=2020.1\"\n" + //
             "\n" + //
             "[[package]]\n" + //
-            "name = \"python-dateutil\"\n" + //
+            "name = \"python-DATEUTIL\"\n" + //
             "version = \"2.9.0.post0\"\n" + //
             "description = \"Extensions to the standard Python datetime module\"\n" + //
             "optional = false\n" + //
@@ -115,9 +115,9 @@ public class PoetryDetectableExcludeDevTest extends DetectableFunctionalTest {
         NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.PYPI, codeLocations.get(0).getDependencyGraph());
 
         graphAssert.hasRootSize(1);
-        graphAssert.hasRootDependency("pendulum", "3.0.0");
-        graphAssert.hasParentChildRelationship("pendulum", "3.0.0", "python-dateutil", "2.9.0.post0");
-        graphAssert.hasParentChildRelationship("pendulum", "3.0.0", "tzdata", "2024.1");
+        graphAssert.hasRootDependency("pendulum-xyz", "3.0.0");
+        graphAssert.hasParentChildRelationship("pendulum-xyz", "3.0.0", "python-dateutil", "2.9.0.post0");
+        graphAssert.hasParentChildRelationship("pendulum-xyz", "3.0.0", "tzdata", "2024.1");
         graphAssert.hasParentChildRelationship("python-dateutil", "2.9.0.post0", "six", "1.16.0");
     }
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/functional/PoetryDetectableTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/functional/PoetryDetectableTest.java
@@ -43,11 +43,11 @@ public class PoetryDetectableTest extends DetectableFunctionalTest {
             "version = \"1.4.0\"",
             "",
             "[package.dependencies]",
-            "importlib-metadata = \"*\"",
+            "importLib-metadata = \"*\"",
             "",
             "[[package]]",
             "category = \"dev\"",
-            "name = \"importlib-metadata\"",
+            "name = \"Importlib_Metadata\"",
             "python-versions = \"!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7\"",
             "version = \"1.6.0\""
         );

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/unit/PoetryLockParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/unit/PoetryLockParserTest.java
@@ -17,11 +17,11 @@ public class PoetryLockParserTest {
 
         String input = String.join(System.lineSeparator(), Arrays.asList(
             "[[package]]",
-            "name = \"Pytest_Cov\"",
+            "name = \"Pytest___Cov\"",
             "version = \"2.8.1\"",
             "",
             "[[package]]",
-            "name = \"pytest.mock\"",
+            "name = \"pytest.-_mock\"",
             "version = \"2.0.0\""
         ));
         PoetryLockParser poetryLockParser = new PoetryLockParser();

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/unit/PoetryLockParserTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/poetry/unit/PoetryLockParserTest.java
@@ -17,11 +17,11 @@ public class PoetryLockParserTest {
 
         String input = String.join(System.lineSeparator(), Arrays.asList(
             "[[package]]",
-            "name = \"pytest-cov\"",
+            "name = \"Pytest_Cov\"",
             "version = \"2.8.1\"",
             "",
             "[[package]]",
-            "name = \"pytest-mock\"",
+            "name = \"pytest.mock\"",
             "version = \"2.0.0\""
         ));
         PoetryLockParser poetryLockParser = new PoetryLockParser();


### PR DESCRIPTION
# Description

Poetry is quite flexible with how users can specify required package names and dependencies.
In addition to case-insensitivity in package names, characters "-", ".", and "_" are equivalent.
To address this, this PR implements package name "normalization", similar to the following definition: https://peps.python.org/pep-0503/#normalized-names