### PR TITLE
Fix and enable CLA integration test class

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/battery/docker/util/DockerAssertions.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/util/DockerAssertions.java
@@ -53,14 +53,15 @@ public class DockerAssertions {
         Assertions.assertEquals("SUCCESS", detector.get().status);
     }
 
+
     public void successfulOperationStatusJson(String operationKey) {
         FormattedOutput statusJson = locateStatusJson();
-        Optional<FormattedOperationOutput> detector = statusJson.operations.stream().filter(it -> it.descriptionKey.equals(operationKey))
+        Optional<FormattedOperationOutput> operation = statusJson.operations.stream().filter(it -> it.descriptionKey.equals(operationKey))
             .findFirst();
 
-        Assertions.assertTrue(detector.isPresent(), "Could not find required operation '" + operationKey + "' in status json detector list.");
+        Assertions.assertTrue(operation.isPresent(), "Could not find required operation '" + operationKey + "' in status json detector list.");
 
-        Assertions.assertEquals("SUCCESS", detector.get().status);
+        Assertions.assertEquals("SUCCESS", operation.get().status);
     }
 
     public void successfulToolStatusJson(String detectorType) {
@@ -149,6 +150,10 @@ public class DockerAssertions {
                 .findAny().isPresent(),
             String.format("Expected BDIO file %s, but it was not created", requiredBdioFilename)
         );
+    }
+
+    public void exitCodeIs(int expected) {
+        Assertions.assertEquals(expected, dockerDetectResult.getExitCode());
     }
 
     public File getOutputDirectory() {

--- a/src/test/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperationIT.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/componentlocationanalysis/GenerateComponentLocationAnalysisOperationIT.java
@@ -2,17 +2,17 @@ package com.synopsys.integration.detect.workflow.componentlocationanalysis;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckTestConnection;
 import com.synopsys.integration.detect.battery.docker.provider.BuildDockerImageProvider;
 import com.synopsys.integration.detect.battery.docker.util.DetectCommandBuilder;
 import com.synopsys.integration.detect.battery.docker.util.DetectDockerTestRunner;
 import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
 import com.synopsys.integration.detect.configuration.DetectProperties;
+import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 
-@Disabled
 @Tag("integration")
 public class GenerateComponentLocationAnalysisOperationIT {
     @Test
@@ -24,33 +24,40 @@ public class GenerateComponentLocationAnalysisOperationIT {
             commandBuilder.property(DetectProperties.DETECT_COMPONENT_LOCATION_ANALYSIS_ENABLED, "true");
             commandBuilder.property(DetectProperties.BLACKDUCK_OFFLINE_MODE, "true");
             commandBuilder.property(DetectProperties.BLACKDUCK_OFFLINE_MODE_FORCE_BDIO, "true");
-            commandBuilder.property(DetectProperties.DETECT_INCLUDED_DETECTOR_TYPES, "DETECTOR");
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, "DETECTOR");
             commandBuilder.property(DetectProperties.LOGGING_LEVEL_COM_SYNOPSYS_INTEGRATION, "DEBUG");
 
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.successfulOperation(GenerateComponentLocationAnalysisOperation.OPERATION_NAME);
             dockerAssertions.logContainsPattern("Component Location Analysis File: .*components-with-locations\\.json");
-            dockerAssertions.logDoesNotContain("COMPONENT_LOCATOR: SUCCESS");
+            dockerAssertions.logDoesNotContain("COMPONENT_LOCATION_ANALYSIS: SUCCESS");
+            dockerAssertions.logDoesNotContain("COMPONENT_LOCATION_ANALYSIS: FAILURE");
+            dockerAssertions.exitCodeIs(ExitCodeType.SUCCESS.getExitCode());
         }
     }
 
     @Test
-    void onlineRapidPkgMngrScan_analysisEnabled() throws IOException {
+    void testOnlineRapidPkgMngrScan_analysisEnabled() throws IOException {
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("component-location-analysis-test", "gradle-simple:1.0.0")) {
             test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("SimpleGradle.dockerfile"));
 
-            DetectCommandBuilder commandBuilder = DetectCommandBuilder.withOfflineDefaults().defaultDirectories(test);
+            BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+
+            DetectCommandBuilder commandBuilder = new DetectCommandBuilder().defaults().defaultDirectories(test);
+            commandBuilder.connectToBlackDuck(blackDuckTestConnection);
             commandBuilder.property(DetectProperties.DETECT_COMPONENT_LOCATION_ANALYSIS_ENABLED, "true");
             commandBuilder.property(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE, "RAPID");
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, "DETECTOR");
             commandBuilder.property(DetectProperties.LOGGING_LEVEL_COM_SYNOPSYS_INTEGRATION, "DEBUG");
 
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
-            dockerAssertions.successfulOperation(GenerateComponentLocationAnalysisOperation.OPERATION_NAME);
-            dockerAssertions.logContainsPattern("Component Location Analysis File: .*components-with-locations\\.json");
-            dockerAssertions.logDoesNotContain("COMPONENT_LOCATOR: SUCCESS");
-
+            // currently this operation fails because in RAPID mode with no matching policies in BD, Component Locator does not get any components to look up
+            dockerAssertions.logContains(GenerateComponentLocationAnalysisOperation.OPERATION_NAME + ": FAILURE");
+            dockerAssertions.logDoesNotContain("COMPONENT_LOCATION_ANALYSIS: SUCCESS");
+            dockerAssertions.logDoesNotContain("COMPONENT_LOCATION_ANALYSIS: FAILURE");
+            dockerAssertions.exitCodeIs(ExitCodeType.SUCCESS.getExitCode());
         }
     }
 
@@ -64,33 +71,41 @@ public class GenerateComponentLocationAnalysisOperationIT {
             commandBuilder.property(DetectProperties.DETECT_COMPONENT_LOCATION_ANALYSIS_STATUS, "true");
             commandBuilder.property(DetectProperties.BLACKDUCK_OFFLINE_MODE, "true");
             commandBuilder.property(DetectProperties.BLACKDUCK_OFFLINE_MODE_FORCE_BDIO, "true");
-            commandBuilder.property(DetectProperties.DETECT_INCLUDED_DETECTOR_TYPES, "DETECTOR");
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, "DETECTOR");
             commandBuilder.property(DetectProperties.LOGGING_LEVEL_COM_SYNOPSYS_INTEGRATION, "DEBUG");
 
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.successfulOperation(GenerateComponentLocationAnalysisOperation.OPERATION_NAME);
             dockerAssertions.logContainsPattern("Component Location Analysis File: .*components-with-locations\\.json");
-            dockerAssertions.logContains("COMPONENT_LOCATOR: SUCCESS");
+            dockerAssertions.logContains("COMPONENT_LOCATION_ANALYSIS: SUCCESS");
+            dockerAssertions.logDoesNotContain("COMPONENT_LOCATION_ANALYSIS: FAILURE");
+            dockerAssertions.exitCodeIs(ExitCodeType.SUCCESS.getExitCode());
         }
     }
 
     @Test
-    void onlineRapidPkgMngrScan_analysisEnabled_affectsStatus() throws IOException {
+    void testOnlineRapidPkgMngrScan_analysisEnabled_affectsStatus() throws IOException {
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("component-location-analysis-test", "gradle-simple:1.0.0")) {
             test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("SimpleGradle.dockerfile"));
 
-            DetectCommandBuilder commandBuilder = DetectCommandBuilder.withOfflineDefaults().defaultDirectories(test);
+            BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+
+            DetectCommandBuilder commandBuilder = new DetectCommandBuilder().defaults().defaultDirectories(test);
+            commandBuilder.connectToBlackDuck(blackDuckTestConnection);
             commandBuilder.property(DetectProperties.DETECT_COMPONENT_LOCATION_ANALYSIS_ENABLED, "true");
             commandBuilder.property(DetectProperties.DETECT_COMPONENT_LOCATION_ANALYSIS_STATUS, "true");
             commandBuilder.property(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE, "RAPID");
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, "DETECTOR");
             commandBuilder.property(DetectProperties.LOGGING_LEVEL_COM_SYNOPSYS_INTEGRATION, "DEBUG");
 
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
-            dockerAssertions.successfulOperation(GenerateComponentLocationAnalysisOperation.OPERATION_NAME);
-            dockerAssertions.logContainsPattern("Component Location Analysis File: .*components-with-locations\\.json");
-            dockerAssertions.logContains("COMPONENT_LOCATOR: SUCCESS");
+            // currently this operation fails because in RAPID mode with no matching policies in BD, Component Locator does not get any components to look up
+            dockerAssertions.logContains(GenerateComponentLocationAnalysisOperation.OPERATION_NAME + ": FAILURE");
+            dockerAssertions.logDoesNotContain("COMPONENT_LOCATION_ANALYSIS: SUCCESS");
+            dockerAssertions.logContains("COMPONENT_LOCATION_ANALYSIS: FAILURE");
+            dockerAssertions.exitCodeIs(ExitCodeType.FAILURE_COMPONENT_LOCATION_ANALYSIS.getExitCode());
         }
     }
 }


### PR DESCRIPTION
# Description

This test was previously disabled.

After enabling it I realized there were a few issues which I addressed.

One issue remains and it's that in order to perform a rapid scan with a successful CLA run, BD must have configured policies which are triggered by the Detect run. Since Detect integration tests are run against several BD instances (and for one of them it would be difficult to put policies in place without first coming up with additional automation), as part of this change I decided to change the test to instead test a failed rapid scan workflow.