### PR TITLE
Use CLA version 1.1.12 to resolve a StringIndexOutOfBoundsException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ dependencies {
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.10'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
     implementation 'com.synopsys:method-analyzer-core:0.2.9'
-    implementation "${locatorGroup}:${locatorModule}:1.1.11"
+    implementation "${locatorGroup}:${locatorModule}:1.1.12"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 


### PR DESCRIPTION
# Description

Before this change Detect would fail when scanning some project with CLA, such as `maven-surefire`.
With this change Detect runs successfully in such scenarios.