### PR TITLE
Applicable check for Stateless Detector scans

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -62,11 +62,13 @@ public class RapidModeStepRunner {
         List<HttpUrl> parsedUrls = new ArrayList<>();
         Set<FormattedCodeLocation> formattedCodeLocations = new HashSet<>();
 
-        List<HttpUrl> uploadResultsUrls = operationRunner.performRapidUpload(blackDuckRunData, bdioResult, rapidScanConfig.orElse(null));
+        stepHelper.runToolIfIncluded(DetectTool.DETECTOR, "Detector Scan", () -> {
+            List<HttpUrl> uploadResultsUrls = operationRunner.performRapidUpload(blackDuckRunData, bdioResult, rapidScanConfig.orElse(null));
         
-        if (uploadResultsUrls != null && uploadResultsUrls.size() > 0) {
-            processScanResults(uploadResultsUrls, parsedUrls, formattedCodeLocations, DetectTool.DETECTOR.name());
-        }
+            if (uploadResultsUrls != null && uploadResultsUrls.size() > 0) {
+                processScanResults(uploadResultsUrls, parsedUrls, formattedCodeLocations, DetectTool.DETECTOR.name());
+            }
+        });
 
         stepHelper.runToolIfIncluded(DetectTool.SIGNATURE_SCAN, "Signature Scanner", () -> {
             logger.debug("Stateless scan signature scan detected.");


### PR DESCRIPTION
Stateless Detector scans currently do a decent amount of processing before realizing they can't create a BDIO and then exiting. We should instead only execute them if the are enabled specifically by the user (mentioned in tools or by default when no tools property is mentioned).