### PR TITLE
Revert "Applicable check for Stateless Detector scans"

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -62,13 +62,11 @@ public class RapidModeStepRunner {
         List<HttpUrl> parsedUrls = new ArrayList<>();
         Set<FormattedCodeLocation> formattedCodeLocations = new HashSet<>();
 
-        stepHelper.runToolIfIncluded(DetectTool.DETECTOR, "Detector Scan", () -> {
-            List<HttpUrl> uploadResultsUrls = operationRunner.performRapidUpload(blackDuckRunData, bdioResult, rapidScanConfig.orElse(null));
+        List<HttpUrl> uploadResultsUrls = operationRunner.performRapidUpload(blackDuckRunData, bdioResult, rapidScanConfig.orElse(null));
         
-            if (uploadResultsUrls != null && uploadResultsUrls.size() > 0) {
-                processScanResults(uploadResultsUrls, parsedUrls, formattedCodeLocations, DetectTool.DETECTOR.name());
-            }
-        });
+        if (uploadResultsUrls != null && uploadResultsUrls.size() > 0) {
+            processScanResults(uploadResultsUrls, parsedUrls, formattedCodeLocations, DetectTool.DETECTOR.name());
+        }
 
         stepHelper.runToolIfIncluded(DetectTool.SIGNATURE_SCAN, "Signature Scanner", () -> {
             logger.debug("Stateless scan signature scan detected.");


### PR DESCRIPTION
Reverts blackducksoftware/synopsys-detect#1134

This simply removes the 
stepHelper.runToolIfIncluded(DetectTool.DETECTOR, "Detector Scan", ()
wrapper and restores the original code. We use these lines for Bazel and Docker scans and not just Detector scans.