### PR TITLE
Fix Property Update Bug for Scan Settings File

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/AutonomousManager.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/AutonomousManager.java
@@ -123,8 +123,10 @@ public class AutonomousManager {
 
     public SortedMap<String, String> getAllScanSettingsProperties() {
         SortedMap<String, String> scanSettingsProperties = new TreeMap<>();
-        scanSettingsProperties.putAll(scanSettings.getDetectorSharedProperties());
-        scanSettingsProperties.putAll(scanSettings.getGlobalDetectProperties());
+        detectorSharedProperties = scanSettings.getDetectorSharedProperties();
+        globalProperties = scanSettings.getGlobalDetectProperties();
+        scanSettingsProperties.putAll(detectorSharedProperties);
+        scanSettingsProperties.putAll(globalProperties);
         scanSettings.getScanTypes().forEach(scanType ->  {
             scanSettingsProperties.putAll(scanType.getScanProperties());
         });


### PR DESCRIPTION
# Description

This PR would fix a bug that the properties are wrongly updated during the second run. The problem was that Maps were not initialized that during the initialization of the Scan Settings Model, these maps were not initialized and they were treated as new maps so all the properties irrespective of their presence.