### PR TITLE
Log only server roles, instead of fetching potentially thousands of project roles

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,4 +1,4 @@
 // Updating blackduck-common version here might necessitate an update to integration-common version in src/main/resources/create-gradle-airgap-script.ftl \
 // to ensure the integration-common versions in both airgap and non-airgap are the same. 
-gradle.ext.blackDuckCommonVersion='66.2.18'
+gradle.ext.blackDuckCommonVersion='66.2.20'
 gradle.ext.springBootVersion='2.7.12'

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/BlackDuckConnectivityChecker.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/BlackDuckConnectivityChecker.java
@@ -55,17 +55,16 @@ public class BlackDuckConnectivityChecker {
             logger.info(String.format("Successfully connected to Black Duck (version %s)!", version));
 
             if (logger.isDebugEnabled()) {
-                // These (particularly fetching roles) can be very slow operations
                 UserView userView = userService.findCurrentUser();
                 logger.debug("Connected as: " + userView.getUserName());
 
                 UserGroupService userGroupService = blackDuckServicesFactory.createUserGroupService();
-                List<RoleAssignmentView> roles = userGroupService.getRolesForUser(userView);
-                logger.debug("Roles: " + roles.stream().map(RoleAssignmentView::getName).distinct().collect(Collectors.joining(", ")));
+                List<RoleAssignmentView> roles = userGroupService.getServerRolesForUser(userView);
+                logger.debug("Server Roles: " + roles.stream().map(RoleAssignmentView::getName).distinct().collect(Collectors.joining(", ")));
 
                 BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
                 List<UserGroupView> groups = blackDuckApiClient.getAllResponses(userView.metaMultipleResponses(USERGROUPS));
-                logger.debug("Group: " + groups.stream().map(UserGroupView::getName).distinct().collect(Collectors.joining(", ")));
+                logger.debug("Groups: " + groups.stream().map(UserGroupView::getName).distinct().collect(Collectors.joining(", ")));
             }
         } catch (IntegrationException e) {
             throw new DetectUserFriendlyException(


### PR DESCRIPTION
Log only server roles, instead of fetching potentially thousands of project roles

# Description

Prior to this change, Detect would fetch all roles including project roles.
In cases when there are many projects this can mean fetching thousands of roles.
This decreases run time and the number of requests while still providing some useful information in the log in debug mode.

Example updated log:

```
2024-06-07 14:40:48 MDT TRACE [main] --- completed request: https://us03-int-hub02.nprd.sig.synopsys.com/api/users/00000000-0000-0000-0001-000000000001/roles?filter=scope%3Aserver&limit=100&offset=0 (346 ms)
2024-06-07 14:40:48 MDT DEBUG [main] --- Server Roles: System Administrator, Global Code Scanner, Policy Manager, License Manager, Custom Fields Administrator, User Administrator, Global Project Group Administrator, Global Project Manager, Component Manager, Global Project Administrator, Global Notification Viewer, Copyright Editor, Global Security Manager, Project Creator, Global Project Viewer, Global Release Creator
```

# Prerequisites

This change depends on https://github.com/blackducksoftware/blackduck-common/pull/423
Do not merge until the above is released.