### PR TITLE
Fix IDETECT-4391 and IDETECT-4392

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/AutonomousManager.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/AutonomousManager.java
@@ -40,7 +40,7 @@ public class AutonomousManager {
     private SortedMap<String, String> userProvidedProperties = new TreeMap<>();
     private SortedMap<String, String> globalProperties = new TreeMap<>();
     private SortedMap<String, String> detectorSharedProperties = new TreeMap<>();
-    private static final List<String> propertiesNotAutonomous = Arrays.asList("blackduck.api.token", "detect.diagnostic", "detect.blackduck.scan.mode", "detect.source.path", "detect.tools");
+    private static final List<String> propertiesNotAutonomous = Arrays.asList("blackduck.api.token", "detect.diagnostic", "detect.source.path", "detect.tools");
 
     public AutonomousManager(
             DirectoryManager directoryManager,
@@ -54,8 +54,10 @@ public class AutonomousManager {
         this.autonomousScanEnabled = autonomousScanEnabled;
         this.userProvidedProperties = userProvidedProperties;
         detectSourcePath = directoryManager.getSourceDirectory().getPath();
-        createScanSettingsTargetFile();
-        scanSettings = initializeScanSettingsModel();
+        if(autonomousScanEnabled) {
+            createScanSettingsTargetFile();
+            scanSettings = initializeScanSettingsModel();
+        }
     }
 
     public boolean getAutonomousScanEnabled() {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/AutonomousManager.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/AutonomousManager.java
@@ -35,6 +35,7 @@ public class AutonomousManager {
     private File scanSettingsTargetFile;
     private ScanSettings scanSettings;
     private boolean autonomousScanEnabled;
+    private String blackDuckScanMode;
     private final DetectConfigurationFactory detectConfigurationFactory;
     private final DetectPropertyConfiguration detectConfiguration;
     private SortedMap<String, String> userProvidedProperties = new TreeMap<>();
@@ -74,6 +75,10 @@ public class AutonomousManager {
 
     public boolean isScanSettingsFilePresent() {
         return scanSettingsTargetFile != null && scanSettingsTargetFile.exists();
+    }
+
+    public void setBlackDuckScanMode(String scanMode) {
+        this.blackDuckScanMode = scanMode;
     }
 
     public void writeScanSettingsModelToTarget() throws IOException {
@@ -205,7 +210,10 @@ public class AutonomousManager {
     }
 
     private void updateGlobalProperties(String propertyKey, String propertyValue, boolean userProvidedProperty) {
-        if(userProvidedProperty) {
+        if(propertyKey.equals("detect.blackduck.scan.mode")) {
+            propertyValue = blackDuckScanMode;
+            globalProperties.put(propertyKey, propertyValue);
+        } else if(userProvidedProperty) {
             globalProperties.put(propertyKey, propertyValue);
         } else {
             globalProperties.putIfAbsent(propertyKey, propertyValue);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/DetectBoot.java
@@ -227,6 +227,7 @@ public class DetectBoot {
             boolean blackduckScanModeSpecified = detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
             BlackDuckConnectionDetails blackDuckConnectionDetails = detectConfigurationFactory.createBlackDuckConnectionDetails();
             BlackduckScanMode blackduckScanMode = decideScanMode(blackDuckConnectionDetails, scanTypeEvidenceMap, blackduckScanModeSpecified, detectConfigurationFactory, autonomousScanEnabled, detectConfiguration);
+            autonomousManager.setBlackDuckScanMode(blackduckScanMode.toString());
             ProductDecider productDecider = new ProductDecider();
             BlackDuckDecision blackDuckDecision = productDecider.decideBlackDuck(
                 blackDuckConnectionDetails,


### PR DESCRIPTION
# Description

This PR fixes the bugs described in IDETECT-4391 and IDETECT-4392. Scan Settings folder will not be created when autonomous scan is not enabled and also scan mode information will be stored in the scan settings file.