### PR TITLE
fix(autonomous-scanning): Source path resolution fix and NPE fix in BinaryScan flow.

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/AutonomousManager.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/AutonomousManager.java
@@ -5,6 +5,7 @@ import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -98,7 +99,7 @@ public class AutonomousManager {
     
     public Map<DetectTool, Set<String>> getScanTypeMap(boolean hasImageOrTar) {
         ScanTypeDecider autoDetectTool = new ScanTypeDecider();
-        return autoDetectTool.decide(hasImageOrTar, detectConfiguration);
+        return autoDetectTool.decide(hasImageOrTar, detectConfiguration, Paths.get(detectSourcePath));
     }
 
     public SortedMap<String, String> getAllScanSettingsProperties() {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/ScanTypeDecider.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/autonomous/ScanTypeDecider.java
@@ -28,9 +28,8 @@ import org.slf4j.LoggerFactory;
 public class ScanTypeDecider {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     
-    public Map<DetectTool, Set<String>> decide(boolean hasImageOrTar, DetectPropertyConfiguration detectConfiguration) {
+    public Map<DetectTool, Set<String>> decide(boolean hasImageOrTar, DetectPropertyConfiguration detectConfiguration, Path detectSourcePath) {
         if (!hasImageOrTar && detectConfiguration.getValue(DetectProperties.DETECT_AUTONOMOUS_SCAN_ENABLED)) {
-            Path detectSourcePath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_SOURCE_PATH);
             AllNoneEnumCollection<DetectTool> includedTools = detectConfiguration.getValue(DetectProperties.DETECT_TOOLS);
             AllNoneEnumCollection<DetectTool> excludedTools = detectConfiguration.getValue(DetectProperties.DETECT_TOOLS_EXCLUDED);
             if (detectSourcePath == null) {

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/BinaryScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/BinaryScanStepRunner.java
@@ -67,7 +67,7 @@ public class BinaryScanStepRunner {
                 .get();// Very important not to binary scan the same Docker output that we sig scanned (=codelocation name collision)
         }
 
-        if (!binaryTargets.isEmpty()) {
+        if (binaryTargets != null && !binaryTargets.isEmpty()) {
             binaryUpload = operationRunner.collectBinaryTargets(binaryTargets).get();
         }
 


### PR DESCRIPTION
**Description**
- Resolves the NPE mentioned in IDETECT-4400.
- Resolves the source path resolution bug when detect.source.path isn't explicitly set. `ScanTypeDecider.decide(...)` was reading the detect.source.path value from the DetectProperties class. This should be pulled from DirectoryManager instead as DirectoryManager already has the resolved value of the PWD if `detect.source.path` isn't explicitly set by the user. This is available in the AutonomousManager class already so I have just passed it to the ScanTypeDecider.


