### PR TITLE
Fix Integration Tests for Autonomous Scanning.

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
@@ -61,6 +61,7 @@ public class AutonomousScanTests {
 
             commandBuilder.property(DetectProperties.DETECT_AUTONOMOUS_SCAN_ENABLED, String.valueOf(true));
             commandBuilder.property(DetectProperties.DETECT_ACCURACY_REQUIRED, "NONE");
+            commandBuilder.property(DetectProperties.DETECT_TOOLS_EXCLUDED,"BINARY_SCAN");
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.bdioFiles(1);
@@ -71,7 +72,6 @@ public class AutonomousScanTests {
             dockerAssertions.autonomousDetectorAssertions("GRADLE");
             dockerAssertions.autonomousScanTypeAssertions("DETECTOR", "detect.accuracy.required", "detect.detector.search.depth");
             dockerAssertions.autonomousScanTypeAssertions("SIGNATURE_SCAN");
-            dockerAssertions.autonomousScanTypeAssertions("BINARY_SCAN","detect.binary.scan.search.depth");
 
             blackduckAssertions.hasComponents("Apache Commons Text","XStream");
         }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
@@ -64,6 +64,7 @@ public class AutonomousScanTests {
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.bdioFiles(1);
+            dockerAssertions.logContains("1jrfwrfh");
             dockerAssertions.locateScanSettingsFile();
             dockerAssertions.autonomousScanModeAssertions("INTELLIGENT");
             dockerAssertions.autonomousDetectorAssertions("MAVEN", "detect.maven.include.shaded.dependencies");

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
@@ -65,7 +65,6 @@ public class AutonomousScanTests {
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.bdioFiles(1);
-            dockerAssertions.logContains("1jrfwrfh");
             dockerAssertions.locateScanSettingsFile();
             dockerAssertions.autonomousScanModeAssertions("INTELLIGENT");
             dockerAssertions.autonomousDetectorAssertions("MAVEN", "detect.maven.include.shaded.dependencies");

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/integration/DetectOnDetectTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/integration/DetectOnDetectTest.java
@@ -155,6 +155,7 @@ public class DetectOnDetectTest {
             commandBuilder.waitForResults();
 
             commandBuilder.property(DetectProperties.DETECT_AUTONOMOUS_SCAN_ENABLED, String.valueOf(true));
+            commandBuilder.property(DetectProperties.DETECT_TOOLS_EXCLUDED,"BINARY_SCAN");
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.bdioFiles(1); //7 code locations, 6 bdio, 1 signature scanner

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/util/DockerAssertions.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/util/DockerAssertions.java
@@ -170,7 +170,7 @@ public class DockerAssertions {
     // TODO convenience methods on dockerAssertions for testing whether a detector was ATTEMPTED, SUCCESSFUL, ...
 
     public void logContains(String thing) {
-        Assertions.assertTrue(dockerDetectResult.getDetectLogs().contains(thing), "Expected logs to contain '" + thing + "' but they did not");
+        Assertions.assertTrue(dockerDetectResult.getDetectLogs().contains(thing), "Expected logs to contain '" + thing + "' but they did not.");
     }
 
     public void logDoesNotContain(String thing) {

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/util/DockerAssertions.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/util/DockerAssertions.java
@@ -170,7 +170,7 @@ public class DockerAssertions {
     // TODO convenience methods on dockerAssertions for testing whether a detector was ATTEMPTED, SUCCESSFUL, ...
 
     public void logContains(String thing) {
-        Assertions.assertTrue(dockerDetectResult.getDetectLogs().contains(thing), "Expected logs to contain '" + thing + "' but they did not.");
+        Assertions.assertTrue(dockerDetectResult.getDetectLogs().contains(thing), "Expected logs to contain '" + thing + "' but they did not. \n " + dockerDetectResult.getDetectLogs());
     }
 
     public void logDoesNotContain(String thing) {

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/util/DockerAssertions.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/util/DockerAssertions.java
@@ -170,7 +170,7 @@ public class DockerAssertions {
     // TODO convenience methods on dockerAssertions for testing whether a detector was ATTEMPTED, SUCCESSFUL, ...
 
     public void logContains(String thing) {
-        Assertions.assertTrue(dockerDetectResult.getDetectLogs().contains(thing), "Expected logs to contain '" + thing + "' but they did not. \n " + dockerDetectResult.getDetectLogs());
+        Assertions.assertTrue(dockerDetectResult.getDetectLogs().contains(thing), "Expected logs to contain '" + thing + "' but they did not");
     }
 
     public void logDoesNotContain(String thing) {


### PR DESCRIPTION
This PR removes BINARY_SCAN tool from the integration tests for Autonomous Scan. The BD instance which the build machine was using gave an error while uploading the binary zip file resulting in the tests to fail. 
