### PR TITLE
Remove intermediate Go versions from the list of tested versions

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/battery/docker/GoModTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/GoModTest.java
@@ -27,11 +27,6 @@ public class GoModTest {
 
     private static final String[] GO_VERSIONS_TO_TEST = new String[] {
         "1.16.15",
-        "1.17.13",
-        "1.18.10",
-        "1.19.12",
-        "1.20.4",
-        "1.21.9",
         "1.22.2"
     };
 


### PR DESCRIPTION
Remove intermediate Go versions from the list of tested versions to reduce the number of BD requests

# Description

This is to help with build times and build failures that have been happening lately.
I ran a comprehensive build from this branch and it passed.
**Update:** I ran another build, and unfortunately it failed, so we'll likely need additional or different changes.