### PR TITLE
Disable autonomous scan docker tests

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
@@ -18,7 +18,7 @@ public class AutonomousScanTests {
 
     public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
 
-    @Test
+//    @Test
     void autonomousScanModeOFFLINETest() throws Exception {
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("autonomous-scan-mode-test-1", "detect-9.8.0:1.0.1")) {
             test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("Detect-9.8.0.dockerfile"));
@@ -39,7 +39,7 @@ public class AutonomousScanTests {
         }
     }
 
-    @Test
+//    @Test
     void autonomousScanModeONLINETest() throws Exception {
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("autonomous-scan-mode-test-3", "autonomous-test:1.0.0")) {
 

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
@@ -39,7 +39,7 @@ public class AutonomousScanTests {
         }
     }
 
-//    @Test
+    @Test
     void autonomousScanModeONLINETest() throws Exception {
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("autonomous-scan-mode-test-3", "autonomous-test:1.0.0")) {
 

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/integration/DetectOnDetectTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/integration/DetectOnDetectTest.java
@@ -140,7 +140,7 @@ public class DetectOnDetectTest {
         }
     }
 
-    @Test
+//    @Test
     public void testRunWithAutonomousEnabled() throws Exception {
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("autonomous-scan-test", "detect-9.8.0:1.0.0")) {
             test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("Detect-9.8.0.dockerfile"));


### PR DESCRIPTION
Disable autonomous scan docker tests temporarily from master to unblock CF tasks.
These 2 test failures can be debugged by enabling them on a separate branch.