### PR TITLE
restructure multipart upload release note

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -4,8 +4,8 @@
 
 ### New features
 
-* [solution_name] is now capable of handling binary scans greater than 5 GB. When a file greater than this size is submitted [solution_name] will submit the file in 5 MB pieces until the entire file has been submitted. 
-Note: this feature requires [blackduck_product_name] 2024.7.0 or later.
+* [solution_name] now supports binary scanning of files up to 100GB via a chunking method employed during upload.    
+    <note type="note">This feature requires [blackduck_product_name] 2024.7.0 or later.</note>
 
 ### Changed features
 


### PR DESCRIPTION
I was a little too aggressive on the merge of the multipart upload. This updates the release notes to match the review comments.