### PR TITLE
Improve error message when sending large files to old servers

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
@@ -73,7 +73,7 @@ public class BinaryUploadOperation {
         if (status.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
             // This is a special case until we support only 2024.7 and later BlackDuck's that have
             // the multipart upload endpoint.
-            exception = new IntegrationException("File exceeds the per file upload limit of 5 GB.");
+            exception = new IntegrationException("Submitted file exceeds the file size upload limit.");
         } else if (status.getException().isPresent()) {
             exception = status.getException().get();      
         }

--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +70,11 @@ public class BinaryUploadOperation {
         
         IntegrationException exception = null;
         
-        if (status.getException().isPresent()) {
+        if (status.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            // This is a special case until we support only 2024.7 and later BlackDuck's that have
+            // the multipart upload endpoint.
+            exception = new IntegrationException("File exceeds the per file upload limit of 5 GB.");
+        } else if (status.getException().isPresent()) {
             exception = status.getException().get();      
         }
         


### PR DESCRIPTION
When a large file is sent to an old BD server we try to split it into pieces. This can't be done as the older server does not have the new endpoint to receive these pieces. We should fail like before but print a better error message.