### PR TITLE
Add jcenter to list of repositories so magpie library can be located (9.9.z)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,10 @@ subprojects {
 }
 
 allprojects {
+    repositories {
+        maven { url "${internalRepoHost}/artifactory/jcenter" }
+    }
+
     dependencies {
         implementation "com.google.guava:guava:32.1.2-jre"
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -27,6 +27,12 @@ dependencyManagement {
     }
 }
 
+final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
+
+repositories {
+    maven { url "${internalRepoHost}/artifactory/jcenter" }
+}
+
 dependencies {
     implementation "org.freemarker:freemarker:2.3.31"
     implementation("com.synopsys.integration:common-gradle-plugin:${managedCgpVersion}") {


### PR DESCRIPTION
# Description

Add jcenter to list of repositories so magpie library can be located for branch 9.9.z
This change can be reverted once we have a more permanent solution.