### PR TITLE
Restore old binary upload support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ dependencies {
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.10'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'com.synopsys.integration:blackduck-upload-common:1.0.0'
+    implementation 'com.synopsys.integration:blackduck-upload-common:1.0.1'
     implementation 'com.synopsys:method-analyzer-core:0.2.9'
     implementation "${locatorGroup}:${locatorModule}:1.1.13"
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -48,6 +48,7 @@ import com.synopsys.integration.blackduck.bdio2.util.Bdio2Factory;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationService;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationWaitResult;
+import com.synopsys.integration.blackduck.codelocation.binaryscanner.BinaryScanBatchOutput;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.ScanBatch;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.ScanBatchRunner;
 import com.synopsys.integration.blackduck.codelocation.signaturescanner.command.ScanCommandOutput;
@@ -1217,6 +1218,14 @@ public class OperationRunner {
 
     public void publishImpactSuccess() {
         statusEventPublisher.publishStatusSummary(Status.forTool(DetectTool.IMPACT_ANALYSIS, StatusType.SUCCESS));
+    }
+    
+    public CodeLocationCreationData<BinaryScanBatchOutput> uploadLegacyBinaryScanFile(File binaryUpload, NameVersion projectNameVersion, BlackDuckRunData blackDuckRunData)
+        throws OperationException {
+        return auditLog.namedPublic("Binary Upload", "Binary",
+            () -> new BinaryUploadOperation(statusEventPublisher)
+                .uploadLegacyBinaryScanFile(binaryUpload, blackDuckRunData.getBlackDuckServicesFactory().createBinaryScanUploadService(), codeLocationNameManager, projectNameVersion)
+        );
     }
 
     public BinaryUploadStatus uploadBinaryScanFile(File binaryUpload, NameVersion projectNameVersion, BlackDuckRunData blackDuckRunData)

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/BinaryScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/BinaryScanStepRunner.java
@@ -11,6 +11,8 @@ import org.slf4j.LoggerFactory;
 
 import com.synopsys.blackduck.upload.rest.model.response.BinaryFinishResponseContent;
 import com.synopsys.blackduck.upload.rest.status.BinaryUploadStatus;
+import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
+import com.synopsys.integration.blackduck.codelocation.binaryscanner.BinaryScanBatchOutput;
 import com.synopsys.integration.detect.lifecycle.OperationException;
 import com.synopsys.integration.detect.lifecycle.run.data.BlackDuckRunData;
 import com.synopsys.integration.detect.lifecycle.run.data.DockerTargetData;
@@ -38,6 +40,21 @@ public class BinaryScanStepRunner {
         if (binaryScanFile.isPresent()) {
             BinaryUploadStatus status = operationRunner.uploadBinaryScanFile(binaryScanFile.get(), projectNameVersion, blackDuckRunData);
             return extractBinaryScanId(status);
+        } else {
+            return Optional.empty();
+        }
+    }
+    
+    public Optional<CodeLocationCreationData<BinaryScanBatchOutput>> runLegacyBinaryScan(
+        DockerTargetData dockerTargetData,
+        NameVersion projectNameVersion,
+        BlackDuckRunData blackDuckRunData,
+        Set<String> binaryTargets
+    )
+        throws OperationException {
+        Optional<File> binaryScanFile = determineBinaryScanFileTarget(dockerTargetData, binaryTargets);
+        if (binaryScanFile.isPresent()) {
+            return Optional.of(operationRunner.uploadLegacyBinaryScanFile(binaryScanFile.get(), projectNameVersion, blackDuckRunData));
         } else {
             return Optional.empty();
         }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -15,9 +15,11 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
 import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
+import com.synopsys.integration.blackduck.codelocation.binaryscanner.BinaryScanBatchOutput;
 import com.synopsys.integration.blackduck.codelocation.upload.UploadOutput;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.blackduck.service.model.ProjectVersionWrapper;
+import com.synopsys.integration.blackduck.version.BlackDuckVersion;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detect.lifecycle.OperationException;
 import com.synopsys.integration.detect.lifecycle.run.data.BlackDuckRunData;
@@ -47,6 +49,7 @@ public class IntelligentModeStepRunner {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final StepHelper stepHelper;
     private final Gson gson;
+    private static final BlackDuckVersion MIN_MULTIPART_BINARY_VERSION = new BlackDuckVersion(2024, 7, 0);
 
     public IntelligentModeStepRunner(OperationRunner operationRunner, StepHelper stepHelper, Gson gson) {
         this.operationRunner = operationRunner;
@@ -125,10 +128,22 @@ public class IntelligentModeStepRunner {
 
         stepHelper.runToolIfIncluded(DetectTool.BINARY_SCAN, "Binary Scanner", () -> {
             BinaryScanStepRunner binaryScanStepRunner = new BinaryScanStepRunner(operationRunner);
-            Optional<String> scanId = binaryScanStepRunner.runBinaryScan(dockerTargetData, projectNameVersion, blackDuckRunData, binaryTargets);
 
-            if (scanId.isPresent()) {
-                scanIdsToWaitFor.add(scanId.get());
+            if (isMultipartUploadPossible(blackDuckRunData)) {
+                Optional<String> scanId = 
+                        binaryScanStepRunner.runBinaryScan(dockerTargetData, projectNameVersion, blackDuckRunData, binaryTargets);
+
+                if (scanId.isPresent()) {
+                    scanIdsToWaitFor.add(scanId.get());
+                }
+            } else {
+                Optional<CodeLocationCreationData<BinaryScanBatchOutput>> codeLocationData = 
+                        binaryScanStepRunner.runLegacyBinaryScan(dockerTargetData, projectNameVersion, blackDuckRunData, binaryTargets);
+
+                if (codeLocationData.isPresent()) {
+                    codeLocationAccumulator.addWaitableCodeLocations(codeLocationData.get());
+                    mustWaitAtBomSummaryLevel.set(true);
+                }
             }
         });
 
@@ -342,5 +357,10 @@ public class IntelligentModeStepRunner {
             operationRunner.publishReport(new ReportDetectResult("Notices Report", noticesFile.getCanonicalPath()));
 
         }
+    }
+    
+    private boolean isMultipartUploadPossible(BlackDuckRunData blackDuckRunData) {
+        Optional<BlackDuckVersion> blackDuckVersion = blackDuckRunData.getBlackDuckServerVersion();
+        return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_MULTIPART_BINARY_VERSION);
     }
 }

--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +14,14 @@ import com.synopsys.blackduck.upload.client.model.BinaryScanRequestData;
 import com.synopsys.blackduck.upload.client.uploaders.BinaryUploader;
 import com.synopsys.blackduck.upload.client.uploaders.UploaderFactory;
 import com.synopsys.blackduck.upload.rest.status.BinaryUploadStatus;
+import com.synopsys.integration.blackduck.codelocation.CodeLocationCreationData;
+import com.synopsys.integration.blackduck.codelocation.Result;
+import com.synopsys.integration.blackduck.codelocation.binaryscanner.BinaryScan;
+import com.synopsys.integration.blackduck.codelocation.binaryscanner.BinaryScanBatch;
+import com.synopsys.integration.blackduck.codelocation.binaryscanner.BinaryScanBatchOutput;
+import com.synopsys.integration.blackduck.codelocation.binaryscanner.BinaryScanOutput;
+import com.synopsys.integration.blackduck.codelocation.binaryscanner.BinaryScanUploadService;
+import com.synopsys.integration.blackduck.exception.BlackDuckIntegrationException;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
 import com.synopsys.integration.detect.configuration.enumeration.ExitCodeType;
 import com.synopsys.integration.detect.lifecycle.run.data.BlackDuckRunData;
@@ -97,4 +106,88 @@ public class BinaryUploadOperation {
 
         return uploadFactory.createBinaryUploader("/api/uploads", binaryData);
     }
+    
+    public CodeLocationCreationData<BinaryScanBatchOutput> uploadLegacyBinaryScanFile(
+            File binaryScanFile,
+            BinaryScanUploadService binaryScanUploadService,
+            CodeLocationNameManager codeLocationNameManager,
+            NameVersion projectNameVersion
+        )
+            throws DetectUserFriendlyException {
+            String codeLocationName = codeLocationNameManager.createBinaryScanCodeLocationName(
+                binaryScanFile,
+                projectNameVersion.getName(),
+                projectNameVersion.getVersion()
+            );
+            try {
+                logger.info("Preparing to upload binary scan file: " + binaryScanFile.getAbsolutePath());
+                BinaryScan binaryScan = new BinaryScan(binaryScanFile, projectNameVersion.getName(), projectNameVersion.getVersion(), codeLocationName);
+                BinaryScanBatch binaryScanBatch = new BinaryScanBatch(binaryScan);
+                CodeLocationCreationData<BinaryScanBatchOutput> codeLocationCreationData = binaryScanUploadService.uploadBinaryScan(binaryScanBatch);
+
+                BinaryScanBatchOutput binaryScanBatchOutput = codeLocationCreationData.getOutput();
+                // The throwExceptionForError() in BinaryScanBatchOutput has a bug, so doing that work here
+                throwExceptionForError(binaryScanBatchOutput);
+
+                logger.info("Successfully uploaded binary scan file: " + binaryScanFile.getAbsolutePath());
+                statusEventPublisher.publishStatusSummary(new Status(STATUS_KEY, StatusType.SUCCESS));
+                return codeLocationCreationData;
+            } catch (IntegrationException e) {
+                statusEventPublisher.publishStatusSummary(new Status(STATUS_KEY, StatusType.FAILURE));
+                throw new DetectUserFriendlyException("Failed to upload binary scan file.", e, ExitCodeType.FAILURE_BLACKDUCK_FEATURE_ERROR);
+            }
+        }
+
+        public CodeLocationCreationData<BinaryScanBatchOutput> uploadBinaryScanFiles(
+            BinaryScanBatch binaryScanBatch,
+            BinaryScanUploadService binaryScanUploadService,
+            NameVersion projectNameVersion
+        )
+            throws DetectUserFriendlyException {
+            try {
+                CodeLocationCreationData<BinaryScanBatchOutput> codeLocationCreationData = binaryScanUploadService.uploadBinaryScan(binaryScanBatch);
+
+                BinaryScanBatchOutput binaryScanBatchOutput = codeLocationCreationData.getOutput();
+                // The throwExceptionForError() in BinaryScanBatchOutput has a bug, so doing that work here
+                throwExceptionForError(binaryScanBatchOutput);
+                statusEventPublisher.publishStatusSummary(new Status(STATUS_KEY, StatusType.SUCCESS));
+                return codeLocationCreationData;
+            } catch (IntegrationException e) {
+                statusEventPublisher.publishStatusSummary(new Status(STATUS_KEY, StatusType.FAILURE));
+                throw new DetectUserFriendlyException("Failed to upload binary scan file.", e, ExitCodeType.FAILURE_BLACKDUCK_FEATURE_ERROR);
+            }
+        }
+
+        // BinaryScanBatchOutput used to do this, but our understanding of what needs to happen has been
+        // changing rapidly. Once we're confident we know what it should do, it should presumably move back there.
+        private void throwExceptionForError(BinaryScanBatchOutput binaryScanBatchOutput) throws BlackDuckIntegrationException {
+            for (BinaryScanOutput binaryScanOutput : binaryScanBatchOutput) {
+                if (binaryScanOutput.getResult() == Result.FAILURE) {
+                    // Black Duck responses are single-line message (loggable as-is), but nginx Bad Gateway responses are
+                    // multi-line html with the message embedded (that mess up the log).
+                    // cleanResponse() attempts to produce something reasonable to log in either case
+                    String cleanedBlackDuckResponse = cleanResponse(binaryScanOutput.getResponse());
+                    String uploadErrorMessage = String.format(
+                        "Error when uploading binary scan: %s (Black Duck response: %s)",
+                        binaryScanOutput.getErrorMessage().orElse(binaryScanOutput.getStatusMessage()),
+                        cleanedBlackDuckResponse
+                    );
+                    logger.error(uploadErrorMessage);
+                    throw new BlackDuckIntegrationException(uploadErrorMessage);
+                }
+            }
+        }
+
+        private String cleanResponse(String response) {
+            if (StringUtils.isBlank(response)) {
+                return "";
+            }
+            String lengthLimitedResponse = StringUtils.substring(response, 0, 200);
+            if (!lengthLimitedResponse.equals(response)) {
+                lengthLimitedResponse = lengthLimitedResponse + "...";
+            }
+            String[] searchList = { "\n", "\r" };
+            String[] replacementList = { " ", "" };
+            return StringUtils.replaceEachRepeatedly(lengthLimitedResponse, searchList, replacementList);
+        }
 }


### PR DESCRIPTION
We need to fully support older BlackDucks when it comes to uploading binary files. This work restores the old code path so things work as before for older servers. There is really no new code except in IntelligentModeStepRunner that checks the version and routes calls to the correct upload path. I named the older path Legacy so it would be easy to remove that code if we ever want to.

Note: this also updates to the latest upload library that should restore support for Java 8.