### PR TITLE
Pick up version 1.0.2 of the upload library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ dependencies {
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.10'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'com.synopsys.integration:blackduck-upload-common:1.0.1'
+    implementation 'com.synopsys.integration:blackduck-upload-common:1.0.2'
     implementation 'com.synopsys:method-analyzer-core:0.2.9'
     implementation "${locatorGroup}:${locatorModule}:1.1.13"
 


### PR DESCRIPTION
This new version of the library improves Java 8 compatibility. 