### PR TITLE
Fix missing certificate logic for new signature scanner installer

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,4 +1,4 @@
 // Updating blackduck-common version here might necessitate an update to integration-common version in src/main/resources/create-gradle-airgap-script.ftl \
 // to ensure the integration-common versions in both airgap and non-airgap are the same. 
-gradle.ext.blackDuckCommonVersion='replace-me-with-appropriate-blackduck-common-version'
+gradle.ext.blackDuckCommonVersion='66.2.26'
 gradle.ext.springBootVersion='2.7.12'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,4 +1,4 @@
 // Updating blackduck-common version here might necessitate an update to integration-common version in src/main/resources/create-gradle-airgap-script.ftl \
 // to ensure the integration-common versions in both airgap and non-airgap are the same. 
-gradle.ext.blackDuckCommonVersion='66.2.23'
+gradle.ext.blackDuckCommonVersion='replace-me-with-appropriate-blackduck-common-version'
 gradle.ext.springBootVersion='2.7.12'

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchRunnerWithBlackDuck.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchRunnerWithBlackDuck.java
@@ -48,7 +48,7 @@ public class CreateScanBatchRunnerWithBlackDuck {
 
         ScannerInstaller scannerInstallerVariant;
 
-        if (shouldUseNewApiScannerInstaller(blackDuckVersion)) {
+        if (shouldUseToolsApiScannerInstaller(blackDuckVersion)) {
             logger.trace("Using new Scan CLI download API.");
             scannerInstallerVariant = new ToolsApiScannerInstaller(
                     slf4jIntLogger,
@@ -78,7 +78,7 @@ public class CreateScanBatchRunnerWithBlackDuck {
         return ScanBatchRunner.createComplete(intEnvironmentVariables, scanPathsUtility, scanCommandRunner, scannerInstallerVariant);
     }
 
-    private boolean shouldUseNewApiScannerInstaller(Optional<BlackDuckVersion> blackDuckVersion) {
+    private boolean shouldUseToolsApiScannerInstaller(Optional<BlackDuckVersion> blackDuckVersion) {
         return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_BLACK_DUCK_VERSION);
     }
 

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchRunnerWithBlackDuck.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchRunnerWithBlackDuck.java
@@ -55,6 +55,7 @@ public class CreateScanBatchRunnerWithBlackDuck {
                     blackDuckHttpClient,
                     cleanupZipExpander,
                     scanPathsUtility,
+                    keyStoreHelper,
                     blackDuckServerConfig.getBlackDuckUrl(),
                     operatingSystemType,
                     installDirectory


### PR DESCRIPTION
Relates to IDETECT-4244, see comments under that ticket for original MR.

Before calling ToolsApiScannerInstaller, we pass in a class that represents the Java keystore that comes with the JRE inside the scan-cli ZIP. The installer will add the certificate for the BD server client has connected to so that the scan-cli can verify the server's identity.

See related blackduck-common MR that must be merged first: https://github.com/blackducksoftware/blackduck-common/pull/433