### PR TITLE
blackduck-common version bump (IDETECT-4344)

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,4 +1,4 @@
 // Updating blackduck-common version here might necessitate an update to integration-common version in src/main/resources/create-gradle-airgap-script.ftl \
 // to ensure the integration-common versions in both airgap and non-airgap are the same. 
-gradle.ext.blackDuckCommonVersion='66.2.26'
+gradle.ext.blackDuckCommonVersion='66.2.27'
 gradle.ext.springBootVersion='2.7.12'

--- a/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchRunnerWithBlackDuck.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/signaturescanner/operation/CreateScanBatchRunnerWithBlackDuck.java
@@ -49,7 +49,7 @@ public class CreateScanBatchRunnerWithBlackDuck {
         ScannerInstaller scannerInstallerVariant;
 
         if (shouldUseToolsApiScannerInstaller(blackDuckVersion)) {
-            logger.trace("Using new Scan CLI download API.");
+            logger.debug("Using Tools Scan CLI download API (new).");
             scannerInstallerVariant = new ToolsApiScannerInstaller(
                     slf4jIntLogger,
                     blackDuckHttpClient,
@@ -61,7 +61,7 @@ public class CreateScanBatchRunnerWithBlackDuck {
                     installDirectory
             );
         } else {
-            logger.trace("Using old Scan CLI download API.");
+            logger.debug("Using Zip Scan CLI download API (old).");
             scannerInstallerVariant = new ZipApiScannerInstaller(
                     slf4jIntLogger,
                     signatureScannerClient,


### PR DESCRIPTION
Must be merged after https://github.com/blackducksoftware/blackduck-common/pull/434

Fixes IDETECT-4344, pulls in changes in library that now will use the same version file we always have. 

Also updates a log statement to be TRACE level instead of DEBUG level. (_The log message indicates whether or not we are using the old or new download API. Originally this was kept at trace level for the sake of dev/qa debugging, but now I don't see why it shouldn't be in DEBUG mode since we have an entry for the API update in our release notes_)