### PR TITLE
Override change to force v1.2.13 for logback-* transitives and spring-boot-starter-logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ dependencies {
     implementation project(':detector')
 
     implementation 'ch.qos.logback:logback-classic:1.2.13'
+    implementation 'ch.qos.logback:logback-core:1.2.13'
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.10'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
@@ -192,11 +193,10 @@ dependencies {
         implementation('org.apache.cxf:cxf-rt-frontend-jaxrs:4.0.4') {
             because 'previous version has a vulnerability'
         }
-        implementation('ch.qos.logback:logback-core:1.2.13') {
+        implementation('ch.qos.logback:logback-classic:1.2.13') {
             because 'previous version has a vulnerability'
         }
-
-        implementation('ch.qos.logback:logback-classic:1.2.13') {
+        implementation('ch.qos.logback:logback-core:1.2.13') {
             because 'previous version has a vulnerability'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,6 @@ dependencies {
     implementation project(':detector')
 
     implementation 'ch.qos.logback:logback-classic:1.2.13'
-    implementation 'ch.qos.logback:logback-core:1.2.13'
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.10'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
@@ -191,9 +190,6 @@ dependencies {
             because 'previous version has a vulnerability'
         }
         implementation('org.apache.cxf:cxf-rt-frontend-jaxrs:4.0.4') {
-            because 'previous version has a vulnerability'
-        }
-        implementation('ch.qos.logback:logback-classic:1.2.13') {
             because 'previous version has a vulnerability'
         }
         implementation('ch.qos.logback:logback-core:1.2.13') {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         javaTargetCompatibility = 8
         javaSourceCompatibility = 8
     }
-
+    ext['logback.version'] = '1.2.13'
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript
 
     dependencies {
@@ -190,6 +190,13 @@ dependencies {
             because 'previous version has a vulnerability'
         }
         implementation('org.apache.cxf:cxf-rt-frontend-jaxrs:4.0.4') {
+            because 'previous version has a vulnerability'
+        }
+        implementation('ch.qos.logback:logback-core:1.2.13') {
+            because 'previous version has a vulnerability'
+        }
+
+        implementation('ch.qos.logback:logback-classic:1.2.13') {
             because 'previous version has a vulnerability'
         }
     }


### PR DESCRIPTION
# Description

Override change to force v1.2.13 for logback-* transitives and spring-boot-starter-logging

# Github Issues

IDETECT-4408
