### PR TITLE
Cp idetect 4433 doc partial

### DIFF
--- a/documentation/src/main/markdown/gettingstarted/gettinghelp.md
+++ b/documentation/src/main/markdown/gettingstarted/gettinghelp.md
@@ -6,7 +6,7 @@
 | ---- | ------------------- | ----------- | ----------- |
 | Help | --help | -h | Provides basic help information (including how to get more detailed help). |
 | Interactive | --interactive | -i | Guides you through configuring [company_name] [solution_name]. |
-| Diagnostic | --diagnostic | -d | Creates a zip file containing diagnostic information for support.  <br /> See also [Diagnostic Mode](../troubleshooting/diagnosticmode.md)|
+| Diagnostic | --diagnostic | -d | Creates a zip file containing diagnostic information for support.  <br /> See [Diagnostic Mode](../troubleshooting/diagnosticmode.md)|
 | hyaml | --helpyaml | -hyaml | To generate a configuration file template for setting properties. |
 
 Additional resources are available at [Synopsys Software Integrity Community](https://community.synopsys.com).

--- a/documentation/src/main/markdown/gettingstarted/gettinghelp.md
+++ b/documentation/src/main/markdown/gettingstarted/gettinghelp.md
@@ -6,7 +6,7 @@
 | ---- | ------------------- | ----------- | ----------- |
 | Help | --help | -h | Provides basic help information (including how to get more detailed help). |
 | Interactive | --interactive | -i | Guides you through configuring [company_name] [solution_name]. |
-| Diagnostic | --diagnostic | -d | Creates a zip file containing diagnostic information for support. |
+| Diagnostic | --diagnostic | -d | Creates a zip file containing diagnostic information for support.  <br /> See also [Diagnostic Mode](../troubleshooting/diagnosticmode.md)|
 | hyaml | --helpyaml | -hyaml | To generate a configuration file template for setting properties. |
 
 Additional resources are available at [Synopsys Software Integrity Community](https://community.synopsys.com).

--- a/documentation/src/main/markdown/troubleshooting/diagnosticmode.md
+++ b/documentation/src/main/markdown/troubleshooting/diagnosticmode.md
@@ -8,7 +8,7 @@ To enable diagnostic mode, add any one of the following to the command line:
 
 * -d
 * --diagnostic
-* [--detect.diagnostic](../properties/configuration/debug.md#diagnostic-mode)
+* [--detect.diagnostic=true](../properties/configuration/debug.md#diagnostic-mode)
 
 A diagnostic zip includes many files valuable for troubleshooting, such as:
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -513,7 +513,7 @@ public class DetectProperties {
                 )
                 .setInfo("Reduced Persistence", DetectPropertyFromVersion.VERSION_8_3_0)
                 .setHelp(
-                    "Use this value to control how unmatched files from signature scans are stored. For a full explanation, please refer to https://sig-product-docs.synopsys.com/bundle/bd-hub/page/ComponentDiscovery/about_reduced_persistence_signature_scanning.html")
+                    "Use this value to control how unmatched files from signature scans are stored. For a full explanation, please refer to <xref href=\"https://sig-product-docs.synopsys.com/bundle/bd-hub/page/ComponentDiscovery/about_reduced_persistence_signature_scanning.html\" scope=\"external\" outputclass=\"external\" format=\"html\" target=\"_blank\">about reduced persistence signature scanning.</xref>")
                 .setGroups(DetectGroup.SIGNATURE_SCANNER, DetectGroup.GLOBAL)
                 .build();
 
@@ -651,8 +651,7 @@ public class DetectProperties {
             .setInfo("Diagnostic Mode", DetectPropertyFromVersion.VERSION_6_5_0)
             .setHelp(
                 "When enabled, diagnostic mode collects files valuable for troubleshooting (logs, BDIO file, extraction files, reports, etc.), writes them to a zip file, and logs the path to the zip file.",
-                "See also https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/troubleshooting/diagnosticmode.html" 
-            )
+                "See <xref href=\"https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/troubleshooting/diagnosticmode.html\" scope=\"external\" format=\"html\" target=\"_blank\">for more Diagnostic Mode information.</xref>")
             .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
             .build(); 
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -651,7 +651,7 @@ public class DetectProperties {
             .setInfo("Diagnostic Mode", DetectPropertyFromVersion.VERSION_6_5_0)
             .setHelp(
                 "When enabled, diagnostic mode collects files valuable for troubleshooting (logs, BDIO file, extraction files, reports, etc.), writes them to a zip file, and logs the path to the zip file.",
-                "See <xref href=\"https://sig%2Dproduct%2Ddocs%2Esynopsys%2Ecom/bundle/integrations%2Ddetect/page/troubleshooting/diagnosticmode%2Ehtml\" scope=\"external\" format=\"html\" target=\"_blank\">for more Diagnostic Mode information.</xref>")
+                "See the following for more <xref href=\"https://sig%2Dproduct%2Ddocs%2Esynopsys%2Ecom/bundle/integrations%2Ddetect/page/troubleshooting/diagnosticmode%2Ehtml\" scope=\"external\" format=\"html\" target=\"_blank\">Diagnostic Mode information.</xref>")
             .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
             .build(); 
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -513,7 +513,7 @@ public class DetectProperties {
                 )
                 .setInfo("Reduced Persistence", DetectPropertyFromVersion.VERSION_8_3_0)
                 .setHelp(
-                    "Use this value to control how unmatched files from signature scans are stored. For a full explanation, please refer to <xref href=\"https://sig-product-docs.synopsys.com/bundle/bd-hub/page/ComponentDiscovery/about_reduced_persistence_signature_scanning.html\" scope=\"external\" outputclass=\"external\" format=\"html\" target=\"_blank\">about reduced persistence signature scanning.</xref>")
+                    "Use this value to control how unmatched files from signature scans are stored. For a full explanation, please refer to <xref href=\"https://sig%2Dproduct%2Ddocs%2Esynopsys%2Ecom/bundle/bd%2Dhub/page/ComponentDiscovery/about%5Freduced%5Fpersistence%5Fsignature%5Fscanning%2Ehtml\" scope=\"external\" outputclass=\"external\" format=\"html\" target=\"_blank\">about reduced persistence signature scanning.</xref>")
                 .setGroups(DetectGroup.SIGNATURE_SCANNER, DetectGroup.GLOBAL)
                 .build();
 
@@ -651,7 +651,7 @@ public class DetectProperties {
             .setInfo("Diagnostic Mode", DetectPropertyFromVersion.VERSION_6_5_0)
             .setHelp(
                 "When enabled, diagnostic mode collects files valuable for troubleshooting (logs, BDIO file, extraction files, reports, etc.), writes them to a zip file, and logs the path to the zip file.",
-                "See <xref href=\"https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/troubleshooting/diagnosticmode.html\" scope=\"external\" format=\"html\" target=\"_blank\">for more Diagnostic Mode information.</xref>")
+                "See <xref href=\"https://sig%2Dproduct%2Ddocs%2Esynopsys%2Ecom/bundle/integrations%2Ddetect/page/troubleshooting/diagnosticmode%2Ehtml\" scope=\"external\" format=\"html\" target=\"_blank\">for more Diagnostic Mode information.</xref>")
             .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
             .build(); 
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -881,7 +881,7 @@ public class DetectProperties {
             .setInfo("Gradle Configuration Types Excluded", DetectPropertyFromVersion.VERSION_7_10_0)
             .setHelp(
                 createTypeFilterHelpText("Gradle configuration types"),
-                "Including dependencies from unresolved Gradle configurations could lead to false positives. Dependency versions from an unresolved configuration may differ from a resolved one. See https://docs.gradle.org/8.2/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs"
+                "Including dependencies from unresolved Gradle configurations could lead to false positives. Dependency versions from an unresolved configuration may differ from a resolved one. See Gradle docs <xref href=\"https://docs%2Egradle%2Eorg/8%2E2/userguide/declaring%5Fdependencies%2Ehtml\" scope=\"external\" format=\"html\" target=\"_blank\">for more information.</xref>"
             )
             .setExample(GradleConfigurationType.UNRESOLVED.name())
             .setGroups(DetectGroup.GRADLE, DetectGroup.SOURCE_SCAN)

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -513,7 +513,7 @@ public class DetectProperties {
                 )
                 .setInfo("Reduced Persistence", DetectPropertyFromVersion.VERSION_8_3_0)
                 .setHelp(
-                    "Use this value to control how unmatched files from signature scans are stored. For a full explanation, please refer to <xref href=\"https://sig-product-docs.synopsys.com/bundle/bd-hub/page/ComponentDiscovery/about_reduced_persistence_signature_scanning.html\" scope=\"external\" outputclass=\"external\" format=\"html\" target=\"_blank\">about reduced persistence signature scanning.</xref>")
+                    "Use this value to control how unmatched files from signature scans are stored. For a full explanation, please refer to https://sig-product-docs.synopsys.com/bundle/bd-hub/page/ComponentDiscovery/about_reduced_persistence_signature_scanning.html")
                 .setGroups(DetectGroup.SIGNATURE_SCANNER, DetectGroup.GLOBAL)
                 .build();
 
@@ -650,9 +650,11 @@ public class DetectProperties {
         BooleanProperty.newBuilder("detect.diagnostic", false)
             .setInfo("Diagnostic Mode", DetectPropertyFromVersion.VERSION_6_5_0)
             .setHelp(
-                "When enabled, diagnostic mode collects files valuable for troubleshooting (logs, BDIO file, extraction files, reports, etc.), writes them to a zip file, and logs the path to the zip file.")
+                "When enabled, diagnostic mode collects files valuable for troubleshooting (logs, BDIO file, extraction files, reports, etc.), writes them to a zip file, and logs the path to the zip file.",
+                "See also https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/troubleshooting/diagnosticmode.html" 
+            )
             .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
-            .build();
+            .build(); 
 
     public static final BooleanProperty DETECT_IGNORE_CONNECTION_FAILURES =
         BooleanProperty.newBuilder("detect.ignore.connection.failures", false)
@@ -1758,7 +1760,7 @@ public class DetectProperties {
             .setInfo("Logging Level", DetectPropertyFromVersion.VERSION_5_3_0)
             .setHelp(
                 "The logging level of Detect.",
-                "To keep the log file size manageable, use INFO level logging for normal use. Use DEBUG or TRACE for troubleshooting.<p/>" +
+                "To keep the log file size manageable, use INFO level logging for normal use and DEBUG or TRACE for troubleshooting.<p/>" +
                     "Detect logging uses Spring Boot logging, which uses Logback (https://logback.qos.ch). " +
                     "The format of this property name is <i>logging.level.{package}[.{class}]</i>. " +
                     "The property name shown above specifies package <i>com.synopsys.integration</i> because that is the name of Detect's top-level package. " +
@@ -1767,7 +1769,7 @@ public class DetectProperties {
                     "However, you can use this property to set the logging level for some of the non-Synopsys libraries that Detect uses by using the appropriate package name. " +
                     "For example, <i>logging.level.org.apache.http=TRACE</i> sets the logging level to TRACE for the Apache HTTP client library. " +
                     "<p/>" +
-                    "For log message format, Detect uses a default value of <i>%d{yyyy-MM-dd HH:mm:ss z} ${LOG_LEVEL_PATTERN:%-6p}[%thread] %clr(---){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}</i>. "
+                    "For log message format, a default value of <i>%d{yyyy-MM-dd HH:mm:ss z} ${LOG_LEVEL_PATTERN:%-6p}[%thread] %clr(---){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}</i> is used. "
                     +
                     "You can change your log message format by setting the Spring Boot <i>logging.pattern.console</i> property to a different pattern. " +
                     "<p/>" +


### PR DESCRIPTION
This includes updates to gettinghelp.md and diagnosticmode.md for 9.9.0 and a partial change for the properties.
Properties table updates include a link to the diagnostic mode page and some typo/url fixes.
Note that better properties updates will come in 9.10.0 so IDETECT-4433 will stay open for 9.10.0