### PR TITLE
Memoize BD data in BlackDuckAssertions to improve test runtime

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/workflow/blackduck/report/RiskReportServiceTestIT.java
+++ b/src/test/java/com/synopsys/integration/detect/workflow/blackduck/report/RiskReportServiceTestIT.java
@@ -44,7 +44,7 @@ public class RiskReportServiceTestIT {
         BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
         ReportService reportService = blackDuckTestConnection.createReportService();
 
-        ProjectVersionWrapper projectVersionWrapper = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, PROJECT_VERSION_NAME).retrieveProjectVersionWrapper();
+        ProjectVersionWrapper projectVersionWrapper = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, PROJECT_VERSION_NAME).getProjectVersionWrapper();
 
         File folder = folderForReport.toFile();
         File pdfFile = reportService.createReportPdfFile(folder, projectVersionWrapper.getProjectView(), projectVersionWrapper.getProjectVersionView());
@@ -58,7 +58,7 @@ public class RiskReportServiceTestIT {
         BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
         ReportService reportService = blackDuckTestConnection.createReportService();
 
-        ProjectVersionWrapper projectVersionWrapper = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, PROJECT_VERSION_NAME).retrieveProjectVersionWrapper();
+        ProjectVersionWrapper projectVersionWrapper = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, PROJECT_VERSION_NAME).getProjectVersionWrapper();
 
         File noticeReportFile = reportService.createNoticesReportFile(
             folderForReport.toFile(),
@@ -81,7 +81,7 @@ public class RiskReportServiceTestIT {
         final String localPathForPdfReport = "/Users/ekerwin/Documents/working/riskreport_pdf";
         final String localPathForNoticesReport = "/Users/ekerwin/Documents/working/notices";
 
-        ProjectVersionWrapper projectVersionWrapper = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, PROJECT_VERSION_NAME).retrieveProjectVersionWrapper();
+        ProjectVersionWrapper projectVersionWrapper = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, PROJECT_VERSION_NAME).getProjectVersionWrapper();
 
         File pdfReportFolder = new File(localPathForPdfReport);
         File noticesReportFolder = new File(localPathForNoticesReport);


### PR DESCRIPTION
# Description

Memoize BD data in BlackDuckAssertions to improve test runtime.
I tested this change on Jenkins and due to the general variability of test run time it is not clear how much of an improvement this is.
I suspect we are shaving off up to a minute from the overall test run time.
