### PR TITLE
Improve package json extraction

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectable/util/SemVerComparator.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectable/util/SemVerComparator.java
@@ -1,0 +1,31 @@
+package com.synopsys.integration.detectable.detectable.util;
+
+import java.util.Comparator;
+
+public class SemVerComparator implements Comparator<String> {
+    @Override
+    public int compare(String v1, String v2) {
+        // Split each version string into parts
+        String[] v1Parts = v1.split("\\.");
+        String[] v2Parts = v2.split("\\.");
+
+        // Determine the maximum length to iterate over
+        int maxLength = Math.max(v1Parts.length, v2Parts.length);
+
+        // Compare each part until we know which string is smallest
+        for (int i = 0; i < maxLength; i++) {
+            int part1 = (i < v1Parts.length) ? Integer.parseInt(v1Parts[i]) : 0;
+            int part2 = (i < v2Parts.length) ? Integer.parseInt(v2Parts[i]) : 0;
+
+            int comparison = Integer.compare(part1, part2);
+
+            // If the parts are not equal, return the comparison result
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+
+        // If all parts are equal, return 0
+        return 0;
+    }
+}

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/NpmPackageJsonParseDetectable.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/NpmPackageJsonParseDetectable.java
@@ -1,8 +1,6 @@
 package com.synopsys.integration.detectable.detectables.npm.packagejson;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 
 import com.synopsys.integration.common.util.finder.FileFinder;
 import com.synopsys.integration.detectable.Detectable;

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -77,9 +79,35 @@ public class PackageJsonExtractor {
             .collect(Collectors.toList());
     }
 
+//    private Dependency entryToDependency(String key, String value) {
+//        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, key, value);
+//        return new Dependency(externalId);
+//    }
+    
     private Dependency entryToDependency(String key, String value) {
-        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, key, value);
+        // Extract the lowest version from the value
+        String version = extractLowestVersion(value);
+        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, key, version);
         return new Dependency(externalId);
+    }
+
+    private String extractLowestVersion(String value) {
+        // If the value starts with "http", "file", or is "latest", return the value as is.
+        if (value.startsWith("http") || value.startsWith("file") || value.equals("latest")) {
+            return value;
+        }
+
+        // Split the value into parts by spaces, "||", or "-".
+        String[] parts = value.split("\\s+|\\|\\||-");
+        String lowestVersion = Arrays.stream(parts)
+            .map(part -> part.replaceAll("x|\\*", "0")) // Replace "x" or "*" with "0"
+            .map(part -> part.replaceAll("[^0-9.]", "")) // Remove all non-digit and non-period characters
+            .filter(part -> part.matches("\\d+\\.\\d+\\.\\d+")) // Filter out parts that don't match the version pattern
+            // TODO need to read doc, test the below two lines
+            .min(Comparator.naturalOrder()) // Find the smallest part
+            .orElse(value); // If no part matches the version pattern, return the original value
+
+        return lowestVersion;
     }
 
 }

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
@@ -80,7 +80,6 @@ public class PackageJsonExtractor {
     }
     
     private Dependency entryToDependency(String key, String value) {
-        // Extract the lowest version from the value
         String version = extractLowestVersion(value);
         ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, key, version);
         return new Dependency(externalId);
@@ -96,7 +95,7 @@ public class PackageJsonExtractor {
             .map(part -> part.replaceAll("[>=<~^]", ""))
             // Filter out parts that don't match the version pattern
             .filter(part -> part.matches("\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+|\\d+"))
-            // Use the compareVersions method to find smallest version in each value
+            // Use compareSemVerVersions method to find smallest version in each value
             .min(this::compareSemVerVersions)
             // If no part matches the version pattern, return the original value.
             .orElse(value);

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,6 +21,7 @@ import com.synopsys.integration.bdio.model.externalid.ExternalId;
 import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
 import com.synopsys.integration.detectable.detectable.codelocation.CodeLocation;
 import com.synopsys.integration.detectable.detectable.util.EnumListFilter;
+import com.synopsys.integration.detectable.detectable.util.SemVerComparator;
 import com.synopsys.integration.detectable.detectables.npm.NpmDependencyType;
 import com.synopsys.integration.detectable.extraction.Extraction;
 
@@ -86,6 +86,8 @@ public class PackageJsonExtractor {
     }
 
     private String extractLowestVersion(String value) {
+        SemVerComparator semVerComparator = new SemVerComparator();
+        
         // Split the value into parts by spaces, "||", or "-".
         String[] parts = value.split("\\s+|\\|\\||-");
         String lowestVersion = Arrays.stream(parts)
@@ -96,36 +98,10 @@ public class PackageJsonExtractor {
             // Filter out parts that don't match the version pattern
             .filter(part -> part.matches("\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+|\\d+"))
             // Use compareSemVerVersions method to find smallest version in each value
-            .min(this::compareSemVerVersions)
+            .min(semVerComparator)
             // If no part matches the version pattern, return the original value.
             .orElse(value);
 
         return lowestVersion;
     }
-    
-    private int compareSemVerVersions(String v1, String v2) {
-        // Split each version string into parts
-        String[] v1Parts = v1.split("\\.");
-        String[] v2Parts = v2.split("\\.");
-
-        // Determine the maximum length to iterate over
-        int maxLength = Math.max(v1Parts.length, v2Parts.length);
-
-        // Compare each part until we know which string is smallest
-        for (int i = 0; i < maxLength; i++) {
-            int part1 = (i < v1Parts.length) ? Integer.parseInt(v1Parts[i]) : 0;
-            int part2 = (i < v2Parts.length) ? Integer.parseInt(v2Parts[i]) : 0;
-
-            int comparison = Integer.compare(part1, part2);
-
-            // If the parts are not equal, return the comparison result
-            if (comparison != 0) {
-                return comparison;
-            }
-        }
-
-        // If all parts are equal, return 0
-        return 0;
-    }
-
 }

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
@@ -2,8 +2,6 @@ package com.synopsys.integration.detectable.detectables.npm.packagejson.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.HashMap;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +17,6 @@ import com.synopsys.integration.detectable.detectable.util.EnumListFilter;
 import com.synopsys.integration.detectable.detectables.npm.NpmDependencyType;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.CombinedPackageJson;
 import com.synopsys.integration.detectable.detectables.npm.packagejson.PackageJsonExtractor;
-import com.synopsys.integration.detectable.detectables.npm.packagejson.model.PackageJson;
 import com.synopsys.integration.detectable.extraction.Extraction;
 import com.synopsys.integration.detectable.util.graph.GraphAssert;
 

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
@@ -76,6 +76,41 @@ class PackageJsonExtractorTest {
         graphAssert.hasRootDependency(testDevDep2);
         graphAssert.hasRootSize(4);
     }
+    
+    @Test
+    void extractWithNonNumericalCharacters() {
+        CombinedPackageJson packageJson = new CombinedPackageJson();
+        packageJson.getDependencies().put("foo", "1.0.0 - 2.9999.9999");
+        packageJson.getDependencies().put("bar", ">=1.0.2 <2.1.2");
+        packageJson.getDependencies().put("qux", "<1.0.0 || >=2.3.1 <2.4.5 || >=2.5.2 <3.0.0");
+        packageJson.getDependencies().put("asd", "http://asdf.com/asdf.tar.gz");
+        packageJson.getDependencies().put("til", "~1.2");
+        packageJson.getDependencies().put("thr", "3.3.x");
+        packageJson.getDependencies().put("myproject", "1.0.0-SNAPSHOT");
+        
+        Extraction extraction = createExtractor(NpmDependencyType.PEER).extract(packageJson);
+        CodeLocation codeLocation = extraction.getCodeLocations().get(0);
+        DependencyGraph dependencyGraph = codeLocation.getDependencyGraph();
+        
+        ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+        ExternalId testCharDep1 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "foo", "1.0.0");
+        ExternalId testCharDep2 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "bar", "1.0.2");
+        ExternalId testCharDep3 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "qux", "1.0.0");
+        ExternalId testCharDep4 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "asd", "http://asdf.com/asdf.tar.gz");
+        ExternalId testCharDep5 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "til", "1.2");
+        ExternalId testCharDep6 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "thr", "3.3.0");
+        ExternalId testCharDep7 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "myproject", "1.0.0");        
+        
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, dependencyGraph);
+        graphAssert.hasRootDependency(testCharDep1);
+        graphAssert.hasRootDependency(testCharDep2);
+        graphAssert.hasRootDependency(testCharDep3);
+        graphAssert.hasRootDependency(testCharDep4);
+        graphAssert.hasRootDependency(testCharDep5);
+        graphAssert.hasRootDependency(testCharDep6);
+        graphAssert.hasRootDependency(testCharDep7);
+        graphAssert.hasRootSize(7);
+    }
 
     private CombinedPackageJson createPackageJson() {
         CombinedPackageJson combinedPackageJson = new CombinedPackageJson();

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -1,24 +1,7 @@
 # Current Release notes
 
-## Version 9.9.0
+## Version 10.0.0
 
 ### New features
 
-* [solution_name] now supports binary scanning of large files via a chunking method employed during upload. Testing has confirmed successful upload of 20GB files.
-    <note type="note">This feature requires [blackduck_product_name] 2024.7.0 or later.</note>
-
-### Changed features
-
-* When running [company_name] [solution_name] against a [blackduck_product_name] instance of version 2024.7.0 or later, the Scan CLI tool download will use a new format for the URL. 
-	* Current URL format: https://<BlackDuck_Instance>/download/scan.cli-macosx.zip
-	* New URL format: https://<BlackDuck_Instance>/api/tools/scan.cli.zip/versions/latest/platforms/macosx
-
-### Resolved issues
-
-* (IDETECT-4408) - Remediated vulnerability in Logback-Core library to resolve high severity issues [CVE-2023-6378](https://nvd.nist.gov/vuln/detail/CVE-2023-6378) and [CVE-2023-6481](https://nvd.nist.gov/vuln/detail/CVE-2023-6481).
-
-### Dependency updates
-
-* Component Location Analysis version updated to 1.1.13
-* Project Inspector version updated to 2024.9.0
-* Logback Core version updated to 1.2.13
+* The npm package.json detector now performs additional parsing when attempting to find dependency versions. This can result in additional matches since versions like ^1.2.0 will now be extracted as 1.2.0 instead of as the raw ^1.2.0 string. In the case where multiple versions for a dependency are discovered, the earliest version will be used.

--- a/documentation/src/main/markdown/previousreleasenotes.md
+++ b/documentation/src/main/markdown/previousreleasenotes.md
@@ -1,6 +1,29 @@
 <!-- Check the support matrix to determine supported, non-current major version releases -->
 # Release notes for previous supported versions
 
+## Version 9.9.0
+
+### New features
+
+* [solution_name] now supports binary scanning of large files via a chunking method employed during upload. Testing has confirmed successful upload of 20GB files.
+    <note type="note">This feature requires [blackduck_product_name] 2024.7.0 or later.</note>
+
+### Changed features
+
+* When running [company_name] [solution_name] against a [blackduck_product_name] instance of version 2024.7.0 or later, the Scan CLI tool download will use a new format for the URL. 
+    * Current URL format: https://<BlackDuck_Instance>/download/scan.cli-macosx.zip
+    * New URL format: https://<BlackDuck_Instance>/api/tools/scan.cli.zip/versions/latest/platforms/macosx
+
+### Resolved issues
+
+* (IDETECT-4408) - Remediated vulnerability in Logback-Core library to resolve high severity issues [CVE-2023-6378](https://nvd.nist.gov/vuln/detail/CVE-2023-6378) and [CVE-2023-6481](https://nvd.nist.gov/vuln/detail/CVE-2023-6481).
+
+### Dependency updates
+
+* Component Location Analysis version updated to 1.1.13
+* Project Inspector version updated to 2024.9.0
+* Logback Core version updated to 1.2.13
+
 ## Version 9.8.0
 
 ### New features


### PR DESCRIPTION
npm allows for several characters that provide for choosing flexible versions. See: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#dependencies

If we include these characters in the BDIO then those components will not be matched. We should attempt to find the "best" version we can and send that instead. This means removing the characters and choosing the lowest numerical version after that if there are several choices, the theory being that we should be cautious and report lowest versions that in theory have the most vulnerabilities for users to correct.