### PR TITLE
Upgrade binary uploader library to honor ENVs and larger chunk size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ dependencies {
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.10'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'com.synopsys.integration:blackduck-upload-common:1.0.2'
+    implementation 'com.synopsys.integration:blackduck-upload-common:1.1.0'
     implementation 'com.synopsys:method-analyzer-core:0.2.9'
     implementation "${locatorGroup}:${locatorModule}:1.1.13"
 

--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
@@ -94,11 +94,9 @@ public class BinaryUploadOperation {
                 .setAlwaysTrustServerCertificate(blackDuckRunData.getBlackDuckServerConfig().isAlwaysTrustServerCertificate())
                 .setBlackDuckUrl(blackDuckRunData.getBlackDuckServerConfig().getBlackDuckUrl())
                 .setApiToken(blackDuckRunData.getBlackDuckServerConfig().getApiToken().get());
-        
+
         UploaderConfig uploaderConfig = uploaderConfigBuilder.build();
         UploaderFactory uploadFactory = new UploaderFactory(uploaderConfig, new Slf4jIntLogger(logger), new Gson());
-        
-        int uploadChunkSize = uploaderConfig.getUploadChunkSize();
 
         BinaryScanRequestData binaryData = new BinaryScanRequestData(projectNameVersion.getName(),
                 projectNameVersion.getVersion(), codeLocationName, "");

--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
@@ -2,7 +2,6 @@ package com.synopsys.integration.detect.tool.binaryscanner;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -35,7 +34,6 @@ import com.synopsys.integration.util.NameVersion;
 
 public class BinaryUploadOperation {
     private static final String STATUS_KEY = "BINARY_SCAN";
-    private static final int MULTIUPLOAD_CHUNK_SIZE = 5242880; // 5 MB chunks specified in bytes
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private final StatusEventPublisher statusEventPublisher;
@@ -90,16 +88,17 @@ public class BinaryUploadOperation {
         String codeLocationName = codeLocationNameManager.createBinaryScanCodeLocationName(binaryUpload,
                 projectNameVersion.getName(), projectNameVersion.getVersion());
 
-        UploaderConfig.Builder uploaderConfigBuilder = UploaderConfig.createConfigFromProperties(
-                blackDuckRunData.getBlackDuckServerConfig().getProxyInfo(), new Properties())
-                .setUploadChunkSize(MULTIUPLOAD_CHUNK_SIZE)
+        UploaderConfig.Builder uploaderConfigBuilder =  UploaderConfig.createConfigFromEnvironment(
+                blackDuckRunData.getBlackDuckServerConfig().getProxyInfo())
                 .setTimeoutInSeconds(blackDuckRunData.getBlackDuckServerConfig().getTimeout())
                 .setAlwaysTrustServerCertificate(blackDuckRunData.getBlackDuckServerConfig().isAlwaysTrustServerCertificate())
                 .setBlackDuckUrl(blackDuckRunData.getBlackDuckServerConfig().getBlackDuckUrl())
                 .setApiToken(blackDuckRunData.getBlackDuckServerConfig().getApiToken().get());
-
+        
         UploaderConfig uploaderConfig = uploaderConfigBuilder.build();
         UploaderFactory uploadFactory = new UploaderFactory(uploaderConfig, new Slf4jIntLogger(logger), new Gson());
+        
+        int uploadChunkSize = uploaderConfig.getUploadChunkSize();
 
         BinaryScanRequestData binaryData = new BinaryScanRequestData(projectNameVersion.getName(),
                 projectNameVersion.getVersion(), codeLocationName, "");


### PR DESCRIPTION
This PR:
- picks up a new version of the uploader library. This library uses newer 25 MB default chunk sizes
- changes a call during configuration so that the library picks up various override ENVs from the environment if they are specified.

Existing tests should cover Detect's perspective of the change.