### PR TITLE
Increase versions of tested package managers in integration tests and add Dart integration test

### DIFF
--- a/src/test/java/com/synopsys/integration/detect/battery/docker/DartTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/DartTest.java
@@ -1,0 +1,32 @@
+package com.synopsys.integration.detect.battery.docker;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.detect.battery.docker.provider.BuildDockerImageProvider;
+import com.synopsys.integration.detect.battery.docker.util.DetectCommandBuilder;
+import com.synopsys.integration.detect.battery.docker.util.DetectDockerTestRunner;
+import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
+import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
+import com.synopsys.integration.detector.base.DetectorType;
+
+@Tag("integration")
+public class DartTest {
+    @Test
+    void smokeTest() throws IOException {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-dart-smoke", "detect-dart-smoke:3.5.0")) {
+            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("Dart.dockerfile"));
+
+            DetectCommandBuilder commandBuilder = DetectCommandBuilder.withOfflineDefaults().defaultDirectories(test);
+            commandBuilder.tools(DetectTool.DETECTOR);
+
+            DockerAssertions dockerAssertions = test.run(commandBuilder);
+
+            dockerAssertions.logContains("Dart CLI: SUCCESS");
+            dockerAssertions.successfulDetectorType(DetectorType.DART.toString());
+            dockerAssertions.atLeastOneBdioFile();
+        }
+    }
+}

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/DartTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/DartTest.java
@@ -16,7 +16,7 @@ import com.synopsys.integration.detector.base.DetectorType;
 public class DartTest {
     @Test
     void smokeTest() throws IOException {
-        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-dart-smoke", "detect-dart-smoke:3.5.0")) {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-dart-smoke", "detect-dart-smoke:3.5.0-1")) {
             test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("Dart.dockerfile"));
 
             DetectCommandBuilder commandBuilder = DetectCommandBuilder.withOfflineDefaults().defaultDirectories(test);

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -22,7 +22,7 @@ public class MavenShadedDependenciesTest {
 
     @Test
     void mavenShadedDependencyTest() throws IOException,IntegrationException {
-        try(DetectDockerTestRunner test = new DetectDockerTestRunner("detect-maven-shaded-dependency", "detect-maven:1.0.0")) {
+        try(DetectDockerTestRunner test = new DetectDockerTestRunner("detect-maven-shaded-dependency", "detect-maven:3.9.8")) {
             test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("MavenShadedDependencies.dockerfile"));
 
             String projectVersion = PROJECT_NAME + "-PI";

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/YoctoTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/YoctoTest.java
@@ -17,7 +17,7 @@ import com.synopsys.integration.detector.base.DetectorType;
 public class YoctoTest {
     @Test
     void smokeTest() throws IOException {
-        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-yocto-smoke", "detect-yocto-smoke:1.0.0")) {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-yocto-smoke", "detect-yocto-smoke:5.0.2")) {
             test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("Yocto.dockerfile"));
 
             DetectCommandBuilder commandBuilder = DetectCommandBuilder.withOfflineDefaults().defaultDirectories(test);

--- a/src/test/resources/docker/Dart.dockerfile
+++ b/src/test/resources/docker/Dart.dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-20240110-slim
 
-RUN apt-get update && apt-get -y install wget unzip
+RUN apt-get update && apt-get -y install wget unzip openjdk-17-jdk
 
 RUN wget https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.0/linux_packages/dart_3.5.0-1_amd64.deb
 

--- a/src/test/resources/docker/Dart.dockerfile
+++ b/src/test/resources/docker/Dart.dockerfile
@@ -1,0 +1,15 @@
+FROM debian:bookworm-20240110-slim
+
+RUN apt-get update && apt-get -y install wget unzip
+
+RUN wget https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.0/linux_packages/dart_3.5.0-1_amd64.deb
+
+RUN dpkg -i dart_3.5.0-1_amd64.deb
+
+# Do not change SRC_DIR, value is expected by tests
+ENV SRC_DIR=/opt/project/src
+
+# Set up the test project
+RUN mkdir -p ${SRC_DIR}
+
+RUN dart create ${SRC_DIR} --force

--- a/src/test/resources/docker/MavenShadedDependencies.dockerfile
+++ b/src/test/resources/docker/MavenShadedDependencies.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-17
+FROM maven:3.9.8-eclipse-temurin-17
 
 # Do not change SRC_DIR, value is expected by tests
 ENV SRC_DIR=/opt/project/src

--- a/src/test/resources/docker/Yocto.dockerfile
+++ b/src/test/resources/docker/Yocto.dockerfile
@@ -23,7 +23,7 @@ ENV SRC_DIR=/opt/project/src
 
 # Set up the test project
 RUN mkdir -p ${SRC_DIR}
-RUN git clone -b yocto-4.3.1 --depth 1 https://github.com/yoctoproject/poky.git ${SRC_DIR}
+RUN git clone -b yocto-5.0.2 --depth 1 https://github.com/yoctoproject/poky.git ${SRC_DIR}
 
 RUN cd ${SRC_DIR} \
   && sed -i 's/INHERIT += "sanity"/#INHERIT += "sanity"/g' meta/conf/sanity.conf


### PR DESCRIPTION
# Description

I decided to use existing tests as much as possible instead of creating new ones in order to not increase test runtime and load on BD.
So, for Maven and Yocto I simply increased the versions being tested in existing tests.
For Dart I added a new test as previously there was no Dart integration test.