### PR TITLE
Increase upload timeout for binary multipart scans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.synopsys.integration'
 
-version = '9.10.0-SIGQA3-dterry.IDETECT-4464-increase-upload-timeout-SNAPSHOT'
+version = '9.10.0-SIGQA2-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.synopsys.integration'
 
-version = '9.10.0-SIGQA2-SNAPSHOT'
+version = '9.10.0-SIGQA2-dterry.IDETECT-4464-increase-upload-timeout'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.synopsys.integration'
 
-version = '9.10.0-SIGQA2-dterry.IDETECT-4464-increase-upload-timeout'
+version = '9.10.0-SIGQA3-dterry.IDETECT-4464-increase-upload-timeout-SNAPSHOT'
 
 apply plugin: 'com.synopsys.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
@@ -91,6 +91,7 @@ public class BinaryUploadOperation {
         UploaderConfig.Builder uploaderConfigBuilder =  UploaderConfig.createConfigFromEnvironment(
                 blackDuckRunData.getBlackDuckServerConfig().getProxyInfo())
                 .setTimeoutInSeconds(blackDuckRunData.getBlackDuckServerConfig().getTimeout())
+                .setMultipartUploadTimeoutInMinutes(blackDuckRunData.getBlackDuckServerConfig().getTimeout() /  60)
                 .setAlwaysTrustServerCertificate(blackDuckRunData.getBlackDuckServerConfig().isAlwaysTrustServerCertificate())
                 .setBlackDuckUrl(blackDuckRunData.getBlackDuckServerConfig().getBlackDuckUrl())
                 .setApiToken(blackDuckRunData.getBlackDuckServerConfig().getApiToken().get());


### PR DESCRIPTION
In addition to a connection timeout, the multipart library has a timeout for how long the actual upload of the binary can take. We need to make this honor the detect.timeout property so if the user allows for more time the scan should not stop at the default 10 minute timeout.