### PR TITLE
cp_IDETECT-4471 clarify jenkins plugin permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ application.properties
 application.yml
 !/src/test/resources/lifecycle/autonomous/sample-project/only-text/build.gradle
 !/src/test/resources/lifecycle/autonomous/sample-project/text-and-binary/build.gradle
+src/test/resources/lifecycle/autonomous/post-run-scan-settings/a9cedd7c-bed3-3fa1-b4b3-18f3c8a6869a.json

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/usersandroles.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/usersandroles.md
@@ -7,7 +7,7 @@ First you must configure a user/API token in [blackduck_product_name] so that th
 4. Click **Create New Token**. The Create New Token dialog box appears
 5. Type your name in the **Name** field.
 6. Optional: in the **Description** field, you can type a description or definition.
-7. Select **Read Access** and/or **Write Access**.
+7. Select **Read Access** and **Write Access**.
 8. Click **Create**. The API token displays in a pop-up window. For security reasons, this is the only time your user API token displays. Please save this token. If the token is lost, you must regenerate it.
 9. Optional: To modify an access token that you created, click the arrow in the same row as the access
 token name to open a drop-down menu and select **Edit**, **Delete**, or **Regenerate**.


### PR DESCRIPTION
Remove "or" so that users don't end up with project creation permission issues.
