### PR TITLE
Sonar issue fix - Update exception handling for phone home try block

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/ProductBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/ProductBoot.java
@@ -126,9 +126,9 @@ public class ProductBoot {
                         waitAtScanLevel
                     );
                 } catch (IntegrationException e) {
-                    logger.debug("Failed to fetch Analytics credentials. Skipping phone home.");
+                    logger.debug("Failed to fetch Analytics credentials. Skipping phone home. Exception: " + e.getMessage());
                 } catch (JsonSyntaxException e) {
-                    logger.debug("Analytics credentials file syntax is invalid. Skipping phone home.");
+                    logger.debug("Analytics credentials file syntax is invalid. Skipping phone home. Exception: " + e.getMessage());
                 } finally {
                     if (bdRunData == null)
                         bdRunData = BlackDuckRunData.onlineNoPhoneHome(blackDuckDecision.scanMode(), blackDuckServicesFactory, blackDuckConnectivityResult, waitAtScanLevel);

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/ProductBoot.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/ProductBoot.java
@@ -125,12 +125,10 @@ public class ProductBoot {
                         blackDuckConnectivityResult,
                         waitAtScanLevel
                     );
-                } catch (IOException | InterruptedException e) {
+                } catch (IntegrationException e) {
                     logger.debug("Failed to fetch Analytics credentials. Skipping phone home.");
                 } catch (JsonSyntaxException e) {
                     logger.debug("Analytics credentials file syntax is invalid. Skipping phone home.");
-                } catch (Exception e) {
-                    logger.debug("Skipping phone home due to {}.", e.getClass().getName());
                 } finally {
                     if (bdRunData == null)
                         bdRunData = BlackDuckRunData.onlineNoPhoneHome(blackDuckDecision.scanMode(), blackDuckServicesFactory, blackDuckConnectivityResult, waitAtScanLevel);

--- a/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeCredentialsFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeCredentialsFactory.java
@@ -37,7 +37,7 @@ public class PhoneHomeCredentialsFactory {
         );
     }
 
-    public PhoneHomeCredentials getGa4Credentials() throws IOException, InterruptedException, JsonSyntaxException, IntegrationException {
+    public PhoneHomeCredentials getGa4Credentials()  throws JsonSyntaxException, IntegrationException {
         String fileUrl = CREDENTIALS_PATH;
         if (isTestEnvironment()) {
             fileUrl = TEST_CREDENTIALS_PATH;


### PR DESCRIPTION
Fixes a Sonar Cloud issue related to exception handling. 
The getGa4Credentials method would only throw an IntegrationException or a JsonHandlingException.
An InterruptedException is not required to be handled in this case. If we do handle it, we need to interrupt the thread or throw the exception which this part of the code is trying to avoid. Detect should not be interrupted due to any phone home workflow related exceptions. 