### PR TITLE
Ensure Detect exits in case of unhandled errors

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/Application.java
+++ b/src/main/java/com/synopsys/integration/detect/Application.java
@@ -95,7 +95,12 @@ public class Application implements ApplicationRunner {
             staticLogger.debug("Reason: ", ex);
         }
         if (!selfUpdated) {
-            builder.run(args);
+            try {
+                builder.run(args);
+            } catch (Throwable t) {
+                // ensure the process does not "hang" in case of some non-shutdown Executor(s) and an unhandled error
+                System.exit(ExitCodeType.FAILURE_UNKNOWN_ERROR.getExitCode());
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Detect had the potential to not exit (hang) if the following happened in this particular order:

1. An ExecutorService is instantiated and at least one task is submitted to it
- This causes another thread to run
- Such is the case when signature scanner runs
2. A detect operation throws an Error
- Specifically error, not an exception, since operation runner already handles exceptions

## Other Approaches Considered

### Catch throwables of type Error when executing Operations

Since handling throwable of type Error is not recommended, I decided to not take this route. See: https://docs.oracle.com/javase/6/docs/api/java/lang/Error.html

Additionally, there may be other places where error can occur in the future.

### Track ExecutorService instances and call shutdown() on them as soon as we’re done

There are several places where ExecutorService instances are created and refactoring all those areas can be risky.