### PR TITLE
Capture applicable detectory types in the metadata for phone home

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/DetectRun.java
@@ -7,14 +7,14 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.stream.Collectors;
 
 import com.synopsys.integration.configuration.property.types.enumallnone.list.AllEnumList;
-import com.synopsys.integration.configuration.property.types.enumallnone.list.NoneEnumList;
 import com.synopsys.integration.detect.configuration.DetectProperties;
 import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detect.lifecycle.autonomous.AutonomousManager;
+import com.synopsys.integration.detect.workflow.phonehome.PhoneHomeManager;
 import com.synopsys.integration.detector.base.DetectorType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,6 +110,13 @@ public class DetectRun {
 
             if (productRunData.shouldUseBlackDuckProduct()) {
                 BlackDuckRunData blackDuckRunData = productRunData.getBlackDuckRunData();
+
+                blackDuckRunData.getPhoneHomeManager().ifPresent(
+                    phoneHomeManager -> phoneHomeApplicableDetectorTypes(
+                        phoneHomeManager, universalToolsResult.getApplicableDetectorTypes()
+                    )
+                );
+
                 if (blackDuckRunData.isNonPersistent() && blackDuckRunData.isOnline()) {
                     RapidModeStepRunner rapidModeSteps = new RapidModeStepRunner(operationRunner, stepHelper, bootSingletons.getGson(), bootSingletons.getDirectoryManager());
 
@@ -140,6 +147,11 @@ public class DetectRun {
         } finally {
             operationSystem.ifPresent(OperationSystem::publishOperations);
         }
+    }
+
+    public void phoneHomeApplicableDetectorTypes(PhoneHomeManager phoneHomeManager, Set<DetectorType> applicableDetectorTypes) {
+        Map<DetectorType, Long> detectorTimes = applicableDetectorTypes.stream().collect(Collectors.toMap(detectorType -> detectorType, detectorType -> 0L));
+        phoneHomeManager.savePhoneHomeDetectorTimes(detectorTimes);
     }
 
     private Set<String> getDecidedTools(BootSingletons bootSingletons, Map<DetectTool, Set<String>> scanTypeEvidenceMap) {

--- a/src/main/java/com/synopsys/integration/detect/workflow/phonehome/OnlinePhoneHomeManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/phonehome/OnlinePhoneHomeManager.java
@@ -20,6 +20,7 @@ public class OnlinePhoneHomeManager extends PhoneHomeManager {
     public PhoneHomeResponse phoneHome(Map<String, String> metadata, String... artifactModules) {
         Map<String, String> metaDataToSend = new HashMap<>();
         metaDataToSend.putAll(metadata);
+        metaDataToSend.putAll(detectorTypesMetadata);
         metaDataToSend.putAll(additionalMetaData);
         return blackDuckPhoneHomeHelper.handlePhoneHome("synopsys-detect", detectInfo.getDetectVersion(), metaDataToSend, artifactModules);
     }

--- a/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeManager.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/phonehome/PhoneHomeManager.java
@@ -29,6 +29,8 @@ public abstract class PhoneHomeManager {
     protected PhoneHomeResponse currentPhoneHomeResponse;
     protected Map<String, String> additionalMetaData;
     protected List<Operation> operations = new LinkedList<>();
+    protected Map<String, String> detectorTypesMetadata = new HashMap<>();
+    protected Map<String, String> operationsMetadata = new HashMap<>();
 
     protected PhoneHomeManager(Map<String, String> additionalMetaData, DetectInfo detectInfo, EventSystem eventSystem) {
         this.detectInfo = detectInfo;
@@ -44,10 +46,18 @@ public abstract class PhoneHomeManager {
         if (operations.isEmpty()) {
             return;
         }
-        Map<String, String> operationMetadata = new HashMap<>();
-        operations.forEach(operation -> addOperationToMap(operation, operationMetadata));
-        logger.trace("Phoning home {}/{} operations.", operationMetadata.size(), operations.size());
-        safelyPhoneHome(operationMetadata);
+        operations.forEach(operation -> addOperationToMap(operation, operationsMetadata));
+        logger.trace("Phoning home {}/{} operations.", operationsMetadata.size(), operations.size());
+        safelyPhoneHome(operationsMetadata);
+    }
+
+    public void savePhoneHomeDetectorTimes(Map<DetectorType, Long> aggregateTimes) {
+        if (aggregateTimes != null) {
+            String applicableBomToolsString = aggregateTimes.keySet().stream()
+                .map(it -> String.format("%s:%s", it.toString(), aggregateTimes.get(it)))
+                .collect(Collectors.joining(","));
+            detectorTypesMetadata.put("detectorTimes", applicableBomToolsString);
+        }
     }
 
     public abstract PhoneHomeResponse phoneHome(Map<String, String> metadata, String... artifactModules);


### PR DESCRIPTION
#### Description
In Detect 8's cascading related updates, there were changes made to the event system in Detect and the phone home workflow stopped capturing detector types and detector times (independent execution time for each detector's extraction). 

An example of the format in which the data was historically sent in the metadata field is as below: 
`detectorTimes -> GRADLE:2343,GIT:32`

This PR simply captures the applicable detector types after all detectors have run. Since a lot of the code related to time capturing was removed, current changes add a default `0L` value for the time - the primary purpose is to ensure we capture which detectors were invoked as this is the most useful data point and we ideally want this to be captured in Detect 9 itself.

Hence, the current phone home workflow will capture the applicable detector types as
`detectorTimes -> GRADLE:0,GIT:0` to ensure the format is compatible with the previous data format.

Created IDETECT-4491 to track the work of updating the event system and capture actual detector times for phone home as a future enhancement.

