### PR TITLE
pnpm remove optimization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ def createBatteryPath() {
 def final locatorGroup = "com.synopsys.integration"
 def final locatorModule = "component-locator"
 final def externalRepoHost = "https://sig-repo.synopsys.com"
-final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
+final def internalRepoHost = "https://artifactory.internal.synopsys.com"
 
 repositories {
     println "Checking if environment property SNPS_INTERNAL_ARTIFACTORY is configured: ${internalRepoHost}"

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ def createBatteryPath() {
 def final locatorGroup = "com.synopsys.integration"
 def final locatorModule = "component-locator"
 final def externalRepoHost = "https://sig-repo.synopsys.com"
-final def internalRepoHost = "https://artifactory.internal.synopsys.com"
+final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 
 repositories {
     println "Checking if environment property SNPS_INTERNAL_ARTIFACTORY is configured: ${internalRepoHost}"

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/process/PnpmYamlTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/process/PnpmYamlTransformer.java
@@ -199,9 +199,9 @@ public class PnpmYamlTransformer {
         
         // Remove extra information from the version string, there will often be peer
         // dependency information that we do not support and is not related to the package version.
-        if (version != null && version.contains("(")) {
-            version = version.split("\\(")[0];
-        }
+//        if (version != null && version.contains("(")) {
+//            version = version.split("\\(")[0];
+//        }
         
         // v6 needs a leading / to find packages, v9 does not.
         String packageFormat = "%s@%s";

--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/process/PnpmYamlTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/process/PnpmYamlTransformer.java
@@ -197,12 +197,6 @@ public class PnpmYamlTransformer {
             version = linkedPackageResolver.resolveVersionOfLinkedPackage(reportingProjectPackagePath, version.replace(LINKED_PACKAGE_PREFIX, ""));
         }
         
-        // Remove extra information from the version string, there will often be peer
-        // dependency information that we do not support and is not related to the package version.
-//        if (version != null && version.contains("(")) {
-//            version = version.split("\\(")[0];
-//        }
-        
         // v6 needs a leading / to find packages, v9 does not.
         String packageFormat = "%s@%s";
         


### PR DESCRIPTION
This MR removes a flawed optimization based on the assumption that the KB would not match peer dependencies, dependencies specified as dependencyName (peerDependency).

Turns out that the pnpm detector has been handling these types of dependencies for awhile now and stripping out the peer dependencies results in less matches than we used to get.

Simply removing the code (which was new in the initial pnpm v9 lockfile code and historically hasn't been there)

@andrian-sevastyanov @devmehtasynopsys please re-review, this is no different than the previous MR except it targets master