### PR TITLE
Python docker integration tests for Pip, Setuptools and Pipenv

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -5,6 +5,7 @@
 ### New features
 
 * The npm package.json detector now performs additional parsing when attempting to find dependency versions. This can result in additional matches since versions like `^1.2.0` will now be extracted as `1.2.0` instead of as the raw `^1.2.0` string. In the case where multiple versions for a dependency are discovered, the earliest version will be used.
+* Support for Python has now been extended with Pip 24.2, Pipenv 2024.0.1, and Setuptools 74.0.0.
 
 ## Version 9.10.0
 

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/AutonomousScanTests.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @Tag("integration")
 public class AutonomousScanTests {
 
-    public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
+    public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 
 //    @Test
     void autonomousScanModeOFFLINETest() throws Exception {

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/GradleNativeInspectorTests.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/GradleNativeInspectorTests.java
@@ -20,7 +20,7 @@ import java.util.Map;
 @Tag("integration")
 public class GradleNativeInspectorTests {
 
-    public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
+    public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
     public static String PROJECT_NAME = "gradle-rich-version";
     
     @Test

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/PipTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/PipTest.java
@@ -24,7 +24,7 @@ import com.synopsys.integration.exception.IntegrationException;
 @Tag("integration")
 public class PipTest {
 
-    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "23.1.2", "24.2" };
+    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "24.2" };
     public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
 
     private static final String PROJECT_NAME = "pip-docker-test-project";

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/PipTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/PipTest.java
@@ -25,7 +25,7 @@ import com.synopsys.integration.exception.IntegrationException;
 public class PipTest {
 
     private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "24.2" };
-    public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
+    public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 
     private static final String PROJECT_NAME = "pip-docker-test-project";
 
@@ -36,7 +36,7 @@ public class PipTest {
     @ParameterizedTest
     @MethodSource("providePipVersionsToTest")
     public void pipExecutableTest(String pipVersion) throws IntegrationException, IOException {
-        try (DetectDockerTestRunner test = new DetectDockerTestRunner("pip-docker-test   ", "pip-docker-test:" + pipVersion)) {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("pip-docker-test", "pip-docker-test:" + pipVersion)) {
 
             Map<String, String> pipDockerfileArgs = new HashMap<>();
             pipDockerfileArgs.put("PIP_VERSION", pipVersion);

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/PipTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/PipTest.java
@@ -1,0 +1,85 @@
+package com.synopsys.integration.detect.battery.docker;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckAssertions;
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckTestConnection;
+import com.synopsys.integration.detect.battery.docker.provider.BuildDockerImageProvider;
+import com.synopsys.integration.detect.battery.docker.util.DetectCommandBuilder;
+import com.synopsys.integration.detect.battery.docker.util.DetectDockerTestRunner;
+import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
+import com.synopsys.integration.detect.configuration.DetectProperties;
+import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
+import com.synopsys.integration.detector.base.DetectorType;
+import com.synopsys.integration.exception.IntegrationException;
+
+@Tag("nirav")
+public class PipTest {
+
+    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "24.2" };
+    public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
+
+    private static final String PROJECT_NAME = "pip-docker";
+
+    private static Stream<String> providePipVersionsToTest() {
+        return Arrays.stream(PIP_VERSIONS_TO_TEST);
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePipVersionsToTest")
+    public void pipExecutableTest(String pipVersion) throws IntegrationException, IOException {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("pip-docker-test   ", "pip-docker-test:" + pipVersion)) {
+
+            Map<String, String> pipDockerfileArgs = new HashMap<>();
+            pipDockerfileArgs.put("PIP_VERSION", pipVersion);
+            pipDockerfileArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
+
+            BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("Pip.dockerfile");
+            buildDockerImageProvider.setBuildArgs(pipDockerfileArgs);
+            test.withImageProvider(buildDockerImageProvider);
+
+            // Set up blackduck connection and environment
+            String projectVersion = PROJECT_NAME + "-" + pipVersion;
+            BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+            BlackDuckAssertions blackduckAssertions = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, projectVersion);
+            blackduckAssertions.emptyOnBlackDuck();
+
+            // Build command with BlackDuck config
+            DetectCommandBuilder commandBuilder = new DetectCommandBuilder().defaults().defaultDirectories(test);
+            commandBuilder.connectToBlackDuck(blackDuckTestConnection);
+            commandBuilder.projectNameVersion(blackduckAssertions);
+            commandBuilder.waitForResults();
+
+            // Set up Detect properties
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, DetectTool.DETECTOR.toString());
+            commandBuilder.property(DetectProperties.DETECT_PIP_PATH, "/usr/local/bin/pip");
+            commandBuilder.property(DetectProperties.DETECT_PYTHON_PATH, "/usr/bin/python3");
+            commandBuilder.property(DetectProperties.DETECT_ACCURACY_REQUIRED, "NONE");
+            DockerAssertions dockerAssertions = test.run(commandBuilder);
+
+            // Detect specific assertions
+            dockerAssertions.successfulDetectorType(DetectorType.PIP.toString());
+            dockerAssertions.atLeastOneBdioFile();
+
+            // Blackduck specific assertions
+            validateComponentsForSamplePipProject(blackduckAssertions);
+        }
+    }
+
+    // These are all components in the requirements.txt file of the test project "<insert-test-project-link>" that should appear on the BOM on BlackDuck
+    // If ever updating the above test project, ensure to update the component list below accordingly
+    private void validateComponentsForSamplePipProject(BlackDuckAssertions blackduckAssertions) throws IntegrationException {
+        blackduckAssertions.hasComponents("Jinja");
+        blackduckAssertions.hasComponents("MarkupSafe");
+        blackduckAssertions.hasComponents("pycparser");
+        blackduckAssertions.hasComponents("PyYAML");
+    }
+}

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/PipTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/PipTest.java
@@ -21,13 +21,13 @@ import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detector.base.DetectorType;
 import com.synopsys.integration.exception.IntegrationException;
 
-@Tag("nirav")
+@Tag("integration")
 public class PipTest {
 
-    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "24.2" };
+    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "23.1.2", "24.2" };
     public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
 
-    private static final String PROJECT_NAME = "pip-docker";
+    private static final String PROJECT_NAME = "pip-docker-test-project";
 
     private static Stream<String> providePipVersionsToTest() {
         return Arrays.stream(PIP_VERSIONS_TO_TEST);
@@ -78,8 +78,9 @@ public class PipTest {
     // If ever updating the above test project, ensure to update the component list below accordingly
     private void validateComponentsForSamplePipProject(BlackDuckAssertions blackduckAssertions) throws IntegrationException {
         blackduckAssertions.hasComponents("Jinja");
-        blackduckAssertions.hasComponents("MarkupSafe");
-        blackduckAssertions.hasComponents("pycparser");
         blackduckAssertions.hasComponents("PyYAML");
+        blackduckAssertions.checkComponentVersionExists("MarkupSafe", "2.1.5");
+        blackduckAssertions.checkComponentVersionExists("Packaging", "24.1");
+        blackduckAssertions.checkComponentVersionExists("pycparser", "2.22");
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/PipenvTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/PipenvTest.java
@@ -25,7 +25,7 @@ import com.synopsys.integration.exception.IntegrationException;
 public class PipenvTest {
 
     private static final String[] PIPENV_VERSIONS_TO_TEST = new String[] { "2024.0.1" };
-    public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
+    public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 
     private static final String PROJECT_NAME = "pipenv-docker-test-project";
 
@@ -36,7 +36,7 @@ public class PipenvTest {
     @ParameterizedTest
     @MethodSource("providePipenvVersionsToTest")
     public void pipenvExecutableTest(String pipenvVersion) throws IntegrationException, IOException {
-        try (DetectDockerTestRunner test = new DetectDockerTestRunner("pipenv-docker-test   ", "pipenv-docker-test:" + pipenvVersion)) {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("pipenv-docker-test", "pipenv-docker-test:" + pipenvVersion)) {
 
             Map<String, String> pipenvDockerfileArgs = new HashMap<>();
             pipenvDockerfileArgs.put("PIPENV_VERSION_VAL", pipenvVersion);

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/PipenvTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/PipenvTest.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -39,7 +38,7 @@ public class PipenvTest {
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("pipenv-docker-test   ", "pipenv-docker-test:" + pipenvVersion)) {
 
             Map<String, String> pipenvDockerfileArgs = new HashMap<>();
-            pipenvDockerfileArgs.put("PIPENV_VERSION", pipenvVersion);
+            pipenvDockerfileArgs.put("PIPENV_VERSION_VAL", pipenvVersion);
             pipenvDockerfileArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
 
             BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("Pipenv.dockerfile");
@@ -70,13 +69,12 @@ public class PipenvTest {
             dockerAssertions.atLeastOneBdioFile();
 
             // Blackduck specific assertions
-            validateComponentsForSamplePipProject(blackduckAssertions);
+            validateComponentsForSamplePipenvProject(blackduckAssertions);
         }
     }
 
-    // These are all components in the requirements.txt file of the test project "<insert-test-project-link>" that should appear on the BOM on BlackDuck
-    // If ever updating the above test project, ensure to update the component list below accordingly
-    private void validateComponentsForSamplePipProject(BlackDuckAssertions blackduckAssertions) throws IntegrationException {
+    // If updating below components, make sure to refer the test project used by the corresponding dockerfile
+    private void validateComponentsForSamplePipenvProject(BlackDuckAssertions blackduckAssertions) throws IntegrationException {
         blackduckAssertions.checkComponentVersionExists("Jinja", "3.0.3");
         blackduckAssertions.checkComponentVersionExists("urllib3", "1.26.8");
         blackduckAssertions.checkComponentVersionExists("MarkupSafe", "2.0.1");

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/PipenvTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/PipenvTest.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -20,7 +21,7 @@ import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detector.base.DetectorType;
 import com.synopsys.integration.exception.IntegrationException;
 
-//@Tag("integration")
+@Tag("integration")
 public class PipenvTest {
 
     private static final String[] PIPENV_VERSIONS_TO_TEST = new String[] { "2024.0.1" };

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/PipenvTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/PipenvTest.java
@@ -1,0 +1,86 @@
+package com.synopsys.integration.detect.battery.docker;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckAssertions;
+import com.synopsys.integration.detect.battery.docker.integration.BlackDuckTestConnection;
+import com.synopsys.integration.detect.battery.docker.provider.BuildDockerImageProvider;
+import com.synopsys.integration.detect.battery.docker.util.DetectCommandBuilder;
+import com.synopsys.integration.detect.battery.docker.util.DetectDockerTestRunner;
+import com.synopsys.integration.detect.battery.docker.util.DockerAssertions;
+import com.synopsys.integration.detect.configuration.DetectProperties;
+import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
+import com.synopsys.integration.detector.base.DetectorType;
+import com.synopsys.integration.exception.IntegrationException;
+
+//@Tag("integration")
+public class PipenvTest {
+
+    private static final String[] PIPENV_VERSIONS_TO_TEST = new String[] { "2024.0.1" };
+    public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
+
+    private static final String PROJECT_NAME = "pipenv-docker-test-project";
+
+    private static Stream<String> providePipenvVersionsToTest() {
+        return Arrays.stream(PIPENV_VERSIONS_TO_TEST);
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePipenvVersionsToTest")
+    public void pipenvExecutableTest(String pipenvVersion) throws IntegrationException, IOException {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("pipenv-docker-test   ", "pipenv-docker-test:" + pipenvVersion)) {
+
+            Map<String, String> pipenvDockerfileArgs = new HashMap<>();
+            pipenvDockerfileArgs.put("PIPENV_VERSION", pipenvVersion);
+            pipenvDockerfileArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
+
+            BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("Pipenv.dockerfile");
+            buildDockerImageProvider.setBuildArgs(pipenvDockerfileArgs);
+            test.withImageProvider(buildDockerImageProvider);
+
+            // Set up blackduck connection and environment
+            String projectVersion = PROJECT_NAME + "-" + pipenvVersion;
+            BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+            BlackDuckAssertions blackduckAssertions = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, projectVersion);
+            blackduckAssertions.emptyOnBlackDuck();
+
+            // Build command with BlackDuck config
+            DetectCommandBuilder commandBuilder = new DetectCommandBuilder().defaults().defaultDirectories(test);
+            commandBuilder.connectToBlackDuck(blackDuckTestConnection);
+            commandBuilder.projectNameVersion(blackduckAssertions);
+            commandBuilder.waitForResults();
+
+            // Set up Detect properties
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, DetectTool.DETECTOR.toString());
+            commandBuilder.property(DetectProperties.DETECT_PIPENV_PATH, "/usr/local/bin/pipenv");
+            commandBuilder.property(DetectProperties.DETECT_PYTHON_PATH, "/usr/bin/python3");
+            commandBuilder.property(DetectProperties.DETECT_ACCURACY_REQUIRED, "NONE");
+            DockerAssertions dockerAssertions = test.run(commandBuilder);
+
+            // Detect specific assertions
+            dockerAssertions.successfulDetectorType(DetectorType.PIP.toString());
+            dockerAssertions.atLeastOneBdioFile();
+
+            // Blackduck specific assertions
+            validateComponentsForSamplePipProject(blackduckAssertions);
+        }
+    }
+
+    // These are all components in the requirements.txt file of the test project "<insert-test-project-link>" that should appear on the BOM on BlackDuck
+    // If ever updating the above test project, ensure to update the component list below accordingly
+    private void validateComponentsForSamplePipProject(BlackDuckAssertions blackduckAssertions) throws IntegrationException {
+        blackduckAssertions.checkComponentVersionExists("Jinja", "3.0.3");
+        blackduckAssertions.checkComponentVersionExists("urllib3", "1.26.8");
+        blackduckAssertions.checkComponentVersionExists("MarkupSafe", "2.0.1");
+        blackduckAssertions.checkComponentVersionExists("idna", "3.3");
+        blackduckAssertions.checkComponentVersionExists("Werkzeug", "2.0.2");
+    }
+}

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/SetuptoolsTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/SetuptoolsTest.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -20,6 +21,7 @@ import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detector.base.DetectorType;
 import com.synopsys.integration.exception.IntegrationException;
 
+@Tag("integration")
 public class SetuptoolsTest {
     private static final String[] SETUPTOOLS_VERSIONS_TO_TEST = new String[] { "74.0.0" };
     private static final String PIP_VERSION = "24.2";

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/SetuptoolsTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/SetuptoolsTest.java
@@ -25,7 +25,7 @@ import com.synopsys.integration.exception.IntegrationException;
 public class SetuptoolsTest {
     private static final String[] SETUPTOOLS_VERSIONS_TO_TEST = new String[] { "74.0.0" };
     private static final String PIP_VERSION = "24.2";
-    public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
+    public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 
     private static final String PROJECT_NAME = "setuptools-docker-test-project";
 

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/SetuptoolsTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/SetuptoolsTest.java
@@ -79,8 +79,8 @@ public class SetuptoolsTest {
     // If updating below components, make sure to refer the test project used by the corresponding dockerfile
     private void validateComponentsForSampleSetuptoolsProject(BlackDuckAssertions blackduckAssertions) throws IntegrationException {
         blackduckAssertions.hasComponents("onnx");
-        blackduckAssertions.hasComponents("PyYAML");
-        blackduckAssertions.checkComponentVersionExists("rwightman/pytorch-image-models", "1.0.9");
+        blackduckAssertions.hasComponents("yarl");
+        blackduckAssertions.checkComponentVersionExists("PyTZ - Python Time Zone Library", "2024.1");
         blackduckAssertions.checkComponentVersionExists("s3fs", "2023.5.0");
         blackduckAssertions.checkComponentVersionExists("tqdm", "4.66.5");
     }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/SetuptoolsTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/SetuptoolsTest.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -21,33 +20,33 @@ import com.synopsys.integration.detect.configuration.enumeration.DetectTool;
 import com.synopsys.integration.detector.base.DetectorType;
 import com.synopsys.integration.exception.IntegrationException;
 
-@Tag("integration")
-public class PipTest {
-
-    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "24.2" };
+public class SetuptoolsTest {
+    private static final String[] SETUPTOOLS_VERSIONS_TO_TEST = new String[] { "74.0.0" };
+    private static final String PIP_VERSION = "24.2";
     public static String ARTIFACTORY_URL = "https://artifactory.internal.synopsys.com:443";
 
-    private static final String PROJECT_NAME = "pip-docker-test-project";
+    private static final String PROJECT_NAME = "setuptools-docker-test-project";
 
-    private static Stream<String> providePipVersionsToTest() {
-        return Arrays.stream(PIP_VERSIONS_TO_TEST);
+    private static Stream<String> provideSetuptoolsVersionsToTest() {
+        return Arrays.stream(SETUPTOOLS_VERSIONS_TO_TEST);
     }
 
     @ParameterizedTest
-    @MethodSource("providePipVersionsToTest")
-    public void pipExecutableTest(String pipVersion) throws IntegrationException, IOException {
-        try (DetectDockerTestRunner test = new DetectDockerTestRunner("pip-docker-test   ", "pip-docker-test:" + pipVersion)) {
+    @MethodSource("provideSetuptoolsVersionsToTest")
+    public void setuptoolsExecutableTest(String setuptoolsVersion) throws IntegrationException, IOException {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("setuptools-docker-test   ", "setuptools-docker-test:" + setuptoolsVersion)) {
 
-            Map<String, String> pipDockerfileArgs = new HashMap<>();
-            pipDockerfileArgs.put("PIP_VERSION", pipVersion);
-            pipDockerfileArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
+            Map<String, String> setuptoolsDockerfileArgs = new HashMap<>();
+            setuptoolsDockerfileArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
+            setuptoolsDockerfileArgs.put("PIP_VERSION", PIP_VERSION);
+            setuptoolsDockerfileArgs.put("SETUPTOOLS_VERSION", setuptoolsVersion);
 
-            BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("Pip.dockerfile");
-            buildDockerImageProvider.setBuildArgs(pipDockerfileArgs);
+            BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("Setuptools.dockerfile");
+            buildDockerImageProvider.setBuildArgs(setuptoolsDockerfileArgs);
             test.withImageProvider(buildDockerImageProvider);
 
             // Set up blackduck connection and environment
-            String projectVersion = PROJECT_NAME + "-" + pipVersion;
+            String projectVersion = PROJECT_NAME + "-" + setuptoolsVersion;
             BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
             BlackDuckAssertions blackduckAssertions = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, projectVersion);
             blackduckAssertions.emptyOnBlackDuck();
@@ -60,26 +59,27 @@ public class PipTest {
 
             // Set up Detect properties
             commandBuilder.property(DetectProperties.DETECT_TOOLS, DetectTool.DETECTOR.toString());
+            commandBuilder.property(DetectProperties.DETECT_INCLUDED_DETECTOR_TYPES, DetectorType.SETUPTOOLS.toString());
             commandBuilder.property(DetectProperties.DETECT_PIP_PATH, "/usr/local/bin/pip");
             commandBuilder.property(DetectProperties.DETECT_PYTHON_PATH, "/usr/bin/python3");
             commandBuilder.property(DetectProperties.DETECT_ACCURACY_REQUIRED, "NONE");
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             // Detect specific assertions
-            dockerAssertions.successfulDetectorType(DetectorType.PIP.toString());
+            dockerAssertions.successfulDetectorType(DetectorType.SETUPTOOLS.toString());
             dockerAssertions.atLeastOneBdioFile();
 
             // Blackduck specific assertions
-            validateComponentsForSamplePipProject(blackduckAssertions);
+            validateComponentsForSampleSetuptoolsProject(blackduckAssertions);
         }
     }
 
     // If updating below components, make sure to refer the test project used by the corresponding dockerfile
-    private void validateComponentsForSamplePipProject(BlackDuckAssertions blackduckAssertions) throws IntegrationException {
-        blackduckAssertions.hasComponents("Jinja");
+    private void validateComponentsForSampleSetuptoolsProject(BlackDuckAssertions blackduckAssertions) throws IntegrationException {
+        blackduckAssertions.hasComponents("onnx");
         blackduckAssertions.hasComponents("PyYAML");
-        blackduckAssertions.checkComponentVersionExists("MarkupSafe", "2.1.5");
-        blackduckAssertions.checkComponentVersionExists("Packaging", "24.1");
-        blackduckAssertions.checkComponentVersionExists("pycparser", "2.22");
+        blackduckAssertions.checkComponentVersionExists("rwightman/pytorch-image-models", "1.0.9");
+        blackduckAssertions.checkComponentVersionExists("s3fs", "2023.5.0");
+        blackduckAssertions.checkComponentVersionExists("tqdm", "4.66.5");
     }
 }

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:8-jdk-slim
+
+ARG ARTIFACTORY_URL
+ARG PIP_VERSION=24.1.2
+
+# Do not change SRC_DIR, value is expected by tests
+ENV SRC_DIR=/opt/project/src
+
+ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
+
+RUN apt-get update -y
+RUN apt-get install -y git bash wget unzip
+RUN apt-get install -y python3 python3-pip
+RUN pip install --upgrade "pip==${PIP_VERSION}"
+
+# Set up the test project
+#RUN mkdir -p ${SRC_DIR}
+#WORKDIR ${SRC_DIR}
+#RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/pip-test-project.zip
+#RUN unzip pip-test-project.zip -d /opt/project/src
+#RUN mv pip-test-project/* .
+#RUN rm -r pip-test-project pip-test-project.zip
+
+RUN mkdir -p /opt/detect
+COPY synopsys-detect-10.0.0-SIGQA4-SNAPSHOT.jar /opt/detect
+
+RUN mkdir -p ${SRC_DIR}
+WORKDIR ${SRC_DIR}
+RUN git clone -b v2.17.3 --depth 1 https://github.com/ansible/ansible.git ${SRC_DIR}

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -1,29 +1,24 @@
 FROM openjdk:8-jdk-slim
 
 ARG ARTIFACTORY_URL
-ARG PIP_VERSION=24.1.2
+ARG PIP_VERSION="24.1.2"
 
 # Do not change SRC_DIR, value is expected by tests
 ENV SRC_DIR=/opt/project/src
 
 ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
 
+# Set up test environment
 RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
 RUN pip install --upgrade "pip==${PIP_VERSION}"
 
-# Set up the test project
-#RUN mkdir -p ${SRC_DIR}
-#WORKDIR ${SRC_DIR}
-#RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/pip-test-project.zip
-#RUN unzip pip-test-project.zip -d /opt/project/src
-#RUN mv pip-test-project/* .
-#RUN rm -r pip-test-project pip-test-project.zip
-
-RUN mkdir -p /opt/detect
-COPY synopsys-detect-10.0.0-SIGQA4-SNAPSHOT.jar /opt/detect
-
+# Set up test project
 RUN mkdir -p ${SRC_DIR}
 WORKDIR ${SRC_DIR}
-RUN git clone -b v2.17.3 --depth 1 https://github.com/ansible/ansible.git ${SRC_DIR}
+RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/pip-test-project.zip
+RUN unzip pip-test-project.zip -d /opt/project/src
+RUN mv pip-test-project/* .
+RUN rm -r pip-test-project pip-test-project.zip
+RUN pip install -r requirements.txt

--- a/src/test/resources/docker/Pipenv.dockerfile
+++ b/src/test/resources/docker/Pipenv.dockerfile
@@ -1,0 +1,25 @@
+FROM openjdk:8-jdk-slim
+
+# Note: Intentionally using the argument name as PIPENV_VERSION_VAL instead of PIPENV_VERSION as the latter
+# conflicts with the `click` Python package's options and causes `pipenv install` to result in an error.
+ARG PIPENV_VERSION_VAL="2024.0.1"
+ARG ARTIFACTORY_URL
+
+# Do not change SRC_DIR, value is expected by tests
+ENV SRC_DIR=/opt/project/src
+
+ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
+
+# Set up test environment
+RUN apt-get update -y
+RUN apt-get install -y git bash wget unzip
+RUN apt-get install -y python3 python3-pip
+RUN pip install --upgrade "pipenv==${PIPENV_VERSION_VAL}"
+
+# Set up test project
+RUN mkdir -p ${SRC_DIR}
+WORKDIR ${SRC_DIR}
+RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/pipenv-test-project.zip
+RUN unzip pipenv-test-project.zip -d /opt/project/src && mv pipenv-test-project/* .
+RUN rm -r pipenv-test-project pipenv-test-project.zip
+RUN pipenv lock && pipenv install --dev

--- a/src/test/resources/docker/Setuptools.dockerfile
+++ b/src/test/resources/docker/Setuptools.dockerfile
@@ -1,0 +1,26 @@
+FROM openjdk:8-jdk-slim
+
+ARG ARTIFACTORY_URL
+ARG PIP_VERSION="24.2"
+ARG SETUPTOOLS_VERSION="74.0.0"
+
+# Do not change SRC_DIR, value is expected by tests
+ENV SRC_DIR=/opt/project/src
+
+ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
+
+# Set up test environment
+RUN apt-get update -y
+RUN apt-get install -y git bash wget unzip
+RUN apt-get install -y python3 python3-pip
+RUN pip install --upgrade "pip==${PIP_VERSION}"
+RUN pip install --upgrade "setuptools==${SETUPTOOLS_VERSION}"
+
+# Set up test project
+RUN mkdir -p ${SRC_DIR}
+WORKDIR ${SRC_DIR}
+RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/setuptools-test-project.zip
+RUN unzip setuptools-test-project.zip -d /opt/project/src
+RUN mv setuptools-test-project/* .
+RUN rm -r setuptools-test-project setuptools-test-project.zip
+RUN /bin/sh -c "pip install ."


### PR DESCRIPTION
#### Description
Docker based integration tests for the 3 build detectors of Python, namely pip, pipenv and setuptools.
These tests help in upgrading the support for these detectors to their latest versions as follows:
pip: 24.2
pipenv: 2024.0.1
setuptools: 74.0.0


#### JIRA
IDETECT-4417
IDETECT-4418
IDETECT-4426