### PR TITLE
Multipart container image upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ def createBatteryPath() {
 def final locatorGroup = "com.synopsys.integration"
 def final locatorModule = "component-locator"
 final def externalRepoHost = "https://sig-repo.synopsys.com"
-final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
+final def internalRepoHost = "https://artifactory.internal.synopsys.com"
 
 repositories {
     println "Checking if environment property SNPS_INTERNAL_ARTIFACTORY is configured: ${internalRepoHost}"
@@ -150,7 +150,7 @@ dependencies {
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.10'
     implementation "com.synopsys.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'com.synopsys.integration:blackduck-upload-common:1.1.0'
+    implementation 'com.synopsys.integration:blackduck-upload-common:2.0.0'
     implementation 'com.synopsys:method-analyzer-core:0.2.9'
     implementation "${locatorGroup}:${locatorModule}:1.1.13"
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ def createBatteryPath() {
 def final locatorGroup = "com.synopsys.integration"
 def final locatorModule = "component-locator"
 final def externalRepoHost = "https://sig-repo.synopsys.com"
-final def internalRepoHost = "https://artifactory.internal.synopsys.com"
+final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 
 repositories {
     println "Checking if environment property SNPS_INTERNAL_ARTIFACTORY is configured: ${internalRepoHost}"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -27,7 +27,7 @@ dependencyManagement {
     }
 }
 
-final def internalRepoHost = "https://artifactory.internal.synopsys.com"
+final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 
 repositories {
     maven { url "${internalRepoHost}/artifactory/jcenter" }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -27,7 +27,7 @@ dependencyManagement {
     }
 }
 
-final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
+final def internalRepoHost = "https://artifactory.internal.synopsys.com"
 
 repositories {
     maven { url "${internalRepoHost}/artifactory/jcenter" }

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -179,7 +179,7 @@ public class ContainerScanStepRunner {
             throw new IntegrationException("Unable to upload multipart container image.", e);
         }
             
-        if (status != null && status.isError()) {
+        if (status == null || status.isError()) {
             handleUploadError(status);
         }
             
@@ -188,7 +188,9 @@ public class ContainerScanStepRunner {
     }
 
     private void handleUploadError(DefaultUploadStatus status) throws IntegrationException {
-        if (status.getException().isPresent()) {
+        if (status == null) {
+            throw new IntegrationException("Unexpected empty response attempting to upload container image.");
+        } if (status.getException().isPresent()) {
             throw status.getException().get();      
         } else {
             throw new IntegrationException(String.format("Unable to upload multipart container image. Status code: {}. {}", status.getStatusCode(), status.getStatusMessage()));

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -190,7 +190,7 @@ public class ContainerScanStepRunner {
     private void handleUploadError(DefaultUploadStatus status) throws IntegrationException {
         if (status == null) {
             throw new IntegrationException("Unexpected empty response attempting to upload container image.");
-        } if (status.getException().isPresent()) {
+        } else if (status.getException().isPresent()) {
             throw status.getException().get();      
         } else {
             throw new IntegrationException(String.format("Unable to upload multipart container image. Status code: {}. {}", status.getStatusCode(), status.getStatusMessage()));

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -165,7 +165,7 @@ public class ContainerScanStepRunner {
         }
     }
     
-    private void multiPartUploadImage() throws IntegrationException {
+    private DefaultUploadStatus multiPartUploadImage() throws IntegrationException {
         String storageServiceEndpoint = String.join("", STORAGE_CONTAINERS_ENDPOINT, scanId.toString());
         ContainerUploader containerUploader = uploadFactory.createContainerUploader(storageServiceEndpoint);
         
@@ -183,7 +183,8 @@ public class ContainerScanStepRunner {
             handleUploadError(status);
         }
             
-        logger.debug("Multipart container scan image uploaded to storage service.");     
+        logger.debug("Multipart container scan image uploaded to storage service.");
+        return status;
     }
 
     private void handleUploadError(DefaultUploadStatus status) throws IntegrationException {

--- a/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/binaryscanner/BinaryUploadOperation.java
@@ -90,7 +90,7 @@ public class BinaryUploadOperation {
 
         UploaderConfig.Builder uploaderConfigBuilder =  UploaderConfig.createConfigFromEnvironment(
                 blackDuckRunData.getBlackDuckServerConfig().getProxyInfo())
-                .setTimeoutInSeconds(blackDuckRunData.getBlackDuckServerConfig().getTimeout())
+                .setBlackDuckTimeoutInSeconds(blackDuckRunData.getBlackDuckServerConfig().getTimeout())
                 .setMultipartUploadTimeoutInMinutes(blackDuckRunData.getBlackDuckServerConfig().getTimeout() /  60)
                 .setAlwaysTrustServerCertificate(blackDuckRunData.getBlackDuckServerConfig().isAlwaysTrustServerCertificate())
                 .setBlackDuckUrl(blackDuckRunData.getBlackDuckServerConfig().getBlackDuckUrl())

--- a/src/test/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunnerTest.java
@@ -1,0 +1,113 @@
+package com.synopsys.integration.detect.lifecycle.run.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.google.gson.Gson;
+import com.synopsys.blackduck.upload.client.uploaders.ContainerUploader;
+import com.synopsys.blackduck.upload.client.uploaders.UploaderFactory;
+import com.synopsys.blackduck.upload.rest.status.DefaultUploadStatus;
+import com.synopsys.integration.blackduck.version.BlackDuckVersion;
+import com.synopsys.integration.detect.lifecycle.run.data.BlackDuckRunData;
+import com.synopsys.integration.detect.lifecycle.run.operation.OperationRunner;
+import com.synopsys.integration.detect.workflow.blackduck.project.options.ProjectGroupOptions;
+import com.synopsys.integration.detect.workflow.file.DirectoryManager;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.util.NameVersion;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ContainerScanStepRunnerTest {
+    @Mock
+    private ContainerUploader mockContainerUploader;
+    
+    @Mock
+    private File mockContainerImage;
+    
+    private ContainerScanStepRunner instance;
+    
+    @BeforeAll
+    public void initMocks() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        
+        NameVersion mockNameVersion = mock(NameVersion.class);
+        OperationRunner mockOperationRunner = mock(OperationRunner.class);
+        DirectoryManager mockDirectoryManager = mock(DirectoryManager.class);
+        File mockBinaryOutputDirectory = mock(File.class);
+        ProjectGroupOptions mockProjectGroupOptions = mock(ProjectGroupOptions.class);
+        BlackDuckRunData mockBlackDuckRunData = mock(BlackDuckRunData.class);
+        BlackDuckVersion mockBlackDuckVersion = mock(BlackDuckVersion.class);
+        UploaderFactory mockUploadFactory = mock(UploaderFactory.class);
+
+        when(mockOperationRunner.calculateProjectGroupOptions()).thenReturn(mockProjectGroupOptions);
+        String expectedProjectGroupName = "expectedProjectGroupName";
+        when(mockProjectGroupOptions.getProjectGroup()).thenReturn(expectedProjectGroupName);
+        when(mockOperationRunner.getDirectoryManager()).thenReturn(mockDirectoryManager);
+        when(mockDirectoryManager.getBinaryOutputDirectory()).thenReturn(mockBinaryOutputDirectory);
+        when(mockBinaryOutputDirectory.exists()).thenReturn(true);
+        when(mockBlackDuckRunData.getBlackDuckServerVersion()).thenReturn(Optional.of(mockBlackDuckVersion));
+        
+        // We are going to say false here to avoid mocking and testing a whole bunch of library specific init
+        // code that the ContainerScanStepRunner constructor does.
+        // We'll call the method we are after directly in the method.invoke call below.
+        when(mockBlackDuckVersion.isAtLeast(new BlackDuckVersion(2024, 10, 0))).thenReturn(false);
+        
+        when(mockUploadFactory.createContainerUploader(Mockito.anyString())).thenReturn(mockContainerUploader);
+        
+        when(mockOperationRunner.getContainerScanImage(Mockito.any(), Mockito.any())).thenReturn(mockContainerImage);
+     
+        instance = new ContainerScanStepRunner(mockOperationRunner, mockNameVersion, mockBlackDuckRunData, new Gson());
+        
+        Field fieldScan = ContainerScanStepRunner.class.getDeclaredField("scanId");
+        fieldScan.setAccessible(true);
+        UUID scanId = UUID.randomUUID();
+        fieldScan.set(instance, scanId);
+
+        Field fieldFactory = ContainerScanStepRunner.class.getDeclaredField("uploadFactory");
+        fieldFactory.setAccessible(true);
+        fieldFactory.set(instance, mockUploadFactory);
+    }
+
+    @Test
+    public void testContainerScanSuccessResult() throws Exception {        
+        DefaultUploadStatus expectedStatus = new DefaultUploadStatus(204, "", null);
+        when(mockContainerUploader.upload(mockContainerImage.toPath())).thenReturn(expectedStatus);
+
+        Method method = ContainerScanStepRunner.class.getDeclaredMethod("multiPartUploadImage");
+        method.setAccessible(true);
+
+        DefaultUploadStatus status = (DefaultUploadStatus) method.invoke(instance);
+
+        assertEquals(204, status.getStatusCode());
+    }
+    
+    @Test
+    public void testContainerScanFailureResult() throws Exception {
+        IntegrationException exception = new IntegrationException("Upload failed.");
+        DefaultUploadStatus expectedStatus = new DefaultUploadStatus(500, "", exception);
+        when(mockContainerUploader.upload(mockContainerImage.toPath())).thenReturn(expectedStatus);
+        
+        Method method = ContainerScanStepRunner.class.getDeclaredMethod("multiPartUploadImage");
+        method.setAccessible(true);
+
+        try {
+            method.invoke(instance);
+        } catch (Exception e) {
+            assertEquals("Upload failed.", e.getCause().getMessage());  
+        }        
+    }
+    
+}


### PR DESCRIPTION
This work uses the upload library to transmit large container images in chunks so that larger file uploads can be achieved. It is very similar to the multipart binary upload work that was delivered in 9.9.