### PR TITLE
Support for Go extended to 1.22.5.

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -12,6 +12,7 @@
 * When running [company_name] [solution_name] against a [blackduck_product_name] instance of version 2024.7.0 or later, the Scan CLI tool download will use a new format for the URL. 
 	* Current URL format: https://<BlackDuck_Instance>/download/scan.cli-macosx.zip
 	* New URL format: https://<BlackDuck_Instance>/api/tools/scan.cli.zip/versions/latest/platforms/macosx
+* Support for GoLang is now extended to Go 1.22.5.
 
 ### Resolved issues
 

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/GoModTest.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/GoModTest.java
@@ -27,7 +27,7 @@ public class GoModTest {
 
     private static final String[] GO_VERSIONS_TO_TEST = new String[] {
         "1.16.15",
-        "1.22.2"
+        "1.22.5"
     };
 
     private static final String PROJECT_NAME = "go-mod-docker";


### PR DESCRIPTION
# Description

Support for Go extended to 1.22.5. 

# Github Issues

IDETECT-4388
