### PR TITLE
Handle file and url components in pnpm detector

### DIFF
--- a/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/process/PnpmYamlTransformer.java
+++ b/detectable/src/main/java/com/synopsys/integration/detectable/detectables/pnpm/lockfile/process/PnpmYamlTransformer.java
@@ -85,10 +85,6 @@ public class PnpmYamlTransformer {
         for (Map.Entry<String, PnpmPackageInfo> packageEntry : packageMap.entrySet()) {
             String packageId = packageEntry.getKey();
             
-            if (packageId.contains("vanilla")) {
-                String breakHere = "";
-            }
-            
             Optional<Dependency> pnpmPackage = buildDependencyFromPackageEntry(packageEntry);
             if (!pnpmPackage.isPresent()) {
                 logger.debug(String.format("Could not add package %s to the graph.", packageId));

--- a/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmYamlTransformerTestv9.java
+++ b/detectable/src/test/java/com/synopsys/integration/detectable/detectables/pnpm/unit/PnpmYamlTransformerTestv9.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.bdio.model.dependency.Dependency;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.model.PnpmPackageInfo;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.process.PnpmLinkedPackageResolver;
 import com.synopsys.integration.detectable.detectables.pnpm.lockfile.process.PnpmYamlTransformer;
@@ -67,5 +68,24 @@ public class PnpmYamlTransformerTestv9 {
         
         assertEquals("@ampproject/remapping", result.getName());
         assertEquals("2.3.0", result.getVersion());
+    }
+    
+    @Test
+    public void testFileAndUrlVersionCreation() throws Exception {
+        Method method = PnpmYamlTransformer.class.getDeclaredMethod("buildDependencyFromPackageEntry", Map.Entry.class);
+        method.setAccessible(true);
+        
+        Map<String, PnpmPackageInfo> packageEntry = new HashMap<>();
+        PnpmPackageInfo packageInfo = new PnpmPackageInfo();
+        packageInfo.version = "10.3.1";
+        packageEntry.put("@use-gesture/vanilla@file:vanilla.tgz", packageInfo);
+        
+        for (Map.Entry<String, PnpmPackageInfo> entry : packageEntry.entrySet()) {
+            Optional<Dependency> optDependency = (Optional<Dependency>) method.invoke(instance, entry);
+            Dependency dependency = optDependency.get();
+            
+            assertEquals("@use-gesture/vanilla", dependency.getName());
+            assertEquals("10.3.1", dependency.getVersion());
+        }
     }
 }


### PR DESCRIPTION
In addition to specifying a version of a component to be pulled from a public repository, components can be specified via file and URLs. These get resolved by pnpm into a version but they are located in different areas than where we typically find them. This work expands how we look for the version of a component.