### PR TITLE
Clean up platform-1 blackduck-client docker images after pushing the image to internal docker registry

### DIFF
--- a/platform-1/submit.sh
+++ b/platform-1/submit.sh
@@ -13,6 +13,10 @@ docker tag ${TARGET_REPO}/${TARGET_IMAGE}:${TARGET_IMAGE_TAG} ${INTERNAL_DOCKER_
 docker push ${INTERNAL_DOCKER_REGISTRY}/${TARGET_REPO}/${TARGET_IMAGE}:${TARGET_IMAGE_TAG}
 docker tag ${INTERNAL_DOCKER_REGISTRY}/${TARGET_REPO}/${TARGET_IMAGE}:${TARGET_IMAGE_TAG} ${TARGET_REPO}/${TARGET_IMAGE}:${TARGET_IMAGE_TAG}
 
+# clean up docker images after pushing
+docker rmi ${INTERNAL_DOCKER_REGISTRY}/${TARGET_REPO}/${TARGET_IMAGE}:${TARGET_IMAGE_TAG}
+docker rmi ${TARGET_REPO}/${TARGET_IMAGE}:${TARGET_IMAGE_TAG}
+
 # upload to artifactory
 zip_sha=$(echo $(sha256sum synopsys-detect-${RELEASE_VERSION}-air-gap.zip) | cut -d' ' -f 1)
 


### PR DESCRIPTION
#### Description
Our release and release-qa jobs build a blackducksoftware/blackduck-client Docker image on the Jenkins build machine, every time these jobs run the `submitToPlatform1` Gradle task, and we tag this image twice. 

Each image is 1.4GB. Whenever release-qa or release is run, these images quickly pile up and cause space issues on the build server.

Currently, we have been manually cleaning up these duplicate images from the build server.

#### JIRA
IDETECT-4237