### PR TITLE
Idetect 4505 - Minimum BD version for correlation scan is 2024.10.0

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectProperties.java
@@ -1813,10 +1813,9 @@ public class DetectProperties {
             .setCategory(DetectCategory.Advanced)
             .build();
 
-    // TODO check/adjust from version once we know
     public static final BooleanProperty DETECT_INTEGRATED_MATCHING_ENABLED =
         BooleanProperty.newBuilder("detect.blackduck.integrated.matching.enabled", false)
-            .setInfo("Integrated Matching Enabled", DetectPropertyFromVersion.VERSION_9_10_0)
+            .setInfo("Integrated Matching Enabled", DetectPropertyFromVersion.VERSION_10_0_0)
             .setHelp(
                 "When enabled, Synopsys Detect activates the Black Duck integrated matching capability to enhance match accuracy.",
                 "The integrated matching capability must be present and enabled in your Black Duck server before you enable the integrated matching feature in Synopsys Detect."

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectPropertyFromVersion.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectPropertyFromVersion.java
@@ -50,8 +50,6 @@ public enum DetectPropertyFromVersion implements PropertyVersion {
     VERSION_9_6_0("9.6.0"),
     VERSION_9_7_0("9.7.0"),
     VERSION_9_8_0("9.8.0"),
-    VERSION_9_9_0("9.9.0"),
-    VERSION_9_10_0("9.10.0"),
     VERSION_10_0_0("10.0.0");
 
     private final String version;

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/version/BlackDuckMinimumVersionChecks.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/version/BlackDuckMinimumVersionChecks.java
@@ -40,7 +40,7 @@ public class BlackDuckMinimumVersionChecks {
         checks.add(new BlackDuckMinimumVersionCheck(
                 "Integrated match correlation",
                 o -> o.isIntegratedMatchingEnabled(),
-                new BlackDuckVersion(2024, 7, 1)
+                new BlackDuckVersion(2024, 10, 0)
         ));
     }
 

--- a/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/version/BlackDuckVersionChecker.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/boot/product/version/BlackDuckVersionChecker.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.version.BlackDuckVersion;
-import com.synopsys.integration.detect.configuration.DetectPropertyConfiguration;
 
 public class BlackDuckVersionChecker {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());


### PR DESCRIPTION
# Description

Sets BD version as 2024.10.0 for integrated match correlation.

# Github Issues

IDETECT-4505
