### PR TITLE
Improve small chunk error handling for container scans

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
+++ b/src/main/java/com/synopsys/integration/detect/lifecycle/run/step/ContainerScanStepRunner.java
@@ -165,19 +165,12 @@ public class ContainerScanStepRunner {
         }
     }
     
-    private DefaultUploadStatus multiPartUploadImage() throws IntegrationException {
+    private DefaultUploadStatus multiPartUploadImage() throws IntegrationException, IOException {
         String storageServiceEndpoint = String.join("", STORAGE_CONTAINERS_ENDPOINT, scanId.toString());
         ContainerUploader containerUploader = uploadFactory.createContainerUploader(storageServiceEndpoint);
         
-        DefaultUploadStatus status;
-        
-        try {
-            logger.debug("Performing multipart container image upload to storage endpoint: {}", storageServiceEndpoint);
-            status = containerUploader.upload(containerImage.toPath());
-        } catch (IOException | IntegrationException e) {
-            logger.trace("Unable to upload multipart container image.");
-            throw new IntegrationException("Unable to upload multipart container image.", e);
-        }
+        logger.debug("Performing multipart container image upload to storage endpoint: {}", storageServiceEndpoint);
+        DefaultUploadStatus status = containerUploader.upload(containerImage.toPath());
             
         if (status == null || status.isError()) {
             handleUploadError(status);


### PR DESCRIPTION
When doing a multipart container scan, if the chunk size is set below the 5 mb minimum we aren't logging a meaningful error. This MR corrects a mistake where I was overwriting the library error message with a less meaningful one of my own. So we simply use the exception coming from the library instead of catching it.