### PR TITLE
DRAFT: IDETECT-4469 - Sanitize the dependency line before processing for dependency extraction

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/python/util/PythonDependencyTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/python/util/PythonDependencyTransformer.java
@@ -21,10 +21,6 @@ public class PythonDependencyTransformer {
         List<PythonDependency> dependencies = new LinkedList<>();
         try (BufferedReader bufferedReader = new BufferedReader(new FileReader(requirementsFile))) {
             for (String line; (line = bufferedReader.readLine()) != null; ) {
-                if (line.contains("\u0000")) {
-                    line = line.replaceAll("\u0000", "");
-                }
-                
                 PythonDependency requirementsFileDependency = transformLine(line);
                 
                 if (requirementsFileDependency != null) {
@@ -112,6 +108,9 @@ public class PythonDependencyTransformer {
     }
 
     public String formatLine(String line) {
+        if (line.contains("\u0000")) {
+            line = line.replaceAll("\u0000", "");
+        }
         int ignoreAfterIndex;
         String formattedLine = line.trim();
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/python/util/PythonDependencyTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/python/util/PythonDependencyTransformer.java
@@ -21,6 +21,9 @@ public class PythonDependencyTransformer {
         List<PythonDependency> dependencies = new LinkedList<>();
         try (BufferedReader bufferedReader = new BufferedReader(new FileReader(requirementsFile))) {
             for (String line; (line = bufferedReader.readLine()) != null; ) {
+                if (line.contains("\u0000")) {
+                    line = line.replaceAll("\u0000", "");
+                }
                 
                 PythonDependency requirementsFileDependency = transformLine(line);
                 


### PR DESCRIPTION
# Description

Sanitize the dependency lines from requirements.txt file by eliminating null (`\u0000`) characters before processing for dependency extraction.