### PR TITLE
update release notes to reflect removal of full snippet scan values

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -20,3 +20,4 @@
 ### Changed features
 
 * The `logging.level.com.synopsys.integration` property that was deprecated in [detect_product_long] 9.x, has been removed. Use `logging.level.detect` instead.
+* The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options for the `detect.blackduck.signature.scanner.snippet.matching` property that was deprecated in [detect_product_long] 9.x, have been removed.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -19,5 +19,5 @@
 
 ### Changed features
 
-* The `logging.level.com.synopsys.integration` property that was deprecated in [detect_product_long] 9.x, has been removed. Use `logging.level.detect` instead.
-* The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options for the `detect.blackduck.signature.scanner.snippet.matching` property that was deprecated in [detect_product_long] 9.x, have been removed.
+* The `logging.level.com.synopsys.integration` property deprecated in [detect_product_short] 9.x, has been removed. Use `logging.level.detect` instead.
+* The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options for the `detect.blackduck.signature.scanner.snippet.matching` property deprecated in [detect_product_short] 9.x, have been removed.


### PR DESCRIPTION
This MR removes values of snippet scans that were deprecated in Detect 9. The code to do this has been delivered already, mostly in blackduck-common, so this is simply updating the release notes.