### PR TITLE
Protect against empty version string

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/workflow/project/ProjectNameVersionDecider.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/project/ProjectNameVersionDecider.java
@@ -37,7 +37,7 @@ public class ProjectNameVersionDecider {
         String decidedProjectVersionName;
         if (StringUtils.isNotBlank(projectVersionOptions.overrideProjectVersionName)) {
             decidedProjectVersionName = projectVersionOptions.overrideProjectVersionName;
-        } else if (chosenToolVersion.isPresent()) {
+        } else if (chosenToolVersion.isPresent() && !chosenToolVersion.get().isBlank()) {
             decidedProjectVersionName = chosenToolVersion.get();
         } else {
             logger.debug("A project version name could not be decided. Using the default version text.");


### PR DESCRIPTION
Previously we only guarded against null. A "" doesn't typically appear in a version but it can if a user actually puts that in the version field. This adds some additional protection against sending no version to BD which fails the project creation or update.