### PR TITLE
Strip out correlation ID in case of rapid/stateless scan mode or offline scan mode

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -228,8 +228,14 @@ public class DetectBoot {
             boolean blackduckScanModeSpecified = detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
             boolean blackduckUrlSpecified = detectConfiguration.wasPropertyProvided(DetectProperties.BLACKDUCK_URL);
             boolean blackduckOfflineModeSpecified = detectConfiguration.wasPropertyProvided(DetectProperties.BLACKDUCK_OFFLINE_MODE);
+            
             BlackDuckConnectionDetails blackDuckConnectionDetails = detectConfigurationFactory.createBlackDuckConnectionDetails();
             BlackduckScanMode blackduckScanMode = decideScanMode(blackDuckConnectionDetails, scanTypeEvidenceMap, blackduckScanModeSpecified, detectConfigurationFactory, autonomousScanEnabled, detectConfiguration);
+            if (!blackduckScanMode.equals(BlackduckScanMode.INTELLIGENT)) {
+                detectBootFactory.stripCorrelationiD("Correlated Scanning is not available for Rapid/Stateless scan mode. A correlation ID will not be set.");
+            } else if (blackduckOfflineModeSpecified) {
+                detectBootFactory.stripCorrelationiD("Correlated Scanning is not available for offline scanning. A correlation ID will not be set.");
+            }
             autonomousManager.setBlackDuckScanMode(blackduckScanMode.toString());
             ProductDecider productDecider = new ProductDecider(autonomousScanEnabled, blackduckUrlSpecified, blackduckOfflineModeSpecified);
             BlackDuckDecision blackDuckDecision = productDecider.decideBlackDuck(

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -228,13 +228,11 @@ public class DetectBoot {
             boolean blackduckScanModeSpecified = detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
             boolean blackduckUrlSpecified = detectConfiguration.wasPropertyProvided(DetectProperties.BLACKDUCK_URL);
             boolean blackduckOfflineModeSpecified = detectConfiguration.wasPropertyProvided(DetectProperties.BLACKDUCK_OFFLINE_MODE);
-            
+            Boolean offline = detectConfiguration.getValue(DetectProperties.BLACKDUCK_OFFLINE_MODE);
             BlackDuckConnectionDetails blackDuckConnectionDetails = detectConfigurationFactory.createBlackDuckConnectionDetails();
             BlackduckScanMode blackduckScanMode = decideScanMode(blackDuckConnectionDetails, scanTypeEvidenceMap, blackduckScanModeSpecified, detectConfigurationFactory, autonomousScanEnabled, detectConfiguration);
-            if (!blackduckScanMode.equals(BlackduckScanMode.INTELLIGENT)) {
-                detectBootFactory.stripCorrelationiD("Correlated Scanning is not available for Rapid/Stateless scan mode. A correlation ID will not be set.");
-            } else if (blackduckOfflineModeSpecified) {
-                detectBootFactory.stripCorrelationiD("Correlated Scanning is not available for offline scanning. A correlation ID will not be set.");
+            if (offline || !blackduckScanMode.equals(BlackduckScanMode.INTELLIGENT)) {
+                detectBootFactory.stripCorrelationiD("Correlated Scanning is not available for Rapid/Stateless scan mode or offline scanning. A correlation ID will not be set.");
             }
             autonomousManager.setBlackDuckScanMode(blackduckScanMode.toString());
             ProductDecider productDecider = new ProductDecider(autonomousScanEnabled, blackduckUrlSpecified, blackduckOfflineModeSpecified);

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBootFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBootFactory.java
@@ -242,5 +242,9 @@ public class DetectBootFactory {
         InteractiveModeDecisionTree interactiveModeDecisionTree = new InteractiveModeDecisionTree(detectInfo, blackDuckConnectivityChecker, propertySources, gson);
         return new InteractiveManager(propertySourceBuilder, writer, interactiveModeDecisionTree);
     }
+    
+    public void stripCorrelationiD(String reason) {
+        detectRunId.stripCorrelationiD(reason);
+    }
 
 }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/DetectRun.java
@@ -89,8 +89,8 @@ public class DetectRun {
             operationRunner.publishProjectNameVersionChosen(nameVersion);
             BdioResult bdio;
             Boolean forceBdio = bootSingletons.getDetectConfigurationFactory().forceBdio();
-            logger.debug("Integrated Matching Correlation ID: {}", bootSingletons.getDetectRunId().getIntegratedMatchingCorrelationId());
-            String correlationId = operationRunner.getDetectConfigurationFactory().isCorrelatedScanningEnabled()? bootSingletons.getDetectRunId().getIntegratedMatchingCorrelationId():null;
+            logger.debug("Integrated Matching Correlation ID: {}", bootSingletons.getDetectRunId().getCorrelationId());
+            String correlationId = operationRunner.getDetectConfigurationFactory().isCorrelatedScanningEnabled()? bootSingletons.getDetectRunId().getCorrelationId():null;
             if (!universalToolsResult.getDetectCodeLocations().isEmpty()
                     || (productRunData.shouldUseBlackDuckProduct() && !productRunData.getBlackDuckRunData().isOnline() && forceBdio && !universalToolsResult.didAnyFail() && exitCodeManager.getWinningExitCode().isSuccess())) {
                 bdio = stepRunner.generateBdio(correlationId, universalToolsResult, nameVersion);

--- a/src/main/java/com/blackduck/integration/detect/workflow/DetectRunId.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/DetectRunId.java
@@ -7,33 +7,33 @@ import java.util.UUID;
 
 public class DetectRunId {
     private final String id;
-    private String integratedMatchingCorrelationId;
+    private String correlationId;
 
     public static DetectRunId createDefault() {
         return new DetectRunId(
             DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss-SSS").withZone(ZoneOffset.UTC).format(Instant.now().atZone(ZoneOffset.UTC)),
-            generateIntegratedMatchingCorrelationId()
+            correlationId()
         );
     }
 
-    public static String generateIntegratedMatchingCorrelationId() {
+    public static String correlationId() {
         return UUID.randomUUID().toString();
     }
 
-    public DetectRunId(String id, String integratedMatchingCorrelationId) {
+    public DetectRunId(String id, String correlationId) {
         this.id = id;
-        this.integratedMatchingCorrelationId = integratedMatchingCorrelationId;
+        this.correlationId = correlationId;
     }
 
     public String getRunId() {
         return this.id;
     }
 
-    public String getIntegratedMatchingCorrelationId() {
-        return integratedMatchingCorrelationId;
+    public String getCorrelationId() {
+        return correlationId;
     }
     
     public void stripCorrelationiD(String reason) {
-        integratedMatchingCorrelationId = "";
+        correlationId = "";
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/workflow/DetectRunId.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/DetectRunId.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public class DetectRunId {
     private final String id;
-    private final String integratedMatchingCorrelationId;
+    private String integratedMatchingCorrelationId;
 
     public static DetectRunId createDefault() {
         return new DetectRunId(
@@ -31,5 +31,9 @@ public class DetectRunId {
 
     public String getIntegratedMatchingCorrelationId() {
         return integratedMatchingCorrelationId;
+    }
+    
+    public void stripCorrelationiD(String reason) {
+        integratedMatchingCorrelationId = "";
     }
 }

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidModeGenerateJsonOperationTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidModeGenerateJsonOperationTest.java
@@ -31,7 +31,7 @@ public class RapidModeGenerateJsonOperationTest {
         File tempDir = tempPath.toFile();
         File scanDir = new File(tempDir, "scan");
         DirectoryOptions directoryOptions = new DirectoryOptions(null, null, null, scanDir.toPath(), null, null, null);
-        DetectRunId detectRunId = new DetectRunId("testId", DetectRunId.generateIntegratedMatchingCorrelationId());
+        DetectRunId detectRunId = new DetectRunId("testId", DetectRunId.correlationId());
         DirectoryManager directoryManager = new DirectoryManager(directoryOptions, detectRunId);
         RapidModeGenerateJsonOperation op = new RapidModeGenerateJsonOperation(gson, directoryManager);
         NameVersion projectNameVersion = new NameVersion("testName", "testVersion");

--- a/src/test/java/com/blackduck/integration/detect/workflow/status/DetectStatusOutputTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/status/DetectStatusOutputTest.java
@@ -19,7 +19,7 @@ public class DetectStatusOutputTest {
         File tempDir = tempPath.toFile();
         File scanDir = new File(tempDir, "scan");
         DirectoryOptions directoryOptions = new DirectoryOptions(null, null, null, scanDir.toPath(), null, null, tempPath);
-        DetectRunId detectRunId = new DetectRunId("testId", DetectRunId.generateIntegratedMatchingCorrelationId());
+        DetectRunId detectRunId = new DetectRunId("testId", DetectRunId.correlationId());
         DirectoryManager directoryManager = new DirectoryManager(directoryOptions, detectRunId);
 
         assertEquals(tempPath.toFile(), directoryManager.getJsonStatusOutputDirectory());


### PR DESCRIPTION
# Description

Strip out correlation ID in case of rapid/stateless scan mode or offline scan mode. This change will be in place until Correlated Scan feature support is added in the server for these scan modes.

# Github Issues

IDETECT-4503
