### PR TITLE
Update Detect 8 to pull from updated artifactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,8 @@ def createBatteryPath() {
 
 def final locatorGroup = "com.synopsys.integration"
 def final locatorModule = "component-locator"
-final def externalRepoHost = "https://sig-repo.synopsys.com"
+final def externalRepoHost = "https://repo.blackduck.com"
+final def externalRepoFallbackHost = "https://sig-repo.synopsys.com"
 final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 
 repositories {
@@ -70,6 +71,14 @@ repositories {
     }
     maven { 
         url "${externalRepoHost}/bds-bdio-release"
+        content { excludeModule(locatorGroup, locatorModule) }
+    }
+        maven { 
+        url = uri("${externalRepoFallbackHost}/artifactory/bds-integration-placeholder-release") 
+        content { includeModule(locatorGroup, locatorModule) }
+    }
+    maven { 
+        url "${externalRepoFallbackHost}/bds-bdio-release"
         content { excludeModule(locatorGroup, locatorModule) }
     }
 }

--- a/buildSrc/src/main/java/com/synopsys/integration/detect/docs/content/Terms.java
+++ b/buildSrc/src/main/java/com/synopsys/integration/detect/docs/content/Terms.java
@@ -10,10 +10,10 @@ public class Terms {
         termMap.put("solution_name", "Synopsys Detect");
         termMap.put("script_repo_url_bash", "https://detect.synopsys.com/detect8.sh");
         termMap.put("script_repo_url_powershell", "https://detect.synopsys.com/detect8.ps1");
-        termMap.put("binary_repo_url_project", "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect");
-        termMap.put("binary_repo_ui_url_project", "https://sig-repo.synopsys.com/ui/repos/tree/General/bds-integrations-release/com/synopsys/integration/synopsys-detect");
-		termMap.put("binary_repo_jenkins_url_project", "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/blackducksoftware/integration/blackduck-detect/");
-		termMap.put("binary_repo_url_sigma", "https://sig-repo.synopsys.com/artifactory/sigma-release-trial/2022.6.0/");
+        termMap.put("binary_repo_url_project", "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect");
+        termMap.put("binary_repo_ui_url_project", "https://repo.blackduck.com/ui/repos/tree/General/bds-integrations-release/com/synopsys/integration/synopsys-detect");
+		termMap.put("binary_repo_jenkins_url_project", "https://repo.blackduck.com/artifactory/bds-integrations-release/com/blackducksoftware/integration/blackduck-detect/");
+		termMap.put("binary_repo_url_sigma", "https://repo.blackduck.com/artifactory/sigma-release-trial/2022.6.0/");
     }
 
     public String put(String termKey, String replacementString) {

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -1,5 +1,12 @@
 # Current Release notes
 
+## Version 8.11.2
+
+### New features
+
+* Adds logic to pull necessary artifacts from the repo.blackduck.com artifactory. If this is not accessible then artifacts will be downloaded from the sig-repo.synopsys.com repository. 
+Note: The repo.blackduck.com artifactory should be added to firewall allow lists to ensure continued operation of [solution_name]. sig-repo.synopsys.com will be sunset February 2025.
+
 ## Version 8.11.0
 
 ### New features

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -2,10 +2,10 @@
 
 ## Version 8.11.2
 
-### New features
+### Changed features
 
-* Adds logic to pull necessary artifacts from the repo.blackduck.com artifactory. If this is not accessible then artifacts will be downloaded from the sig-repo.synopsys.com repository. 
-Note: The repo.blackduck.com artifactory should be added to firewall allow lists to ensure continued operation of [solution_name]. sig-repo.synopsys.com will be sunset February 2025.
+* Adds logic to pull necessary artifacts from the repo.blackduck.com repository. If this is not accessible then artifacts will be downloaded from the sig-repo.synopsys.com repository. 
+Note: The repo.blackduck.com repository should be added to firewall allow lists to ensure continued operation of [solution_name].
 
 ## Version 8.11.0
 

--- a/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/synopsys/integration/detect/configuration/DetectableOptionFactory.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.detect.workflow.ArtifactoryConstants;
+import com.synopsys.integration.detect.workflow.ArtifactoryConstantsHelper;
 import com.synopsys.integration.detect.workflow.diagnostic.DiagnosticSystem;
 import com.synopsys.integration.detectable.detectable.util.EnumListFilter;
 import com.synopsys.integration.detectable.detectables.bazel.BazelDetectableOptions;
@@ -148,7 +149,7 @@ public class DetectableOptionFactory {
         List<String> includedProjectPaths = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_INCLUDED_PROJECT_PATHS);
         List<String> excludedConfigurationNames = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_EXCLUDED_CONFIGURATIONS);
         List<String> includedConfigurationNames = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_INCLUDED_CONFIGURATIONS);
-        String customRepository = ArtifactoryConstants.GRADLE_INSPECTOR_MAVEN_REPO;
+        String customRepository = ArtifactoryConstantsHelper.getArtifactoryUrl() + ArtifactoryConstants.GRADLE_INSPECTOR_MAVEN_REPO;
 
         Set<GradleConfigurationType> excludedConfigurationTypes = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_CONFIGURATION_TYPES_EXCLUDED).representedValueSet();
         EnumListFilter<GradleConfigurationType> dependencyTypeFilter = EnumListFilter.fromExcluded(excludedConfigurationTypes);

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/DockerInspectorInstaller.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/DockerInspectorInstaller.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import com.synopsys.integration.detect.configuration.DetectUserFriendlyException;
 import com.synopsys.integration.detect.workflow.ArtifactResolver;
 import com.synopsys.integration.detect.workflow.ArtifactoryConstants;
+import com.synopsys.integration.detect.workflow.ArtifactoryConstantsHelper;
 import com.synopsys.integration.exception.IntegrationException;
 
 public class DockerInspectorInstaller {
@@ -23,7 +24,7 @@ public class DockerInspectorInstaller {
     public File installJar(File dockerDirectory, Optional<String> dockerVersion) throws IntegrationException, IOException, DetectUserFriendlyException {
         logger.info("Determining the location of the Docker inspector.");
         String location = artifactResolver.resolveArtifactLocation(
-            ArtifactoryConstants.ARTIFACTORY_URL,
+            ArtifactoryConstantsHelper.getArtifactoryUrl(),
             ArtifactoryConstants.DOCKER_INSPECTOR_REPO,
             ArtifactoryConstants.DOCKER_INSPECTOR_PROPERTY,
             dockerVersion.orElse(""),
@@ -35,7 +36,7 @@ public class DockerInspectorInstaller {
     public File installAirGap(File dockerDirectory) throws IntegrationException, IOException, DetectUserFriendlyException {
         logger.info("Determining the location of the Docker inspector.");
         String location = artifactResolver.resolveArtifactLocation(
-            ArtifactoryConstants.ARTIFACTORY_URL,
+            ArtifactoryConstantsHelper.getArtifactoryUrl(),
             ArtifactoryConstants.DOCKER_INSPECTOR_REPO,
             ArtifactoryConstants.DOCKER_INSPECTOR_AIR_GAP_PROPERTY,
             "",

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/nuget/ArtifactoryNugetInspectorInstaller.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/nuget/ArtifactoryNugetInspectorInstaller.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import com.synopsys.integration.detect.configuration.DetectInfo;
 import com.synopsys.integration.detect.tool.detector.inspector.ArtifactoryZipInstaller;
 import com.synopsys.integration.detect.workflow.ArtifactoryConstants;
+import com.synopsys.integration.detect.workflow.ArtifactoryConstantsHelper;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.OperatingSystemType;
@@ -50,7 +51,7 @@ public class ArtifactoryNugetInspectorInstaller {
             return artifactoryZipInstaller.installZipFromSource(
                 installDirectory,
                 ".zip",
-                ArtifactoryConstants.ARTIFACTORY_URL,
+                ArtifactoryConstantsHelper.getArtifactoryUrl(),
                 ArtifactoryConstants.NUGET_INSPECTOR_PROPERTY_REPO,
                 property
             );

--- a/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/projectinspector/installer/ArtifactoryProjectInspectorInstaller.java
+++ b/src/main/java/com/synopsys/integration/detect/tool/detector/inspector/projectinspector/installer/ArtifactoryProjectInspectorInstaller.java
@@ -10,6 +10,7 @@ import com.synopsys.integration.detect.configuration.DetectInfo;
 import com.synopsys.integration.detect.tool.detector.inspector.ArtifactoryZipInstaller;
 import com.synopsys.integration.detect.tool.detector.inspector.projectinspector.ProjectInspectorExecutableLocator;
 import com.synopsys.integration.detect.workflow.ArtifactoryConstants;
+import com.synopsys.integration.detect.workflow.ArtifactoryConstantsHelper;
 import com.synopsys.integration.detectable.detectable.exception.DetectableException;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.OperatingSystemType;
@@ -51,7 +52,7 @@ public class ArtifactoryProjectInspectorInstaller implements ProjectInspectorIns
             return artifactoryZipInstaller.installZipFromSource(
                 installDirectory,
                 ".zip",
-                ArtifactoryConstants.ARTIFACTORY_URL,
+                ArtifactoryConstantsHelper.getArtifactoryUrl(),
                 ArtifactoryConstants.PROJECT_INSPECTOR_PROPERTY_REPO,
                 property
             );

--- a/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstants.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstants.java
@@ -1,10 +1,11 @@
 package com.synopsys.integration.detect.workflow;
 
-public class ArtifactoryConstants {
-    public static final String ARTIFACTORY_URL = "https://sig-repo.synopsys.com/";
+public class ArtifactoryConstants {	
+    public static final String ARTIFACTORY_URL = "https://repo.blackduck.com/";
+    public static final String ARTIFACTORY_FALLBACK_URL = "https://sig-repo.synopsys.com/";
     public static final String VERSION_PLACEHOLDER = "<VERSION>";
 
-    public static final String GRADLE_INSPECTOR_MAVEN_REPO = ARTIFACTORY_URL + "bds-integration-public-cache/";
+    public static final String GRADLE_INSPECTOR_MAVEN_REPO = "bds-integration-public-cache/";
 
     public static final String NUGET_INSPECTOR_PROPERTY_REPO = "bds-integrations-release/com/synopsys/integration/synopsys-detect";
     public static final String NUGET_INSPECTOR_MAC_PROPERTY = "NUGET_INSPECTOR_MAC_LATEST_1";

--- a/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstantsHelper.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstantsHelper.java
@@ -1,0 +1,38 @@
+package com.synopsys.integration.detect.workflow;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ArtifactoryConstantsHelper {
+    private static final Logger logger = LoggerFactory.getLogger(ArtifactoryConstantsHelper.class);
+    
+    public static String getArtifactoryUrl() {
+    	return isBlackDuckUrlAccessible(ArtifactoryConstants.ARTIFACTORY_URL) ? ArtifactoryConstants.ARTIFACTORY_URL : ArtifactoryConstants.ARTIFACTORY_FALLBACK_URL;
+    }
+    
+    public static boolean isBlackDuckUrlAccessible(String targetUrl) {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(targetUrl);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("HEAD");
+            int responseCode = connection.getResponseCode();
+            if (200 <= responseCode && responseCode <= 399) {
+            	return true;
+            } else {
+            	logger.warn(String.format("https://repo.blackduck.com responded with unanticipated code {}. Please allow access through your firewall as https://sig-repo.synopsys.com will be shutdown at the end of February 2025."), responseCode);
+            	return false;
+            }
+        } catch (Exception e) {
+        	logger.warn("https://repo.blackduck.com is inaccessible from this machine. Please allow access through your firewall as https://sig-repo.synopsys.com will be shutdown at the end of February 2025.");
+            return false;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+}

--- a/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstantsHelper.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstantsHelper.java
@@ -8,9 +8,13 @@ import org.slf4j.LoggerFactory;
 
 public class ArtifactoryConstantsHelper {
     private static final Logger logger = LoggerFactory.getLogger(ArtifactoryConstantsHelper.class);
+    private static Boolean isBlackDuckUrlAccessible;
     
     public static String getArtifactoryUrl() {
-    	return isBlackDuckUrlAccessible(ArtifactoryConstants.ARTIFACTORY_URL) ? ArtifactoryConstants.ARTIFACTORY_URL : ArtifactoryConstants.ARTIFACTORY_FALLBACK_URL;
+        if (isBlackDuckUrlAccessible == null) {
+            isBlackDuckUrlAccessible = isBlackDuckUrlAccessible(ArtifactoryConstants.ARTIFACTORY_URL);
+        }
+        return isBlackDuckUrlAccessible ? ArtifactoryConstants.ARTIFACTORY_URL : ArtifactoryConstants.ARTIFACTORY_FALLBACK_URL;
     }
     
     public static boolean isBlackDuckUrlAccessible(String targetUrl) {

--- a/src/main/java/com/synopsys/integration/detect/workflow/blackduck/font/DetectFontInstaller.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/blackduck/font/DetectFontInstaller.java
@@ -12,6 +12,7 @@ import com.synopsys.integration.detect.tool.cache.InstalledToolLocator;
 import com.synopsys.integration.detect.tool.cache.InstalledToolManager;
 import com.synopsys.integration.detect.workflow.ArtifactResolver;
 import com.synopsys.integration.detect.workflow.ArtifactoryConstants;
+import com.synopsys.integration.detect.workflow.ArtifactoryConstantsHelper;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.Slf4jIntLogger;
 import com.synopsys.integration.util.CommonZipExpander;
@@ -33,7 +34,7 @@ public class DetectFontInstaller {
         try {
             logger.info("Determining the location of the fonts bundle.");
             String location = artifactResolver.resolveArtifactLocation(
-                ArtifactoryConstants.ARTIFACTORY_URL,
+                ArtifactoryConstantsHelper.getArtifactoryUrl(),
                 ArtifactoryConstants.FONTS_REPO,
                 ArtifactoryConstants.FONTS_PROPERTY,
                 "",

--- a/src/main/resources/create-gradle-airgap-script.ftl
+++ b/src/main/resources/create-gradle-airgap-script.ftl
@@ -1,5 +1,8 @@
 repositories {
     maven {
+        url 'https://repo.blackduck.com/bds-integration-public-cache/'
+    }
+    maven {
         url 'https://sig-repo.synopsys.com/bds-integration-public-cache/'
     }
 }

--- a/src/test/java/com/synopsys/integration/detect/battery/docker/Dotnet5Test.java
+++ b/src/test/java/com/synopsys/integration/detect/battery/docker/Dotnet5Test.java
@@ -25,7 +25,7 @@ public class Dotnet5Test {
 
             dockerAssertions.successfulDetectorType("NUGET");
             dockerAssertions.atLeastOneBdioFile();
-            dockerAssertions.logContainsPattern("https://sig-repo.synopsys.com/.*bds-integrations-release/com/synopsys/integration/detect-nuget-inspector/"); // Verify we are using the EXTERNAL artifactory to download the inspector.
+            dockerAssertions.logContainsPattern("https://repo.blackduck.com/.*bds-integrations-release/com/synopsys/integration/detect-nuget-inspector/"); // Verify we are using the EXTERNAL artifactory to download the inspector.
         }
     }
 


### PR DESCRIPTION
This change primarily attempts to download artifacts from repo.blackduck.com first, falling back to sig-repo.synopsys.com if it is not accessible. Users should begin to allow repo.blackduck.com through their firewalls if necessary.

More specifically the changes implement this fallback mechanism in the Java code to account for when artifacts are programmatically downloaded. 

While perhaps not critical, it also adds maven repositories to build.gradle files to allow for building from the new artifactory.