### PR TITLE
Strip correlation ID for offline by setting it to null instead of empty string

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/workflow/DetectRunId.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/DetectRunId.java
@@ -34,6 +34,6 @@ public class DetectRunId {
     }
     
     public void stripCorrelationId() {
-        correlationId = "";
+        correlationId = null;
     }
 }


### PR DESCRIPTION
# Description

Strip rip correlation ID for offline by setting it to null instead of empty string to prevent empty field in offline BDIO.

# Github Issues

IDETECT-4503
