### PR TITLE
Put Synopsys name back in place temporarily for Jenkins plugin

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -30,6 +30,7 @@
 
 * The `logging.level.com.synopsys.integration` property deprecated in [detect_product_short] 9.x, has been removed. Use `logging.level.detect` instead.
 * The FULL_SNIPPET_MATCHING and FULL_SNIPPET_MATCHING_ONLY options for the `detect.blackduck.signature.scanner.snippet.matching` property deprecated in [detect_product_short] 9.x, have been removed.
+* The `.blackduck` temporary folder has been added to the default exclusion list.
 
 ### Dependency updates
 

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/airgapfordetect.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/airgapfordetect.md
@@ -1,5 +1,5 @@
 # Jenkins Air Gap mode
-The [detect_product_long] for Jenkins plugin enables you to configure an Air Gap option to run [detect_product_short]. 
+The [company_name] for Jenkins plugin enables you to configure an Air Gap option to run [detect_product_short]. 
 
 Before you can see the [detect_product_short] Air Gap option on the Global Tool Configuration page, you must install the [detect_product_short] plugin.
 

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/autoescapingparameters.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/autoescapingparameters.md
@@ -1,6 +1,6 @@
 # Auto-escaping Parameters
 
-In [detect_product_long] for Jenkins, several special parameters are automatically escaped. 
+In [company_name] [detect_product_short] for Jenkins, several special parameters are automatically escaped. 
 The workflows pertaining to quotation marks and spaces are as follows.
 
 - Detect properties must be separated by spaces or carriage returns/line feeds.
@@ -13,9 +13,9 @@ The workflows pertaining to quotation marks and spaces are as follows.
 You can turn off auto escaping by setting the environment variable *DETECT\_PLUGIN\_ESCAPING* to false.
 Jenkins enables you to set an environment variable at different levels, such as globally or on a per-job basis. If you set the environment variable globally to one value, you can set it at the job level to another value. It is recommended to set the environment variable globally to skip escaping (ensuring past jobs work as expected), and then if you want to make jobs with the auto escaping enabled, you modify the environment variable flag in that job's configuration to enable escaping the characters. The easiest way to accomplish this is to install the ["Environment Injector" Jenkins plugin](https://plugins.jenkins.io/envinject/).
 
-**Note:** In [detect_product_long] plugin version 9, the above recommendations remain the same for agents on Windows systems.  For those agents running on 'NIX systems, *DETECT\_PLUGIN\_ESCAPING* should be set to false.  Ensure that you adhere to the quoting conventions described above. Any input with spaces in the Jenkins configuration should be enclosed in quotes.
+**Note:** In [company_name] [detect_product_short] plugin version 9, the above recommendations remain the same for agents on Windows systems.  For those agents running on 'NIX systems, *DETECT\_PLUGIN\_ESCAPING* should be set to false.  Ensure that you adhere to the quoting conventions described above. Any input with spaces in the Jenkins configuration should be enclosed in quotes.
 
-[detect_product_long] for Jenkins allows some special characters when *DETECT\_PLUGIN\_ESCAPING* is set to false, and spaces can be included without escape sequences provided that they are enclosed in single or double quotes as described above for different agents. Therefore, instead of `My\ Test\ Project1`, you can pass it as `'My Test Project1'`, the project will be created and uploaded to [bd_product_short] as `My Test Project1*.*`
+[company_name] [detect_product_short] for Jenkins allows some special characters when *DETECT\_PLUGIN\_ESCAPING* is set to false, and spaces can be included without escape sequences provided that they are enclosed in single or double quotes as described above for different agents. Therefore, instead of `My\ Test\ Project1`, you can pass it as `'My Test Project1'`, the project will be created and uploaded to [bd_product_short] as `My Test Project1*.*`
 
 If *DETECT\_PLUGIN\_ESCAPING* is set to true, then you can use backtick (\`) to escape spaces which are passed within argument values. Therefore, you can pass values as "Windows` Project" in the arguments.
 

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/configuringtheplugin.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/configuringtheplugin.md
@@ -1,5 +1,5 @@
 # Configuring the Jenkins Plugin
-Use the following process to configure the [detect_product_long] for Jenkins plugin.  Note that the supported credential formats are user name and password or API token.  SAML is not supported.
+Use the following process to configure the [company_name] [detect_product_short] for Jenkins plugin.  Note that the supported credential formats are user name and password or API token.  SAML is not supported.
 
 1. After installing, navigate to **Manage Jenkins** > **Configure System**.
 1. Navigate to the **[detect_product_short]** section, and complete the following.

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/dockercontainers.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/dockercontainers.md
@@ -1,5 +1,5 @@
 # Using Docker Containers - Best Practice
-When running [detect_product_short] for Jenkins using the *DETECT\_JAR* environment variable in a pipeline that has a Docker agent, remember to mount the Detect JAR as a volume.
+When running [company_name] [detect_product_short] for Jenkins using the *DETECT\_JAR* environment variable in a pipeline that has a Docker agent, remember to mount the Detect JAR as a volume.
 
 For example, if you've installed the jar on a node, the JAR won't be accessible from your docker agent unless you either put it somewhere you regularly
 include, or if you mount the path to the jar. Refer to [Docker documentation](https://docs.docker.com/storage/bind-mounts/#choose-the--v-or---mount-flag) for more information.
@@ -18,4 +18,4 @@ pipeline {
 ...
 ```
 
-Applies when running [detect_product_short] for Jenkins with a local JAR (which requires setting the *DETECT\_JAR* environment variable).
+Applies when running [company_name] [detect_product_short] for Jenkins with a local JAR (which requires setting the *DETECT\_JAR* environment variable).

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/downloadingandinstalling.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/downloadingandinstalling.md
@@ -1,5 +1,5 @@
 # Downloading, Installing, and Updating the Plugin
-To install the [detect_product_short] for Jenkins plugin, perform the following steps:
+To install the [company_name] [detect_product_short] for Jenkins plugin, perform the following steps:
 
 1. Navigate to **Manage Jenkins** > **Manage Plugins**.
 1. Select the **Available** tab.  (Note that if the plugin is already installed, it does not appear in the **Available** list.)
@@ -7,18 +7,18 @@ To install the [detect_product_short] for Jenkins plugin, perform the following
 1. Click **Download now and install after restart**. This is the recommendation for installing the plugin.
 1. After restarting Jenkins, confirm that the plugin is successfully installed by navigating to **Manage Jenkins** > **Manage Plugins > Installed**, and verify that **[company_name] [solution_name]** displays in the list.
 
-[detect_product_short] plugin for Jenkins GitHub page [jenkinsci](https://github.com/jenkinsci/synopsys-detect-plugin).
+[company_name] [detect_product_short] plugin for Jenkins GitHub page [jenkinsci](https://github.com/jenkinsci/synopsys-detect-plugin).
 Additional download locations listed in [Download locations](../../downloadingandrunning/downloadlocations.html).
 
-## Updating the [detect_product_short] for Jenkins plugin
-You can update the [detect_product_short] for Jenkins plugin when new versions are released.
+## Updating the [company_name] [detect_product_short] for Jenkins plugin
+You can update the [company_name] [detect_product_short] for Jenkins plugin when new versions are released.
 
 **To update the Jenkins plugin:**
 
 1. Navigate to **Manage Jenkins** > **Manage Plugins**.
 1. Click the **Updates** tab.
 1. Select **Blackduck Detect**
-   1. If there are updates for the [detect_product_short] for Jenkins plugin, the updates display in the list.  If there is not an available update, the [detect_product_short] for Jenkins plugin does not display in this list.
+   1. If there are updates for the [company_name] [detect_product_short] for Jenkins plugin, the updates display in the list.  If there is not an available update, the [company_name] [detect_product_short] for Jenkins plugin does not display in this list.
    1. Alternatively, you can force Jenkins to check for plugin updates by clicking **Check now** on the **Updates** tab.
 1. If there are updates, select the one you want, and click **Download now and install after restart**.
 

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/jenkins.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/jenkins.md
@@ -1,6 +1,6 @@
 # Jenkins Plugin
 
-The [detect_product_short] for Jenkins plugin enables you to install and run [detect_product_short] in your Jenkins instance. 
+The [company_name] [detect_product_short] for Jenkins plugin enables you to install and run [detect_product_short] in your Jenkins instance. 
 
 [detect_product_short] scans code bases in your projects and folders to perform compositional analysis and functions as a [bd_product_short] intelligent scan client. [detect_product_short] sends scan results to [bd_product_short], which generates risk analysis when identifying open source components, licenses, and security vulnerabilities.
 

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/jenkinsrequirements.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/jenkinsrequirements.md
@@ -1,6 +1,6 @@
 # Requirements for [detect_product_short] for Jenkins
 
-Requirements for [detect_product_short] for Jenkins which may be in addition to those for [detect_product_short].
+Requirements for [company_name] [detect_product_short] for Jenkins which may be in addition to those for [detect_product_short].
 
 * Access to the internet is required to download components from GitHub and other locations.
 * Minimum 8GB RAM.

--- a/documentation/src/main/markdown/integrations/jenkinsplugin/runninginjenkins.md
+++ b/documentation/src/main/markdown/integrations/jenkinsplugin/runninginjenkins.md
@@ -1,6 +1,6 @@
-# Running [detect_product_long] in Jenkins
+# Running [detect_product_short] in Jenkins
 
-By default, [detect_product_short] for Jenkins downloads either the latest [detect_product_short] shell script when run on a UNIX node, or PowerShell script when it's run on a Windows node, to the Jenkins tools directory, and then executes that script. Note that you can also use the JAR option to run [detect_product_short].
+By default, [company_name] [detect_product_short] for Jenkins downloads either the latest [detect_product_short] shell script when run on a UNIX node, or PowerShell script when it's run on a Windows node, to the Jenkins tools directory, and then executes that script. Note that you can also use the JAR option to run [detect_product_short].
 
 The [detect_product_short] PowerShell or shell script is downloaded once and placed in the [detect_product_short] working directory. If you want to force the plugin to fetch the latest script, clear out the Detect directory in your Jenkins tools directory.
 
@@ -33,4 +33,4 @@ Refer to the [freestyle example](../../integrations/jenkinsplugin/jenkinsfreest
 ## DSL considerations
 The [detect_product_short] for Jenkins plugin provides Dynamic DSL for both freestyle steps and pipeline steps. Read more at [Dynamic DSL](https://github.com/jenkinsci/job-dsl-plugin/wiki/Dynamic-DSL).
 
-**Note:** that versions 1.72 and later of the DSL plugin do not support the [detect_product_short] for Jenkins plugin pipeline steps.
+**Note:** that versions 1.72 and later of the DSL plugin do not support the [company_name] [detect_product_short] for Jenkins plugin pipeline steps.

--- a/documentation/src/main/resources/templates/downloadlocations.ftl
+++ b/documentation/src/main/resources/templates/downloadlocations.ftl
@@ -5,7 +5,6 @@ The following are download locations for the current version of [detect_product_
 * [detect_product_short] Bash script: [Bash script](${script_repo_url_bash})
 * The [detect_product_short] PowerShell script: [PowerShell script](${script_repo_url_powershell})
 * The [detect_product_short] binary repository (.jar and air gap zip files): [Binary files](${binary_repo_url_project})
-* The [detect_product_short] binary repository user interface view (properties, etc.): [Release Artifacts Repository UI](${binary_repo_ui_url_project})
 * The [detect_product_short] repository for the Jenkins plugin: [Release Artifacts Repository](${binary_repo_jenkins_url_project})
 
 **Note:** For certain types of projects, [detect_product_short] automatically downloads one or more [inspectors](../components/inspectors.md) as needed.

--- a/documentation/src/main/resources/templates/downloadlocations.ftl
+++ b/documentation/src/main/resources/templates/downloadlocations.ftl
@@ -5,11 +5,11 @@ The following are download locations for the current version of [detect_product_
 * [detect_product_short] Bash script: [Bash script](${script_repo_url_bash})
 * The [detect_product_short] PowerShell script: [PowerShell script](${script_repo_url_powershell})
 * The [detect_product_short] binary repository (.jar and air gap zip files): [Binary files](${binary_repo_url_project})
-* The [detect_product_short] binary repository user interface view (properties, etc.): [Artifactory UI](${binary_repo_ui_url_project})
-* The [detect_product_short] repository for the Jenkins plugin: [Artifactory](${binary_repo_jenkins_url_project})
+* The [detect_product_short] binary repository user interface view (properties, etc.): [Release Artifacts Repository UI](${binary_repo_ui_url_project})
+* The [detect_product_short] repository for the Jenkins plugin: [Release Artifacts Repository](${binary_repo_jenkins_url_project})
 
 **Note:** For certain types of projects, [detect_product_short] automatically downloads one or more [inspectors](../components/inspectors.md) as needed.
-* In air-gap environments you may need to download the [var_product_sigma] scanner via artifactory at the following location: [Sigma](${binary_repo_url_sigma})
+* In air-gap environments you may need to download the [var_product_sigma] scanner at the following location: [Sigma](${binary_repo_url_sigma})
 
 * Downloads of binaries and source code for NuGet Inspector are available at the following repo locations: [Binary files](https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/) and [Source code](https://github.com/blackducksoftware/detect-nuget-inspector)
 


### PR DESCRIPTION
Putting Synopsys name back for Jenkins plugin until it is released anew. (Where appropriate) 
Adding RN for new .blackduck folder exclusion.

