### PR TITLE
update blackduck-common to improve multipart upload retry logic

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,4 +1,4 @@
 // Updating blackduck-common version here might necessitate an update to integration-common version in src/main/resources/create-gradle-airgap-script.ftl \
 // to ensure the integration-common versions in both airgap and non-airgap are the same. 
-gradle.ext.blackDuckCommonVersion='67.0.1'
+gradle.ext.blackDuckCommonVersion='67.0.2'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
There is a fix in the integration-rest library that improves retry logic when re-authentication needs to take place.

This is a simple bump of the library, tests are in the libraries themselves.