### PR TITLE
Update documentation around JAR signing verification step

### DIFF
--- a/documentation/src/main/markdown/downloadingandinstalling/verification.md
+++ b/documentation/src/main/markdown/downloadingandinstalling/verification.md
@@ -16,7 +16,7 @@ To verify the [detect_product_short] .jar:
 
 jarsigner -verify -strict {your [detect_product_short] .jar file}
 
-The output should be `jar verified.` (with no warnings).
+The output should be `jar verified.`.
 
 ## Checksum verification
 


### PR DESCRIPTION
The jarsigner tool in the JDK used by the new windows signing client preserves POSIX file permissions and symlink attributes while signing the jar (i.e. these files within the jar are intentionally left unsigned). See JDK tickets below for reference.

Hence, when verifying JARs where these permissions and/or symlinks are preserved during signing, the following warning is displayed after executing `jarsigner -verify -strict <jar-file>`:

> jar verified.
> 
> POSIX file permission and/or symlink attributes detected. These attributes are ignored when signing and are not protected by the signature.

This is an "informational warning" and not a "severe warning". See [jarsigner's Errors and Warnings](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#BGBIIAAG) section for more reference. If there is a severe warning, the `-strict` flag treats them as errors and the "jar verified" message would not be printed.

Hence, as long as the `-strict` flag is being used, confirming that the output says "jar verified." is sufficient for code signature verification.

Related JDK tickets for reference:
User story: https://bugs.openjdk.org/browse/JDK-8252517
ER: https://bugs.openjdk.org/browse/JDK-8218021
Release note around the warning: https://bugs.openjdk.org/browse/JDK-8248263


