### PR TITLE
check for empty policies and not just null

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
@@ -96,7 +96,7 @@ public class RapidScanDetectResult implements DetectResult {
     }
 
     private void addErrorViolationHeader(List<String> resultMessages, List<PolicyRuleSeverityType> errorPolicies) {
-        if (errorPolicies == null || checkForDefaultPolicies(errorPolicies)) {
+        if (checkForDefaultPolicies(errorPolicies)) {
             resultMessages.add("\tCritical and blocking policy violations for");
         } else {
             String violationMessage;
@@ -112,6 +112,10 @@ public class RapidScanDetectResult implements DetectResult {
     }
 
     private boolean checkForDefaultPolicies(List<PolicyRuleSeverityType> errorPolicies) {
+        if (errorPolicies == null || errorPolicies.isEmpty()) {
+            return true;
+        }
+        
         List<PolicyRuleSeverityType> defaultPolicies = Arrays.asList(PolicyRuleSeverityType.CRITICAL, PolicyRuleSeverityType.BLOCKER);
         
         Set<PolicyRuleSeverityType> errorSet = new HashSet<>(errorPolicies);


### PR DESCRIPTION
If a user specifies NONE for policies to fail on, internally this will map to an empty List. The code was previously assuming it could construct a message from an empty list when there really is nothing we should do.

This code restores the previous behavior that Detect would take before this new property was introduced.