### PR TITLE
do not match empty string to make sonar happy

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/SignatureScanVersionChecker.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/SignatureScanVersionChecker.java
@@ -24,7 +24,7 @@ import com.blackduck.integration.util.IntEnvironmentVariables;
 import com.blackduck.integration.util.OperatingSystemType;
 
 public class SignatureScanVersionChecker {
-    private static final String SIGNATURE_SCAN_VERSION_FORMAT = "^(\\d+)\\.(\\d+)\\.(\\d+)(?:[-\\w]*)?$";
+    private static final String SIGNATURE_SCAN_VERSION_FORMAT = "^(\\d+)\\.(\\d+)\\.(\\d+)(?:[-\\w]+)?$";
     
     public static SignatureScannerVersion getSignatureScannerVersion(Logger logger,
             Optional<Path> localScannerInstallPath, File toolsDirectory) throws IOException {


### PR DESCRIPTION
Changed (?:[-\\w]*)? to (?:[-\\w]+)? this ensures that if the optional suffix is present, it must contain at least one character (like -SNAPSHOT), and it avoids matching an empty string.

This makes sonar happy with the regex