### PR TITLE
Normalize root name before checking for workspaces

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -51,6 +51,7 @@ public class UVLockParser {
         TomlParseResult uvLockObject = Toml.parse(lockFileContent);
 
         collectWorkspaceMembers(uvLockObject);
+        rootName = normalizePackageName(rootName);
         if(uvLockObject.get(PACKAGE_KEY) != null) {
             TomlArray dependencies = uvLockObject.getArray(PACKAGE_KEY);
             parseDependencies(dependencies, rootName, uvDetectorOptions);


### PR DESCRIPTION
This PR fixes bug IDETECT-4802 where we normalize the root project name before parsing the lock file for getting the dependencies with the name equivalent to project name.