### PR TITLE
Remove synopsys repo references

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -3,12 +3,10 @@
 **Notices**   
 
 [company_name] [solution_name] has been renamed [detect_product_long] with page links, documentation, and other URLs updated accordingly. Update any [detect_product_short] documentation, or other bookmarks you may have. See the [Domain Change FAQ](https://community.blackduck.com/s/article/Black-Duck-Domain-Change-FAQ).
-* As part of this activity, sig-repo.synopsys.com and detect.synopsys.com are being deprecated. Please make use of repo.blackduck.com and detect.blackduck.com respectively. 
+* Please make use of repo.blackduck.com and detect.blackduck.com for code downloads. 
     * [detect_product_short] script downloads should only be accessed via detect.blackduck.com.
     * [detect_product_short] 10.0.0 and later will only work when using repo.blackduck.com.
-    * If you are using [detect_product_short] 8 or 9 it is essential to update to 8.11.2 or 9.10.1 respectively, before sig-repo is decommissioned.   
-
-<note type="note">It is recommended that customers continue to maintain sig-repo.synopsys.com, and repo.blackduck.com on their allow list until such time as all scripts, services, or pipelines have been updated with the repo.blackduck.com URL.</note>
+    * If you are using [detect_product_short] 8 or 9 it is essential to update to 8.11.2 or 9.10.1 respectively.   
 
 * [bd_product_long] [SCA Scan Service (SCASS)](https://community.blackduck.com/s/question/0D5Uh00000O2ZSYKA3/black-duck-sca-new-ip-address-requirements-for-2025) requires customers add or update IP addresses configured in their network firewalls or allow lists. This action is required to successfully route scan data to the service for processing.
 

--- a/documentation/src/main/markdown/previousreleasenotes.md
+++ b/documentation/src/main/markdown/previousreleasenotes.md
@@ -6,7 +6,7 @@
 ### New features
 
 * When enabled, the new [detect.project.deep.license](properties/configuration/project.md#deep-license-analysis) property sets the Deep License Data and Deep License Data Snippet fields when creating a project. This property can also be used to update existing projects when the [detect.project.version.update](properties/configuration/project.md#update-project-version) property is set to true.
-* The new [detect.project.settings](properties/configuration/project.md#project-settings-via-json) property takes as input a path to a JSON file. This file allows users to pass several existing `detect.project` properties as a single argument to Detect. Detect will parse the JSON file to obtain information relevant to creating or updating projects.
+* The new [detect.project.settings](properties/configuration/project.md#project-settings-json-file-advanced) property takes as input a path to a JSON file. This file allows users to pass several existing `detect.project` properties as a single argument to Detect. Detect will parse the JSON file to obtain information relevant to creating or updating projects.
 * The new [detect.excluded.detectors](properties/configuration/detector.md#detectors-excluded-advanced) property takes as input a comma-separated list of Detector names to exclude. This allows for greater control over selection of Detectors.
 * Added support for capturing dependencies from the `go.mod` file via a new buildless detector named "Go Mod File" for Go projects.
     * Added a new property [detect.go.forge](properties/detectors/go.md#go-forge-url) to customize the Go registry URL used for fetching dependency information. Defaults to `https://proxy.golang.org`.


### PR DESCRIPTION
We've passed the Sept. 30 cut-off for synopsys sites.
We should soon be able to remove the full "Notice" section once the PMO domain change project wraps up and all customers are confirmed to have migrated.
Also updated 11.0.0 release note URL for --detect.project.settings