### PR TITLE
fix(output file in quack patch subdirectory): IDETECT-4970

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -374,7 +374,7 @@ public class OperationRunner {
                 detectorEventPublisher,
                 directoryEvaluator
             );
-            return detectorTool.performDetectors(
+            DetectorToolResult toolResult =  detectorTool.performDetectors(
                 directoryManager,
                 detectRuleSet,
                 detectConfigurationFactory.createDetectorFinderOptions(),
@@ -383,6 +383,15 @@ public class OperationRunner {
                 detectorToolOptions.getRequiredAccuracyTypes(),
                 fileFinder
             );
+
+            if (detectConfigurationFactory.isQuackPatchPossible()) {
+                try {
+                    detectorTool.saveExtractedDetectorsAndTheirRelevantFilePaths(directoryManager, toolResult);
+                } catch (IOException e) {
+                    throw new RuntimeException("Something went wrong writing relevant files: " + e.getMessage());
+                }
+            }
+            return toolResult;
         });
     }
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/RapidModeStepRunner.java
@@ -126,8 +126,12 @@ public class RapidModeStepRunner {
         if (operationRunner.shouldAttemptQuackPatchFullResults()) {
             logger.info("Quack Patch is enabled, attempting to retrieve full Rapid scan results.");
             List<Response> rapidFullResults = operationRunner.waitForRapidFullResults(blackDuckRunData, parsedUrls, mode);
-            File jsonFileFULL = operationRunner.generateFullRapidJsonFile(rapidFullResults);
-            operationRunner.runQuackPatch(jsonFileFULL);
+            if (rapidFullResults.isEmpty()) {
+                logger.info("Quack Patch requires non-empty Rapid Scan results. Skipping Quack Patch.");
+            } else {
+                File jsonFileFULL = operationRunner.generateFullRapidJsonFile(rapidFullResults);
+                operationRunner.runQuackPatch(jsonFileFULL);
+            }
         }
 
         // Generate a report, even an empty one if no scans were done as that is what previous detect versions did.

--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
@@ -160,12 +160,6 @@ public class DetectorTool {
         //Completed.
         logger.debug("Finished running detectors.");
         detectorEventPublisher.publishDetectorsComplete(toolResult);
-
-        try {
-            saveExtractedDetectorsAndTheirRelevantFilePaths(directoryManager, toolResult);
-        } catch (IOException e) {
-            throw new RuntimeException("something went wrong writing relevant files");
-        }
         return toolResult;
     }
 

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidModeGenerateJsonOperation.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidModeGenerateJsonOperation.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -21,7 +20,6 @@ import com.blackduck.integration.log.Slf4jIntLogger;
 import com.blackduck.integration.util.IntegrationEscapeUtil;
 import com.blackduck.integration.util.NameVersion;
 
-import static com.blackduck.integration.detect.workflow.componentlocationanalysis.GenerateComponentLocationAnalysisOperation.INVOKED_DETECTORS_AND_RELEVANT_FILES_JSON;
 import static com.blackduck.integration.detect.workflow.componentlocationanalysis.GenerateComponentLocationAnalysisOperation.QUACKPATCH_SUBDIRECTORY_NAME;
 
 public class RapidModeGenerateJsonOperation { //TODO: extends Operation<File>
@@ -47,7 +45,7 @@ public class RapidModeGenerateJsonOperation { //TODO: extends Operation<File>
             Files.write(filePath, jsonRapidFullResults.getBytes(StandardCharsets.UTF_8));
             return jsonFile;
         } catch (IOException e) {
-            throw new RuntimeException("Something went wrong creating Rapid scan full results JSON file.", e);
+            throw new RuntimeException("Something went wrong creating Rapid scan full results JSON file:", e);
         }
     }
 


### PR DESCRIPTION
 At the end of Detector actions, save applicable detectors and their relevant files to a JSON file if and only if quack patch was enabled and configured with all required properties. (Before this change, we create this file regardless of quack patch being enabled or not.)
