### PR TITLE
fix package name parsing for direct URL references in pip inspector

### DIFF
--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -110,7 +110,7 @@ def populate_dependency_tree(project_root_node, requirements_path):
                 # re matches from left to right, so subsets (e.g. ===) should be before supersets (e.g. ==)
                 # See: https://docs.python.org/3/library/re.html
                 # --rotte NOV 2020
-                package_name = split('===|<=|!=|==|>=|~=|<|>', parsed_requirement.requirement)[0]
+                package_name = split('===|<=|!=|==|>=|~=|<|>|@', parsed_requirement.requirement)[0]
 
             dependency_node = recursively_resolve_dependencies(package_name, [])
 


### PR DESCRIPTION
Add '@' symbol to regex split pattern to properly extract package names from PEP 440 direct URL references

# Description

The script fails to parse package names when they use direct URL references (PEP 440 format) in requirements.txt files. Add @ to the regex pattern to properly extract package names from direct URL references
