### PR TITLE
fix(output files): Only ask NuGet Inspector to generate quack-patch related output files if enabled.

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/nuget/NugetInspectorOptions.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/nuget/NugetInspectorOptions.java
@@ -19,16 +19,68 @@ public class NugetInspectorOptions {
     private final Path inspectedFilesInfoPath;
     private final File nugetInspectorPath;
 
-    public NugetInspectorOptions(boolean ignoreFailures, List<String> excludedModules, List<String> includedModules, List<String> packagesRepoUrl, @Nullable Path nugetConfigPath, Set<NugetDependencyType> nugetExcludedDependencyTypes, @Nullable Path nugetArtifactsPath, @Nullable Path inspectedFilesInfoPath, @Nullable File nugetInspectorPath) {
-        this.ignoreFailures = ignoreFailures;
-        this.excludedModules = excludedModules;
-        this.includedModules = includedModules;
-        this.packagesRepoUrl = packagesRepoUrl;
-        this.nugetConfigPath = nugetConfigPath;
-        this.nugetExcludedDependencyTypes = nugetExcludedDependencyTypes;
-        this.nugetArtifactsPath = nugetArtifactsPath;
-        this.inspectedFilesInfoPath = inspectedFilesInfoPath;
-        this.nugetInspectorPath = nugetInspectorPath;
+    private NugetInspectorOptions(Builder builder) {
+        this.ignoreFailures = builder.ignoreFailures;
+        this.excludedModules = builder.excludedModules;
+        this.includedModules = builder.includedModules;
+        this.packagesRepoUrl = builder.packagesRepoUrl;
+        this.nugetConfigPath = builder.nugetConfigPath;
+        this.nugetExcludedDependencyTypes = builder.nugetExcludedDependencyTypes;
+        this.nugetArtifactsPath = builder.nugetArtifactsPath;
+        this.inspectedFilesInfoPath = builder.inspectedFilesInfoPath;
+        this.nugetInspectorPath = builder.nugetInspectorPath;
+    }
+
+    public static class Builder {
+        private boolean ignoreFailures;
+        private List<String> excludedModules;
+        private List<String> includedModules;
+        private List<String> packagesRepoUrl;
+        private Path nugetConfigPath;
+        private Set<NugetDependencyType> nugetExcludedDependencyTypes;
+        private Path nugetArtifactsPath;
+        private Path inspectedFilesInfoPath;
+        private File nugetInspectorPath;
+
+        public Builder ignoreFailures(boolean ignoreFailures) {
+            this.ignoreFailures = ignoreFailures;
+            return this;
+        }
+        public Builder excludedModules(List<String> excludedModules) {
+            this.excludedModules = excludedModules;
+            return this;
+        }
+        public Builder includedModules(List<String> includedModules) {
+            this.includedModules = includedModules;
+            return this;
+        }
+        public Builder packagesRepoUrl(List<String> packagesRepoUrl) {
+            this.packagesRepoUrl = packagesRepoUrl;
+            return this;
+        }
+        public Builder nugetConfigPath(@Nullable Path nugetConfigPath) {
+            this.nugetConfigPath = nugetConfigPath;
+            return this;
+        }
+        public Builder nugetExcludedDependencyTypes(Set<NugetDependencyType> nugetExcludedDependencyTypes) {
+            this.nugetExcludedDependencyTypes = nugetExcludedDependencyTypes;
+            return this;
+        }
+        public Builder nugetArtifactsPath(@Nullable Path nugetArtifactsPath) {
+            this.nugetArtifactsPath = nugetArtifactsPath;
+            return this;
+        }
+        public Builder inspectedFilesInfoPath(@Nullable Path inspectedFilesInfoPath) {
+            this.inspectedFilesInfoPath = inspectedFilesInfoPath;
+            return this;
+        }
+        public Builder nugetInspectorPath(@Nullable File nugetInspectorPath) {
+            this.nugetInspectorPath = nugetInspectorPath;
+            return this;
+        }
+        public NugetInspectorOptions build() {
+            return new NugetInspectorOptions(this);
+        }
     }
 
     public boolean isIgnoreFailures() {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/nuget/NugetInspectorOptions.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/nuget/NugetInspectorOptions.java
@@ -19,7 +19,7 @@ public class NugetInspectorOptions {
     private final Path inspectedFilesInfoPath;
     private final File nugetInspectorPath;
 
-    public NugetInspectorOptions(boolean ignoreFailures, List<String> excludedModules, List<String> includedModules, List<String> packagesRepoUrl, @Nullable Path nugetConfigPath, Set<NugetDependencyType> nugetExcludedDependencyTypes, @Nullable Path nugetArtifactsPath, Path inspectedFilesInfoPath, @Nullable File nugetInspectorPath) {
+    public NugetInspectorOptions(boolean ignoreFailures, List<String> excludedModules, List<String> includedModules, List<String> packagesRepoUrl, @Nullable Path nugetConfigPath, Set<NugetDependencyType> nugetExcludedDependencyTypes, @Nullable Path nugetArtifactsPath, @Nullable Path inspectedFilesInfoPath, @Nullable File nugetInspectorPath) {
         this.ignoreFailures = ignoreFailures;
         this.excludedModules = excludedModules;
         this.includedModules = includedModules;

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -27,5 +27,5 @@
 ### Resolved issues
 
 * (IDETECT-4960) Added support for Cargo features and optional dependencies in Cargo CLI Detector, allowing precise control over which features are included in the SBOM through cargo tree command flags. See [Cargo](properties/detectors/cargo.md) for details.
-* (IDETECT-4847) Clarified that the value of `detect.container.scan.file.path` should be a path to local .tar file or a HTTP/HTTPS URL for remote .tar file.
-* (IDETECT-4970) Fixed an issue where an output directory `quack-patch` was incorrectly created even when the relevant feature was disabled.
+* (IDETECT-4847) Clarified that the value of `detect.container.scan.file.path` should be a local .tar file path or HTTP/HTTPS URL for a remote .tar file.
+* (IDETECT-4970) Fixed an issue where a `quack-patch` output directory was created despite the feature not being enabled.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -28,3 +28,4 @@
 
 * (IDETECT-4960) Added support for Cargo features and optional dependencies in Cargo CLI Detector, allowing precise control over which features are included in the SBOM through cargo tree command flags. See [Cargo](properties/detectors/cargo.md) for details.
 * (IDETECT-4847) Clarified that the value of `detect.container.scan.file.path` should be a path to local .tar file or a HTTP/HTTPS URL for remote .tar file.
+* (IDETECT-4970) Fixed an issue where an output directory `quack-patch` was incorrectly created even when the relevant feature was disabled.

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
@@ -366,7 +366,17 @@ public class DetectableOptionFactory {
         if (nugetInspectorPath != null) {
             nugetInspectorPathFile = nugetInspectorPath.toFile();
         }
-        return new NugetInspectorOptions(ignoreFailures, excludedModules, includedModules, packagesRepoUrl, nugetConfigPath, nugetExcludedDependencyTypes, nugetArtifactsPath, relevantDetectorsAndFilesInfoPath, nugetInspectorPathFile);
+        return new NugetInspectorOptions.Builder()
+                .ignoreFailures(ignoreFailures)
+                .excludedModules(excludedModules)
+                .includedModules(includedModules)
+                .packagesRepoUrl(packagesRepoUrl)
+                .nugetConfigPath(nugetConfigPath)
+                .nugetExcludedDependencyTypes(nugetExcludedDependencyTypes)
+                .nugetArtifactsPath(nugetArtifactsPath)
+                .inspectedFilesInfoPath(relevantDetectorsAndFilesInfoPath)
+                .nugetInspectorPath(nugetInspectorPathFile)
+                .build();
     }
 
     private boolean getFollowSymLinks() {

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
@@ -355,9 +355,12 @@ public class DetectableOptionFactory {
         Path nugetConfigPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_NUGET_CONFIG_PATH);
         Set<NugetDependencyType> nugetExcludedDependencyTypes = detectConfiguration.getValue(DetectProperties.DETECT_NUGET_DEPENDENCY_TYPES_EXCLUDED).representedValueSet();
         Path nugetArtifactsPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_NUGET_ARTIFACTS_PATH);
-        Path relevantDetectorsAndFilesInfoPath = Paths.get(DirectoryManager.getScanDirectoryName())
-                .resolve(QUACKPATCH_SUBDIRECTORY_NAME)
-                .resolve(INVOKED_DETECTORS_AND_RELEVANT_FILES_JSON);
+        Path relevantDetectorsAndFilesInfoPath = null;
+        if (detectConfiguration.getValue(DetectProperties.DETECT_QUACK_PATCH_ENABLED)) {
+            relevantDetectorsAndFilesInfoPath = Paths.get(DirectoryManager.getScanDirectoryName())
+                    .resolve(QUACKPATCH_SUBDIRECTORY_NAME)
+                    .resolve(INVOKED_DETECTORS_AND_RELEVANT_FILES_JSON);
+        }
         Path nugetInspectorPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_NUGET_INSPECTOR_PATH);
         File nugetInspectorPathFile = null;
         if (nugetInspectorPath != null) {

--- a/src/test/java/com/blackduck/integration/detect/workflow/report/DetectorToolTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/report/DetectorToolTest.java
@@ -1,0 +1,84 @@
+package com.blackduck.integration.detect.workflow.report;
+
+import org.junit.jupiter.api.Test;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import com.blackduck.integration.detect.tool.detector.DetectorTool;
+import com.blackduck.integration.detect.tool.detector.DetectorToolResult;
+import com.blackduck.integration.detect.tool.detector.report.DetectorDirectoryReport;
+import com.blackduck.integration.detect.tool.detector.report.rule.ExtractedDetectorRuleReport;
+import com.blackduck.integration.detect.tool.detector.report.detectable.ExtractedDetectableReport;
+import com.blackduck.integration.detect.workflow.file.DirectoryManager;
+import com.blackduck.integration.detect.workflow.file.DirectoryOptions;
+import com.blackduck.integration.detect.workflow.DetectRunId;
+
+import static com.blackduck.integration.detect.workflow.componentlocationanalysis.GenerateComponentLocationAnalysisOperation.INVOKED_DETECTORS_AND_RELEVANT_FILES_JSON;
+import static com.blackduck.integration.detect.workflow.componentlocationanalysis.GenerateComponentLocationAnalysisOperation.QUACKPATCH_SUBDIRECTORY_NAME;
+import static org.junit.jupiter.api.Assertions.*;
+import com.blackduck.integration.detector.rule.DetectableDefinition;
+import com.blackduck.integration.detectable.detectables.gradle.inspection.GradleInspectorDetectable;
+import com.blackduck.integration.common.util.finder.FileFinder;
+import com.blackduck.integration.detectable.detectable.executable.resolver.GradleResolver;
+import com.blackduck.integration.detectable.detectable.inspector.GradleInspectorResolver;
+import com.blackduck.integration.detectable.detectables.gradle.inspection.GradleInspectorExtractor;
+import com.blackduck.integration.detectable.detectables.gradle.inspection.GradleInspectorOptions;
+import com.blackduck.integration.detectable.detectable.annotation.DetectableInfo;
+import java.lang.reflect.Field;
+
+
+class DetectorToolTest {
+    @Test
+    void testSaveExtractedDetectorsAndTheirRelevantFilePaths_gradle() throws Exception {
+        Path tempDir = Files.createTempDirectory("detect-tool-test");
+        DirectoryManager directoryManager = new DirectoryManager(
+            new DirectoryOptions(tempDir, tempDir, tempDir, tempDir, tempDir, tempDir, tempDir),
+            DetectRunId.createDefault()
+        );
+        File relevantFile = File.createTempFile("build", ".gradle", tempDir.toFile());
+
+        FileFinder fileFinder = (dir, filter, followSymLinks, depth, findInsideMatchingDirectories) -> Collections.singletonList(relevantFile);
+        GradleResolver gradleResolver = env -> null;
+        GradleInspectorResolver gradleInspectorResolver = () -> null;
+        GradleInspectorExtractor gradleInspectorExtractor = new GradleInspectorExtractor(fileFinder, null, null, null, null, null);
+        GradleInspectorOptions gradleInspectorOptions = new GradleInspectorOptions(null, null, null, null);
+
+        DetectableInfo info = GradleInspectorDetectable.class.getAnnotation(DetectableInfo.class);
+        DetectableDefinition gradleInspectorDefinition = new DetectableDefinition(
+            env -> new GradleInspectorDetectable(
+                env, fileFinder, gradleResolver, gradleInspectorResolver, gradleInspectorExtractor, gradleInspectorOptions
+            ),
+            info.name(), info.forge(), info.language(), info.requirementsMarkdown(), info.accuracy()
+        );
+
+        ExtractedDetectableReport extractedDetectableReport = new ExtractedDetectableReport(
+            gradleInspectorDefinition, Collections.emptyList(), Collections.singletonList(relevantFile), null, null
+        );
+        ExtractedDetectorRuleReport extractedDetectorRuleReport = new ExtractedDetectorRuleReport(
+            null, 0, Collections.emptyList(), Collections.emptyList(), extractedDetectableReport
+        );
+        DetectorDirectoryReport directoryReport = new DetectorDirectoryReport(
+            tempDir.toFile(), 0, Collections.emptyList(), Collections.singletonList(extractedDetectorRuleReport), Collections.emptyList()
+        );
+        ArrayList<DetectorDirectoryReport> reports = new ArrayList<>();
+        reports.add(directoryReport);
+        DetectorToolResult toolResult = new DetectorToolResult();
+        Field reportsField = DetectorToolResult.class.getDeclaredField("reports");
+        reportsField.setAccessible(true);
+        reportsField.set(toolResult, reports);
+
+        new DetectorTool(null, null, null, null, null, null, null)
+            .saveExtractedDetectorsAndTheirRelevantFilePaths(directoryManager, toolResult);
+
+        File outputFile = new File(
+            new File(directoryManager.getScanOutputDirectory(), QUACKPATCH_SUBDIRECTORY_NAME),
+            INVOKED_DETECTORS_AND_RELEVANT_FILES_JSON
+        );
+        assertTrue(outputFile.exists());
+        String content = new String(Files.readAllBytes(outputFile.toPath()));
+        assertTrue(content.contains(info.name()));
+        assertTrue(content.contains(relevantFile.getName()));
+    }
+}


### PR DESCRIPTION
Fixes IDETECT-4970 + BDSCA-74

Summary: 
+ Only pass along a path to save relevant files if the relevant feature is enabled.
+ Unrelated to the bug, this MR refactors **NugetInspectorOptions** to use a builder (constructor had too many params, this addresses maintainability suggestion from Zahid previously). This also resolves a sonar complaint. Nullable params are treated the same as before.
+ Minimal unit test for the new output file we create when quack is enabled. 