### PR TITLE
Do not attempt fallback if correlation scanning is enabled

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1800,6 +1800,10 @@ public class OperationRunner {
         }
     }
 
+    public boolean isCorrelationScanningEnabled() {
+        return detectConfigurationFactory.isCorrelatedScanningEnabled();
+    }
+
     public UUID getScanIdFromScanUrl(HttpUrl blackDuckScanUrl) {
         String url = blackDuckScanUrl.toString();
         UUID scanId = UUID.fromString(url.substring(url.lastIndexOf("/") + 1));

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -221,6 +221,7 @@ public class IntelligentModeStepRunner {
                 invokePreScassPackageManagerWorkflow(blackDuckRunData, bdioResult, scanIdsToWaitFor, codeLocationAccumulator, scanId);
             } else {
                 logger.warn("Correlation scanning is enabled. Please verify your SCASS configuration, as it is required for correlation scans to function properly.");
+                operationRunner.publishDetectorFailure();
             }
         } else {
             String scanId = null;

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -220,7 +220,7 @@ public class IntelligentModeStepRunner {
             if (!operationRunner.isCorrelationScanningEnabled()) {
                 invokePreScassPackageManagerWorkflow(blackDuckRunData, bdioResult, scanIdsToWaitFor, codeLocationAccumulator, scanId);
             } else {
-                logger.warn("Correlation scanning is enabled. Please verify your SCASS configuration, as it is required for correlation scans to function properly.");
+                logger.error("Correlation scanning is enabled. Please verify your SCASS configuration, as it is required for correlation scans to function properly.");
                 operationRunner.publishDetectorFailure();
             }
         } else {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -216,7 +216,12 @@ public class IntelligentModeStepRunner {
                     return;
                 }
             }
-            invokePreScassPackageManagerWorkflow(blackDuckRunData, bdioResult, scanIdsToWaitFor, codeLocationAccumulator, scanId);
+
+            if (!operationRunner.isCorrelationScanningEnabled()) {
+                invokePreScassPackageManagerWorkflow(blackDuckRunData, bdioResult, scanIdsToWaitFor, codeLocationAccumulator, scanId);
+            } else {
+                logger.warn("Correlation scanning is enabled. Please verify your SCASS configuration, as it is required for correlation scans to function properly.");
+            }
         } else {
             String scanId = null;
             invokePreScassPackageManagerWorkflow(blackDuckRunData, bdioResult, scanIdsToWaitFor, codeLocationAccumulator, scanId);

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
@@ -3,6 +3,7 @@ package com.blackduck.integration.detect.lifecycle.run.step;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
+import java.net.SocketException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -57,14 +58,14 @@ public class SignatureScanStepRunner {
         List<SignatureScannerReport> reports;
         try {
             reports = executeScan(scanBatch, scanBatchRunner, scanPaths, scanIdsToWaitFor, gson, blackDuckRunData.shouldWaitAtScanLevel(), true);
-        } catch (HttpHostConnectException e) {
+        } catch (SocketException e) {
             if (!operationRunner.isCorrelationScanningEnabled()) {
                 logger.warn("Initial Signature Scan failed due to connectivity issues. Retrying scan. Please allow the SCASS IPs to increase scanning performance.");
                 scanBatch = operationRunner.createScanBatchOnline(detectRunUuid, scanPaths, projectNameVersion, dockerTargetData, blackDuckRunData, true);
                 reports = executeScan(scanBatch, scanBatchRunner, scanPaths, scanIdsToWaitFor, gson, blackDuckRunData.shouldWaitAtScanLevel(), true);
             } else {
                 reports = new ArrayList<>();
-                logger.warn("Correlation scanning is enabled. Please verify your SCASS configuration, as it is required for correlation scans to function properly.");
+                operationRunner.publishSignatureFailure("Correlation scanning is enabled. Please verify your SCASS configuration ad, as it is required for correlation scans to function properly.");
             }
         }
 
@@ -184,7 +185,7 @@ public class SignatureScanStepRunner {
 
     private void processOnlineScan(Set<String> scanIdsToWaitFor, Gson gson, boolean shouldWaitAtScanLevel,
             boolean scassScan, Set<String> failedScans, ScanCommandOutput output, File specificRunOutputDirectory,
-            String scanOutputLocation) throws IOException, HttpHostConnectException {
+            String scanOutputLocation) throws IOException, HttpHostConnectException, SocketException {
         try {
             Reader reader = Files.newBufferedReader(Paths.get(scanOutputLocation));
 
@@ -208,10 +209,10 @@ public class SignatureScanStepRunner {
             failedScans.add(output.getCodeLocationName());
             handleNoScanStatusFile(scanIdsToWaitFor, shouldWaitAtScanLevel, scassScan, scanOutputLocation);
         } catch (IntegrationException e) {
-            if (e.getCause() instanceof HttpHostConnectException) {
+            if (e.getCause() instanceof HttpHostConnectException || e.getCause() instanceof SocketException) {
                 // The most likely cause of a failure like this is that the SCASS URLs are
                 // not accessible. Attempt a legacy scan.
-                throw (HttpHostConnectException) e.getCause();
+                throw (SocketException) e.getCause();
             } else {
                 failedScans.add(output.getCodeLocationName());
                 operationRunner.publishSignatureFailure(e.getMessage());

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
@@ -214,7 +214,7 @@ public class SignatureScanStepRunner {
             failedScans.add(output.getCodeLocationName());
             handleNoScanStatusFile(scanIdsToWaitFor, shouldWaitAtScanLevel, scassScan, scanOutputLocation);
         } catch (IntegrationException e) {
-            if (e.getCause() instanceof HttpHostConnectException || e.getCause() instanceof SocketException) {
+            if (e.getCause() instanceof SocketException) {
                 // The most likely cause of a failure like this is that the SCASS URLs are
                 // not accessible. Attempt a legacy scan.
                 throw (SocketException) e.getCause();

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
@@ -8,11 +8,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.http.conn.HttpHostConnectException;
 import org.jetbrains.annotations.Nullable;
@@ -62,9 +58,14 @@ public class SignatureScanStepRunner {
         try {
             reports = executeScan(scanBatch, scanBatchRunner, scanPaths, scanIdsToWaitFor, gson, blackDuckRunData.shouldWaitAtScanLevel(), true);
         } catch (HttpHostConnectException e) {
-            logger.warn("Initial Signature Scan failed due to connectivity issues. Retrying scan. Please allow the SCASS IPs to increase scanning performance.");
-            scanBatch = operationRunner.createScanBatchOnline(detectRunUuid, scanPaths, projectNameVersion, dockerTargetData, blackDuckRunData, true);
-            reports = executeScan(scanBatch, scanBatchRunner, scanPaths, scanIdsToWaitFor, gson, blackDuckRunData.shouldWaitAtScanLevel(), true);
+            if (!operationRunner.isCorrelationScanningEnabled()) {
+                logger.warn("Initial Signature Scan failed due to connectivity issues. Retrying scan. Please allow the SCASS IPs to increase scanning performance.");
+                scanBatch = operationRunner.createScanBatchOnline(detectRunUuid, scanPaths, projectNameVersion, dockerTargetData, blackDuckRunData, true);
+                reports = executeScan(scanBatch, scanBatchRunner, scanPaths, scanIdsToWaitFor, gson, blackDuckRunData.shouldWaitAtScanLevel(), true);
+            } else {
+                reports = new ArrayList<>();
+                logger.warn("Correlation scanning is enabled. Please verify your SCASS configuration, as it is required for correlation scans to function properly.");
+            }
         }
 
         return operationRunner.calculateWaitableSignatureScannerCodeLocations(notificationTaskRange, reports);

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
@@ -9,7 +9,12 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Collections;
 
 import org.apache.http.conn.HttpHostConnectException;
 import org.jetbrains.annotations.Nullable;


### PR DESCRIPTION
This PR changes the behavior for fallback logic when correlated scanning is enabled. Instead of falling back to normal storage service scan, we fail the scan as SCASS is required for correlation scanning to be executed perfectly. Also, this potentially fixes IDETECT-5013 where signature scan was not executing fallback logic correctly due to a change in Exception which was being thrown.

IDETECT-5060

