### PR TITLE
fix(gradle): Prevent phantom project configurations from leaking into dependency scans

### DIFF
--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -81,9 +81,13 @@ gradle.allprojects {
         // Configure the dependencies task during configuration time
         def dependenciesTask = currentProject.tasks.getByName('dependencies')
 
-        // Set the configurations at configuration time if possible
-        if (!selectedConfigs.isEmpty()) {
-            dependenciesTask.configurations = selectedConfigs
+        // Always set configurations explicitly: null → Gradle reports everything; empty Set → reports nothing.
+        // Phantoms always get an empty Set — their configs maybe (e.g. detekt, ktlint) are injected by
+        // parent subprojects{} blocks, not real dependencies, and must never leak into scan results.
+        if (isPhantom) {
+            dependenciesTask.configurations = [] as Set
+        } else {
+            dependenciesTask.configurations = selectedConfigs as Set
         }
 
         // Set the output file at configuration time if possible


### PR DESCRIPTION
## Problem
Phantom projects also called container projects (injected tool configurations like detekt, ktlint) were being 
reported as real dependencies in scan results because the Gradle dependencies 
task was not explicitly configured to exclude them.

## Solution
Explicitly set the `configurations` property on the dependencies task:
- **Phantom projects:** Always get an empty Set (report no dependencies)
- **Normal projects:** Get selected configurations as before

This prevents injected tooling configurations from phantom projects from 
leaking into vulnerability scan results while maintaining accurate dependency 
reporting for real projects.