### PR TITLE
Add support for BlackDuck controlled properties, specifically for correlated scans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.4.0-SIGQA1-dterry.IDETECT-4817-correlated-scans'
+version = '11.4.0-SIGQA2-dterry.IDETECT-4817-correlated-scans-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.4.0-SIGQA3-dterry.IDETECT-4817-correlated-scans'
+version = '11.4.0-SIGQA4-dterry.IDETECT-4817-correlated-scans-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.4.0-SIGQA2-dterry.IDETECT-4817-correlated-scans-SNAPSHOT'
+version = '11.4.0-SIGQA2-dterry.IDETECT-4817-correlated-scans'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.4.0-SIGQA4-dterry.IDETECT-4817-correlated-scans'
+version = '11.4.0-SIGQA5-dterry.IDETECT-4817-correlated-scans-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.4.0-SIGQA3-dterry.IDETECT-4817-correlated-scans-SNAPSHOT'
+version = '11.4.0-SIGQA3-dterry.IDETECT-4817-correlated-scans'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.4.0-SNAPSHOT'
+version = '11.4.0-SIGQA1-dterry.IDETECT-4817-correlated-scans'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.4.0-SIGQA2-dterry.IDETECT-4817-correlated-scans'
+version = '11.4.0-SIGQA3-dterry.IDETECT-4817-correlated-scans-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.4.0-SIGQA4-dterry.IDETECT-4817-correlated-scans-SNAPSHOT'
+version = '11.4.0-SIGQA4-dterry.IDETECT-4817-correlated-scans'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -495,6 +495,12 @@ public class DetectConfigurationFactory {
             return CorrelatedScanningDecision.offlineModeDisabled();
         }
 
+        // Priority 1b: RAPID/STATELESS modes do not support correlated scanning
+        if (blackDuckDecision.scanMode() != null && blackDuckDecision.scanMode() != BlackduckScanMode.INTELLIGENT) {
+            logger.debug("Correlated scanning disabled: scan mode is {}", blackDuckDecision.scanMode());
+            return CorrelatedScanningDecision.defaultDisabled();
+        }
+
         // Priority 2: User explicitly set the property
         if (detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED)) {
             boolean userValue = detectConfiguration.getValue(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED);

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -42,6 +42,7 @@ import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
 import com.blackduck.integration.detect.configuration.enumeration.ExitCodeType;
 import com.blackduck.integration.detect.configuration.enumeration.RapidCompareMode;
 import com.blackduck.integration.detect.lifecycle.boot.decision.BlackDuckDecision;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 import com.blackduck.integration.detect.lifecycle.boot.decision.RunDecision;
 import com.blackduck.integration.detect.lifecycle.boot.product.ProductBootOptions;
 import com.blackduck.integration.detect.tool.binaryscanner.BinaryScanOptions;
@@ -57,6 +58,7 @@ import com.blackduck.integration.detect.util.finder.DetectExcludedDirectoryFilte
 import com.blackduck.integration.detect.workflow.bdio.BdioOptions;
 import com.blackduck.integration.detect.workflow.blackduck.BlackDuckPostOptions;
 import com.blackduck.integration.detect.workflow.blackduck.developer.RapidScanOptions;
+import com.blackduck.integration.detect.workflow.blackduck.settings.DetectPropertiesSetting;
 import com.blackduck.integration.detect.workflow.blackduck.project.customfields.CustomFieldDocument;
 import com.blackduck.integration.detect.workflow.blackduck.project.options.FindCloneOptions;
 import com.blackduck.integration.detect.workflow.blackduck.project.options.ParentProjectMapOptions;
@@ -473,7 +475,57 @@ public class DetectConfigurationFactory {
         return detectConfiguration.getValue(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED);
     }
 
-    public BlackDuckPostOptions createBlackDuckPostOptions() {
+    /**
+     * Resolves the correlated scanning decision using three-tier priority logic:
+     * 1. Offline mode -> always disabled (correlation requires server connectivity)
+     * 2. User explicitly set property -> use user value
+     * 3. User didn't set, server available -> use server value
+     * 4. User didn't set, server unavailable -> default to false
+     *
+     * @param serverSettings Optional server settings from /api/settings/detect/properties endpoint
+     * @param blackDuckDecision The BlackDuck decision to check for offline mode
+     * @return CorrelatedScanningDecision with enabled flag, supported scan types, and decision source
+     */
+    public CorrelatedScanningDecision resolveCorrelatedScanningDecision(
+        Optional<DetectPropertiesSetting> serverSettings,
+        BlackDuckDecision blackDuckDecision
+    ) {
+        // Priority 1: Offline mode always disables correlation (requires server connectivity)
+        if (blackDuckDecision.isOffline()) {
+            logger.debug("Correlated scanning disabled: offline mode enabled");
+            return CorrelatedScanningDecision.offlineModeDisabled();
+        }
+
+        // Priority 2: User explicitly set the property
+        if (detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED)) {
+            boolean userValue = detectConfiguration.getValue(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED);
+            if (userValue) {
+                logger.info("Correlated scanning enabled by user configuration");
+                return CorrelatedScanningDecision.userEnabled();
+            } else {
+                logger.debug("Correlated scanning disabled by user configuration");
+                return CorrelatedScanningDecision.userDisabled();
+            }
+        }
+
+        // Priority 3: Server settings available
+        if (serverSettings.isPresent()) {
+            DetectPropertiesSetting settings = serverSettings.get();
+            if (settings.isCorrelatedScanningEnabled()) {
+                logger.info("Correlated scanning enabled by server configuration for scan types: {}", settings.getCorrelatedScanningScanTypes());
+                return CorrelatedScanningDecision.serverEnabled(settings.getCorrelatedScanningScanTypes());
+            } else {
+                logger.debug("Correlated scanning disabled by server configuration");
+                return CorrelatedScanningDecision.serverDisabled();
+            }
+        }
+
+        // Priority 4: Default to disabled
+        logger.debug("Correlated scanning disabled by default (no user or server configuration)");
+        return CorrelatedScanningDecision.defaultDisabled();
+    }
+
+    public BlackDuckPostOptions createBlackDuckPostOptions(CorrelatedScanningDecision correlatedScanningDecision) {
         Boolean waitForResults = detectConfiguration.getValue(DetectProperties.DETECT_WAIT_FOR_RESULTS);
         Boolean runRiskReportPdf = detectConfiguration.getValue(DetectProperties.DETECT_RISK_REPORT_PDF);
         Boolean runRiskReportJson = detectConfiguration.getValue(DetectProperties.DETECT_RISK_REPORT_JSON);
@@ -483,7 +535,6 @@ public class DetectConfigurationFactory {
         Path noticesReportPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_NOTICES_REPORT_PATH);
         List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
         List<String> policyNamesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_POLICY_CHECK_FAIL_ON_NAMES);
-        Boolean correlatedScanningEnabled = detectConfiguration.getValue(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED);
 
         return new BlackDuckPostOptions(
             waitForResults,
@@ -493,7 +544,7 @@ public class DetectConfigurationFactory {
             noticesReportPath,
             severitiesToFailPolicyCheck,
             policyNamesToFailPolicyCheck,
-            correlatedScanningEnabled,
+            correlatedScanningDecision,
             runRiskReportJson,
             riskReportJsonPath
         );

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -428,7 +428,7 @@ public class DetectConfigurationFactory {
         return detectConfiguration.getValue(DetectProperties.DETECT_PROJECT_USER_GROUPS);
     }
 
-    public BlackDuckSignatureScannerOptions createBlackDuckSignatureScannerOptions() {
+    public BlackDuckSignatureScannerOptions createBlackDuckSignatureScannerOptions(CorrelatedScanningDecision correlatedScanningDecision) {
         List<Path> signatureScannerPaths = detectConfiguration.getPaths(DetectProperties.DETECT_BLACKDUCK_SIGNATURE_SCANNER_PATHS);
         List<String> exclusionPatterns = collectSignatureScannerDirectoryExclusions();
 
@@ -443,7 +443,6 @@ public class DetectConfigurationFactory {
         Integer maxDepth = detectConfiguration.getValue(DetectProperties.DETECT_EXCLUDED_DIRECTORIES_SEARCH_DEPTH);
         Boolean treatSkippedScansAsSuccess = detectConfiguration.getValue(DetectProperties.DETECT_FORCE_SUCCESS_ON_SKIP);
         Boolean isStateless = BlackduckScanMode.STATELESS.equals(detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE));
-        Boolean correlatedScanningEnabled = detectConfiguration.getValue(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED);
         RapidCompareMode compareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
         Boolean csvArchive = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SIGNATURE_SCANNER_CSV_ARCHIVE);
 
@@ -465,7 +464,7 @@ public class DetectConfigurationFactory {
             treatSkippedScansAsSuccess,
             isStateless,
             findReducedPersistence(),
-            correlatedScanningEnabled,
+            correlatedScanningDecision,
             compareMode,
             csvArchive
         );

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -381,19 +381,28 @@ public class DetectBoot {
 
         DetectPropertiesSetting settings = serverSettings.get();
 
-        // Only log server properties if the user didn't specify correlated scanning themselves
+        // Only report server properties if the user didn't specify correlated scanning themselves
         if (detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED)) {
             return; // User already saw their configured value in the normal property output
         }
 
         boolean correlatedScanningEnabled = settings.isCorrelatedScanningEnabled();
 
-        // Only log if the server has this enabled; don't log at all if false
+        // Only report if the server has this enabled; don't report at all if false
         if (!correlatedScanningEnabled) {
             return;
         }
 
         String correlatedScanningValue = String.valueOf(correlatedScanningEnabled);
+
+        // Publish to status.json
+        Map<String, String> serverProperties = new java.util.LinkedHashMap<>();
+        serverProperties.put("detect.blackduck.correlated.scanning.enabled", correlatedScanningValue);
+        List<String> scanTypes = settings.getCorrelatedScanningScanTypes();
+        if (scanTypes != null && !scanTypes.isEmpty()) {
+            serverProperties.put("detect.blackduck.correlated.scanning.scan.types", String.join(",", scanTypes));
+        }
+        eventSystem.publishEvent(Event.BlackDuckServerPropertiesCollected, serverProperties);
 
         // Log to console
         logger.info("");

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -260,6 +260,9 @@ public class DetectBoot {
         if (productRunData.shouldUseBlackDuckProduct()) {
             Optional<DetectPropertiesSetting> serverSettings = productRunData.getBlackDuckRunData().getServerDetectProperties();
             correlatedScanningDecision = detectConfigurationFactory.resolveCorrelatedScanningDecision(serverSettings, blackDuckDecision);
+
+            // Log Black Duck SCA global properties if they were fetched from the server
+            logBlackDuckServerProperties(detectConfiguration, serverSettings, diagnosticSystem);
         } else {
             correlatedScanningDecision = CorrelatedScanningDecision.defaultDisabled();
         }
@@ -369,5 +372,37 @@ public class DetectBoot {
 
     private void publishCollectedPropertyValues(Map<String, String> maskedRawPropertyValues) {
         eventSystem.publishEvent(Event.RawMaskedPropertyValuesCollected, new TreeMap<>(maskedRawPropertyValues));
+    }
+
+    private void logBlackDuckServerProperties(DetectPropertyConfiguration detectConfiguration, Optional<DetectPropertiesSetting> serverSettings, DiagnosticSystem diagnosticSystem) {
+        if (!serverSettings.isPresent()) {
+            return;
+        }
+
+        DetectPropertiesSetting settings = serverSettings.get();
+
+        // Only log server properties if the user didn't specify correlated scanning themselves
+        if (detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED)) {
+            return; // User already saw their configured value in the normal property output
+        }
+
+        // Determine the value to display
+        String scanTypesValue = (settings.getCorrelatedScanningScanTypes() != null && !settings.getCorrelatedScanningScanTypes().isEmpty())
+            ? String.join(", ", settings.getCorrelatedScanningScanTypes())
+            : "[]";
+
+        // Log to console
+        logger.info("");
+        logger.info("Black Duck SCA global properties:");
+        logger.info("--property = value [notes]");
+        logger.info("------------------------------------------------------------");
+        logger.info("detect.blackduck.correlated.scanning.enabled = {} [SCA]", scanTypesValue);
+        logger.info("------------------------------------------------------------");
+        logger.info("");
+
+        // Append to diagnostic report if diagnostic mode is enabled
+        if (diagnosticSystem != null) {
+            diagnosticSystem.appendBlackDuckServerProperties(scanTypesValue);
+        }
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -383,19 +383,16 @@ public class DetectBoot {
 
         DetectPropertiesSetting settings = serverSettings.get();
 
-        // Only report if the server has this enabled; don't report at all if false
-        if (!settings.isCorrelatedScanningEnabled()) {
-            return;
-        }
-
-        String correlatedScanningValue = String.valueOf(settings.isCorrelatedScanningEnabled());
-
-        // Build the full server properties map
+        // Build the server properties map from whatever the server has enabled.
+        // Only include a property if its server value is worth reporting (e.g. enabled features).
+        // Add new server properties here as DetectPropertiesSetting grows.
         Map<String, String> serverProperties = new LinkedHashMap<>();
-        serverProperties.put("detect.blackduck.correlated.scanning.enabled", correlatedScanningValue);
-        List<String> scanTypes = settings.getCorrelatedScanningScanTypes();
-        if (scanTypes != null && !scanTypes.isEmpty()) {
-            serverProperties.put("detect.blackduck.correlated.scanning.scan.types", String.join(",", scanTypes));
+        if (settings.isCorrelatedScanningEnabled()) {
+            serverProperties.put("detect.blackduck.correlated.scanning.enabled", "true");
+            List<String> scanTypes = settings.getCorrelatedScanningScanTypes();
+            if (scanTypes != null && !scanTypes.isEmpty()) {
+                serverProperties.put("detect.blackduck.correlated.scanning.scan.types", String.join(",", scanTypes));
+            }
         }
 
         // Map each server property key to its corresponding DetectProperty for user-override filtering.
@@ -428,7 +425,7 @@ public class DetectBoot {
 
         // Append to diagnostic report if diagnostic mode is enabled
         if (diagnosticSystem != null) {
-            diagnosticSystem.appendBlackDuckServerProperties(correlatedScanningValue);
+            diagnosticSystem.appendBlackDuckServerProperties(serverProperties);
         }
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -389,10 +389,6 @@ public class DetectBoot {
         Map<String, String> serverProperties = new LinkedHashMap<>();
         if (settings.isCorrelatedScanningEnabled()) {
             serverProperties.put("detect.blackduck.correlated.scanning.enabled", "true");
-            List<String> scanTypes = settings.getCorrelatedScanningScanTypes();
-            if (scanTypes != null && !scanTypes.isEmpty()) {
-                serverProperties.put("detect.blackduck.correlated.scanning.scan.types", String.join(",", scanTypes));
-            }
         }
 
         // Map each server property key to its corresponding DetectProperty for user-override filtering.

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -12,8 +12,10 @@ import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 
 import com.blackduck.integration.configuration.config.MaskedRawValueResult;
+import com.blackduck.integration.configuration.property.base.TypedProperty;
 import com.blackduck.integration.configuration.property.types.enumallnone.list.AllEnumList;
 import com.blackduck.integration.configuration.property.types.path.PathValue;
 import com.blackduck.integration.detect.configuration.connection.BlackDuckConnectionDetails;
@@ -381,27 +383,38 @@ public class DetectBoot {
 
         DetectPropertiesSetting settings = serverSettings.get();
 
-        // Only report server properties if the user didn't specify correlated scanning themselves
-        if (detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED)) {
-            return; // User already saw their configured value in the normal property output
-        }
-
-        boolean correlatedScanningEnabled = settings.isCorrelatedScanningEnabled();
-
         // Only report if the server has this enabled; don't report at all if false
-        if (!correlatedScanningEnabled) {
+        if (!settings.isCorrelatedScanningEnabled()) {
             return;
         }
 
-        String correlatedScanningValue = String.valueOf(correlatedScanningEnabled);
+        String correlatedScanningValue = String.valueOf(settings.isCorrelatedScanningEnabled());
 
-        // Publish to status.json
-        Map<String, String> serverProperties = new java.util.LinkedHashMap<>();
+        // Build the full server properties map
+        Map<String, String> serverProperties = new LinkedHashMap<>();
         serverProperties.put("detect.blackduck.correlated.scanning.enabled", correlatedScanningValue);
         List<String> scanTypes = settings.getCorrelatedScanningScanTypes();
         if (scanTypes != null && !scanTypes.isEmpty()) {
             serverProperties.put("detect.blackduck.correlated.scanning.scan.types", String.join(",", scanTypes));
         }
+
+        // Map each server property key to its corresponding DetectProperty for user-override filtering.
+        // Add new entries here as additional server-driven properties are introduced.
+        Map<String, TypedProperty<?, ?>> serverPropertyOverrides = new LinkedHashMap<>();
+        serverPropertyOverrides.put("detect.blackduck.correlated.scanning.enabled", DetectProperties.DETECT_CORRELATED_SCANNING_ENABLED);
+
+        // Remove any properties the user has already explicitly configured (they saw those in normal property output)
+        serverPropertyOverrides.forEach((key, property) -> {
+            if (detectConfiguration.wasPropertyProvided(property)) {
+                serverProperties.remove(key);
+            }
+        });
+
+        if (serverProperties.isEmpty()) {
+            return;
+        }
+
+        // Publish to status.json
         eventSystem.publishEvent(Event.BlackDuckServerPropertiesCollected, serverProperties);
 
         // Log to console
@@ -409,7 +422,7 @@ public class DetectBoot {
         logger.info("Black Duck SCA global properties:");
         logger.info("--property = value [notes]");
         logger.info("------------------------------------------------------------");
-        logger.info("detect.blackduck.correlated.scanning.enabled = {} [SCA]", correlatedScanningValue);
+        serverProperties.forEach((key, value) -> logger.info("{} = {} [SCA]", key, value));
         logger.info("------------------------------------------------------------");
         logger.info("");
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -47,11 +47,13 @@ import com.blackduck.integration.detect.configuration.validation.DetectConfigura
 import com.blackduck.integration.detect.interactive.InteractiveManager;
 import com.blackduck.integration.detect.lifecycle.autonomous.AutonomousManager;
 import com.blackduck.integration.detect.lifecycle.boot.decision.BlackDuckDecision;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 import com.blackduck.integration.detect.lifecycle.boot.decision.ProductDecider;
 import com.blackduck.integration.detect.lifecycle.boot.decision.RunDecision;
 import com.blackduck.integration.detect.lifecycle.boot.product.ProductBoot;
 import com.blackduck.integration.detect.lifecycle.run.data.ProductRunData;
 import com.blackduck.integration.detect.lifecycle.run.singleton.BootSingletons;
+import com.blackduck.integration.detect.workflow.blackduck.settings.DetectPropertiesSetting;
 import com.blackduck.integration.detect.tool.cache.InstalledToolLocator;
 import com.blackduck.integration.detect.tool.cache.InstalledToolManager;
 import com.blackduck.integration.detect.util.filter.DetectToolFilter;
@@ -191,7 +193,7 @@ public class DetectBoot {
 
         logger.info("");
 
-        ProductRunData productRunData;
+        ProductRunData productRunData = null;
 
         // store the result of hasImageOrTar... we will need this in more than one place.
         boolean hasImageOrTar;
@@ -210,6 +212,7 @@ public class DetectBoot {
         }
         
         Map<DetectTool, Set<String>> scanTypeEvidenceMap = autonomousManager.getScanTypeMap(hasImageOrTar);
+        BlackDuckDecision blackDuckDecision = null;
 
         try {
             boolean blackduckScanModeSpecified = detectConfiguration.wasPropertyProvided(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
@@ -224,7 +227,7 @@ public class DetectBoot {
             }
             autonomousManager.setBlackDuckScanMode(blackduckScanMode.toString());
             ProductDecider productDecider = new ProductDecider(autonomousScanEnabled, blackduckUrlSpecified, blackduckOfflineModeSpecified);
-            BlackDuckDecision blackDuckDecision = productDecider.decideBlackDuck(
+            blackDuckDecision = productDecider.decideBlackDuck(
                 blackDuckConnectionDetails,
                 blackduckScanMode,
                 detectConfigurationFactory.createHasSignatureScan(scanTypeEvidenceMap.containsKey(DetectTool.SIGNATURE_SCAN))
@@ -252,6 +255,15 @@ public class DetectBoot {
             return Optional.of(DetectBootResult.exit(propertyConfiguration, directoryManager, diagnosticSystem));
         }
 
+        // Resolve correlated scanning decision based on user config, server settings, and offline mode
+        CorrelatedScanningDecision correlatedScanningDecision;
+        if (productRunData.shouldUseBlackDuckProduct()) {
+            Optional<DetectPropertiesSetting> serverSettings = productRunData.getBlackDuckRunData().getServerDetectProperties();
+            correlatedScanningDecision = detectConfigurationFactory.resolveCorrelatedScanningDecision(serverSettings, blackDuckDecision);
+        } else {
+            correlatedScanningDecision = CorrelatedScanningDecision.defaultDisabled();
+        }
+
         BootSingletons bootSingletons = detectBootFactory
             .createRunDependencies(
                 productRunData,
@@ -262,7 +274,8 @@ public class DetectBoot {
                 freemarkerConfiguration,
                 installedToolManager,
                 installedToolLocator,
-                autonomousManager
+                autonomousManager,
+                correlatedScanningDecision
             );
 
         return Optional.of(DetectBootResult.run(bootSingletons, propertyConfiguration, productRunData, directoryManager, diagnosticSystem));

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -386,23 +386,27 @@ public class DetectBoot {
             return; // User already saw their configured value in the normal property output
         }
 
-        // Determine the value to display
-        String scanTypesValue = (settings.getCorrelatedScanningScanTypes() != null && !settings.getCorrelatedScanningScanTypes().isEmpty())
-            ? String.join(", ", settings.getCorrelatedScanningScanTypes())
-            : "[]";
+        boolean correlatedScanningEnabled = settings.isCorrelatedScanningEnabled();
+
+        // Only log if the server has this enabled; don't log at all if false
+        if (!correlatedScanningEnabled) {
+            return;
+        }
+
+        String correlatedScanningValue = String.valueOf(correlatedScanningEnabled);
 
         // Log to console
         logger.info("");
         logger.info("Black Duck SCA global properties:");
         logger.info("--property = value [notes]");
         logger.info("------------------------------------------------------------");
-        logger.info("detect.blackduck.correlated.scanning.enabled = {} [SCA]", scanTypesValue);
+        logger.info("detect.blackduck.correlated.scanning.enabled = {} [SCA]", correlatedScanningValue);
         logger.info("------------------------------------------------------------");
         logger.info("");
 
         // Append to diagnostic report if diagnostic mode is enabled
         if (diagnosticSystem != null) {
-            diagnosticSystem.appendBlackDuckServerProperties(scanTypesValue);
+            diagnosticSystem.appendBlackDuckServerProperties(correlatedScanningValue);
         }
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBootFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBootFactory.java
@@ -31,6 +31,7 @@ import com.blackduck.integration.detect.interactive.InteractiveModeDecisionTree;
 import com.blackduck.integration.detect.interactive.InteractivePropertySourceBuilder;
 import com.blackduck.integration.detect.interactive.InteractiveWriter;
 import com.blackduck.integration.detect.lifecycle.autonomous.AutonomousManager;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 import com.blackduck.integration.detect.lifecycle.boot.product.BlackDuckConnectivityChecker;
 import com.blackduck.integration.detect.lifecycle.boot.product.ProductBoot;
 import com.blackduck.integration.detect.lifecycle.boot.product.ProductBootFactory;
@@ -64,6 +65,7 @@ import com.blackduck.integration.detect.workflow.airgap.DockerAirGapCreator;
 import com.blackduck.integration.detect.workflow.airgap.NugetInspectorAirGapCreator;
 import com.blackduck.integration.detect.workflow.airgap.ProjectInspectorAirGapCreator;
 import com.blackduck.integration.detect.workflow.blackduck.analytics.AnalyticsConfigurationService;
+import com.blackduck.integration.detect.workflow.blackduck.settings.DetectPropertiesService;
 import com.blackduck.integration.detect.workflow.blackduck.font.DetectFontInstaller;
 import com.blackduck.integration.detect.workflow.diagnostic.DiagnosticSystem;
 import com.blackduck.integration.detect.workflow.event.EventSystem;
@@ -101,7 +103,8 @@ public class DetectBootFactory {
         Configuration configuration,
         InstalledToolManager installedToolManager,
         InstalledToolLocator installedToolLocator,
-        AutonomousManager autonomousManager
+        AutonomousManager autonomousManager,
+        CorrelatedScanningDecision correlatedScanningDecision
     ) {
         return new BootSingletons(
             productRunData,
@@ -118,7 +121,8 @@ public class DetectBootFactory {
             configuration,
             installedToolManager,
             installedToolLocator,
-            autonomousManager
+            autonomousManager,
+            correlatedScanningDecision
         );
     }
 
@@ -223,6 +227,7 @@ public class DetectBootFactory {
         return new ProductBoot(
             blackDuckConnectivityChecker,
             createAnalyticsConfigurationService(),
+            createDetectPropertiesService(),
             createProductBootFactory(detectConfigurationFactory),
             productBootOptions,
             blackDuckVersionChecker
@@ -231,6 +236,10 @@ public class DetectBootFactory {
 
     public AnalyticsConfigurationService createAnalyticsConfigurationService() {
         return new AnalyticsConfigurationService();
+    }
+
+    public DetectPropertiesService createDetectPropertiesService() {
+        return new DetectPropertiesService();
     }
 
     public InteractiveManager createInteractiveManager(List<PropertySource> propertySources) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/decision/CorrelatedScanningDecision.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/decision/CorrelatedScanningDecision.java
@@ -1,0 +1,100 @@
+package com.blackduck.integration.detect.lifecycle.boot.decision;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class CorrelatedScanningDecision {
+    public enum DecisionSource {
+        USER_ENABLED,
+        USER_DISABLED,
+        SERVER_ENABLED,
+        SERVER_DISABLED,
+        DEFAULT_DISABLED,
+        OFFLINE_MODE_DISABLED
+    }
+
+    private final boolean enabled;
+    private final Set<String> supportedScanTypes;
+    private final DecisionSource source;
+
+    private CorrelatedScanningDecision(boolean enabled, Set<String> supportedScanTypes, DecisionSource source) {
+        this.enabled = enabled;
+        this.supportedScanTypes = supportedScanTypes != null ? new HashSet<>(supportedScanTypes) : Collections.emptySet();
+        this.source = source;
+    }
+
+    public static CorrelatedScanningDecision userEnabled() {
+        // When user enables, support all scan types by default
+        return new CorrelatedScanningDecision(
+            true,
+            createAllScanTypes(),
+            DecisionSource.USER_ENABLED
+        );
+    }
+
+    public static CorrelatedScanningDecision userDisabled() {
+        return new CorrelatedScanningDecision(
+            false,
+            Collections.emptySet(),
+            DecisionSource.USER_DISABLED
+        );
+    }
+
+    public static CorrelatedScanningDecision serverEnabled(List<String> supportedScanTypes) {
+        return new CorrelatedScanningDecision(
+            true,
+            new HashSet<>(supportedScanTypes != null ? supportedScanTypes : Collections.emptyList()),
+            DecisionSource.SERVER_ENABLED
+        );
+    }
+
+    public static CorrelatedScanningDecision serverDisabled() {
+        return new CorrelatedScanningDecision(
+            false,
+            Collections.emptySet(),
+            DecisionSource.SERVER_DISABLED
+        );
+    }
+
+    public static CorrelatedScanningDecision defaultDisabled() {
+        return new CorrelatedScanningDecision(
+            false,
+            Collections.emptySet(),
+            DecisionSource.DEFAULT_DISABLED
+        );
+    }
+
+    public static CorrelatedScanningDecision offlineModeDisabled() {
+        return new CorrelatedScanningDecision(
+            false,
+            Collections.emptySet(),
+            DecisionSource.OFFLINE_MODE_DISABLED
+        );
+    }
+
+    private static Set<String> createAllScanTypes() {
+        Set<String> allTypes = new HashSet<>();
+        allTypes.add("PACKAGE_MANAGER");
+        allTypes.add("SIGNATURE");
+        allTypes.add("BINARY");
+        return allTypes;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Set<String> getSupportedScanTypes() {
+        return Collections.unmodifiableSet(supportedScanTypes);
+    }
+
+    public boolean isScanTypeSupported(String scanType) {
+        return supportedScanTypes.contains(scanType);
+    }
+
+    public DecisionSource getSource() {
+        return source;
+    }
+}

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/decision/CorrelatedScanningDecision.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/decision/CorrelatedScanningDecision.java
@@ -43,9 +43,13 @@ public class CorrelatedScanningDecision {
     }
 
     public static CorrelatedScanningDecision serverEnabled(List<String> supportedScanTypes) {
+        // Filter out BINARY and CONTAINER scan types - they are not supported in correlated mode
+        Set<String> filteredTypes = new HashSet<>(supportedScanTypes != null ? supportedScanTypes : Collections.emptyList());
+        filteredTypes.remove("BINARY");
+        filteredTypes.remove("CONTAINER");
         return new CorrelatedScanningDecision(
             true,
-            new HashSet<>(supportedScanTypes != null ? supportedScanTypes : Collections.emptyList()),
+            filteredTypes,
             DecisionSource.SERVER_ENABLED
         );
     }
@@ -75,10 +79,10 @@ public class CorrelatedScanningDecision {
     }
 
     private static Set<String> createAllScanTypes() {
+        // BINARY and CONTAINER scans are not supported in correlated mode
         Set<String> allTypes = new HashSet<>();
         allTypes.add("PACKAGE_MANAGER");
         allTypes.add("SIGNATURE");
-        allTypes.add("BINARY");
         return allTypes;
     }
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/product/ProductBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/product/ProductBoot.java
@@ -26,6 +26,8 @@ import com.blackduck.integration.detect.lifecycle.run.data.ProductRunData;
 import com.blackduck.integration.detect.util.filter.DetectToolFilter;
 import com.blackduck.integration.detect.workflow.blackduck.analytics.AnalyticsConfigurationService;
 import com.blackduck.integration.detect.workflow.blackduck.analytics.AnalyticsSetting;
+import com.blackduck.integration.detect.workflow.blackduck.settings.DetectPropertiesService;
+import com.blackduck.integration.detect.workflow.blackduck.settings.DetectPropertiesSetting;
 import com.blackduck.integration.detect.workflow.phonehome.PhoneHomeManager;
 import com.blackduck.integration.exception.IntegrationException;
 
@@ -33,6 +35,7 @@ public class ProductBoot {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final BlackDuckConnectivityChecker blackDuckConnectivityChecker;
     private final AnalyticsConfigurationService analyticsConfigurationService;
+    private final DetectPropertiesService detectPropertiesService;
     private final ProductBootFactory productBootFactory;
     private final ProductBootOptions productBootOptions;
     private final BlackDuckVersionChecker blackDuckVersionChecker;
@@ -40,12 +43,14 @@ public class ProductBoot {
     public ProductBoot(
         BlackDuckConnectivityChecker blackDuckConnectivityChecker,
         AnalyticsConfigurationService analyticsConfigurationService,
+        DetectPropertiesService detectPropertiesService,
         ProductBootFactory productBootFactory,
         ProductBootOptions productBootOptions,
         BlackDuckVersionChecker blackDuckVersionChecker
     ) {
         this.blackDuckConnectivityChecker = blackDuckConnectivityChecker;
         this.analyticsConfigurationService = analyticsConfigurationService;
+        this.detectPropertiesService = detectPropertiesService;
         this.productBootFactory = productBootFactory;
         this.productBootOptions = productBootOptions;
         this.blackDuckVersionChecker = blackDuckVersionChecker;
@@ -67,7 +72,8 @@ public class ProductBoot {
             productBootFactory,
             blackDuckConnectivityChecker,
             productBootOptions,
-            analyticsConfigurationService
+            analyticsConfigurationService,
+            detectPropertiesService
         );
 
         if (productBootOptions.isTestConnections()) {
@@ -85,7 +91,8 @@ public class ProductBoot {
         ProductBootFactory productBootFactory,
         BlackDuckConnectivityChecker blackDuckConnectivityChecker,
         ProductBootOptions productBootOptions,
-        AnalyticsConfigurationService analyticsConfigurationService
+        AnalyticsConfigurationService analyticsConfigurationService,
+        DetectPropertiesService detectPropertiesService
     ) throws DetectUserFriendlyException {
         if (!blackDuckDecision.shouldRun()) {
             return null;
@@ -112,7 +119,14 @@ public class ProductBoot {
             setBlackDuckVersionLevel(blackDuckServicesFactory, blackDuckConnectivityResult);
             boolean waitAtScanLevel = shouldWaitAtScanLevel(blackDuckConnectivityResult);
 
-            return createBlackDuckRunDataBasedOnPhoneHomeDecision(blackDuckDecision, blackDuckServicesFactory, blackDuckConnectivityResult, waitAtScanLevel);
+            // Fetch server detect properties settings
+            Optional<DetectPropertiesSetting> serverDetectProperties = fetchDetectPropertiesFromServer(
+                detectPropertiesService,
+                blackDuckServicesFactory.getApiDiscovery(),
+                blackDuckServicesFactory.getBlackDuckApiClient()
+            );
+
+            return createBlackDuckRunDataBasedOnPhoneHomeDecision(blackDuckDecision, blackDuckServicesFactory, blackDuckConnectivityResult, waitAtScanLevel, serverDetectProperties);
         } else {
             if (productBootOptions.isIgnoreConnectionFailures()) {
                 logger.info(String.format("Failed to connect to Black Duck SCA: %s", blackDuckConnectivityResult.getFailureReason()));
@@ -130,7 +144,13 @@ public class ProductBoot {
         }
     }
 
-    private BlackDuckRunData createBlackDuckRunDataBasedOnPhoneHomeDecision(BlackDuckDecision blackDuckDecision, BlackDuckServicesFactory blackDuckServicesFactory, BlackDuckConnectivityResult blackDuckConnectivityResult, boolean waitAtScanLevel) {
+    private BlackDuckRunData createBlackDuckRunDataBasedOnPhoneHomeDecision(
+        BlackDuckDecision blackDuckDecision,
+        BlackDuckServicesFactory blackDuckServicesFactory,
+        BlackDuckConnectivityResult blackDuckConnectivityResult,
+        boolean waitAtScanLevel,
+        Optional<DetectPropertiesSetting> serverDetectProperties
+    ) {
         if (shouldUsePhoneHome(analyticsConfigurationService, blackDuckServicesFactory.getApiDiscovery(), blackDuckServicesFactory.getBlackDuckApiClient())) {
             try {
                 PhoneHomeManager phoneHomeManager = productBootFactory.createPhoneHomeManager(blackDuckServicesFactory,
@@ -140,7 +160,8 @@ public class ProductBoot {
                     blackDuckServicesFactory,
                     phoneHomeManager,
                     blackDuckConnectivityResult,
-                    waitAtScanLevel
+                    waitAtScanLevel,
+                    serverDetectProperties
                 );
             } catch (IntegrationException e) {
                 logger.debug("Failed to fetch Analytics credentials. Skipping phone home. Exception: " + e.getMessage());
@@ -150,7 +171,24 @@ public class ProductBoot {
         } else {
             logger.debug("Skipping phone home due to Black Duck SCA global settings.");
         }
-        return BlackDuckRunData.onlineNoPhoneHome(blackDuckDecision.scanMode(), blackDuckServicesFactory, blackDuckConnectivityResult, waitAtScanLevel);
+        return BlackDuckRunData.onlineNoPhoneHome(blackDuckDecision.scanMode(), blackDuckServicesFactory, blackDuckConnectivityResult, waitAtScanLevel, serverDetectProperties);
+    }
+
+    private Optional<DetectPropertiesSetting> fetchDetectPropertiesFromServer(
+        DetectPropertiesService detectPropertiesService,
+        ApiDiscovery apiDiscovery,
+        BlackDuckApiClient blackDuckApiClient
+    ) {
+        try {
+            DetectPropertiesSetting settings = detectPropertiesService.fetchDetectProperties(apiDiscovery, blackDuckApiClient);
+            logger.debug("Successfully fetched detect properties from server: correlatedScanningEnabled={}, supportedScanTypes={}",
+                settings.isCorrelatedScanningEnabled(),
+                settings.getCorrelatedScanningScanTypes());
+            return Optional.of(settings);
+        } catch (IntegrationException | IOException e) {
+            logger.debug("Failed to fetch detect properties from server. Endpoint may not be available on this Black Duck instance: {}", e.getMessage());
+            return Optional.empty();
+        }
     }
 
     private void setBlackDuckVersionLevel(BlackDuckServicesFactory blackDuckServicesFactory,

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/DetectRun.java
@@ -93,13 +93,12 @@ public class DetectRun {
             Boolean forceBdio = bootSingletons.getDetectConfigurationFactory().forceBdio();
             logger.debug("Integrated Matching Correlation ID: {}", bootSingletons.getDetectRunId().getCorrelationId());
             CorrelatedScanningDecision correlatedScanningDecision = bootSingletons.getCorrelatedScanningDecision();
-            String correlationId = getCorrelationId(correlatedScanningDecision, bootSingletons);
             if (!universalToolsResult.getDetectCodeLocations().isEmpty()
                     || (productRunData.shouldUseBlackDuckProduct()
                     && !productRunData.getBlackDuckRunData().isOnline()
                     && forceBdio && !universalToolsResult.didAnyFail()
                     && exitCodeManager.getWinningExitCodeRequest().getExitCodeType().isSuccess())) {
-                bdio = stepRunner.generateBdio(correlationId, universalToolsResult, nameVersion);
+                bdio = stepRunner.generateBdio(operationRunner.getCorrelationIdForScanType("PACKAGE_MANAGER"), universalToolsResult, nameVersion);
             } else {
                 bdio = BdioResult.none();
             }
@@ -127,8 +126,8 @@ public class DetectRun {
                 );
 
                 if (blackDuckRunData.isNonPersistent() && blackDuckRunData.isOnline()) {
-                    RapidModeStepRunner rapidModeSteps = new RapidModeStepRunner(operationRunner, stepHelper, bootSingletons.getGson(), correlationId, bootSingletons.getDirectoryManager());
-                    
+                    RapidModeStepRunner rapidModeSteps = new RapidModeStepRunner(operationRunner, stepHelper, bootSingletons.getGson(), bootSingletons.getDetectRunId().getCorrelationId(), bootSingletons.getDirectoryManager());
+
                     Optional<String> scaaasFilePath = bootSingletons.getDetectConfigurationFactory().getScaaasFilePath();
                     rapidModeSteps.runOnline(blackDuckRunData, nameVersion, bdio, universalToolsResult.getDockerTargetData(), scaaasFilePath);
                 } else if (blackDuckRunData.isNonPersistent()) {
@@ -170,12 +169,6 @@ public class DetectRun {
     public void phoneHomeApplicableDetectorTypes(PhoneHomeManager phoneHomeManager, Set<DetectorType> applicableDetectorTypes) {
         Map<DetectorType, Long> detectorTimes = applicableDetectorTypes.stream().collect(Collectors.toMap(detectorType -> detectorType, detectorType -> 0L));
         phoneHomeManager.savePhoneHomeDetectorTimes(detectorTimes);
-    }
-
-    private String getCorrelationId(CorrelatedScanningDecision decision, BootSingletons bootSingletons) {
-        return decision.isEnabled() && decision.isScanTypeSupported("PACKAGE_MANAGER")
-            ? bootSingletons.getDetectRunId().getCorrelationId()
-            : null;
     }
 
     private Set<String> getDecidedTools(BootSingletons bootSingletons, Map<DetectTool, Set<String>> scanTypeEvidenceMap) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/DetectRun.java
@@ -173,7 +173,9 @@ public class DetectRun {
     }
 
     private String getCorrelationId(CorrelatedScanningDecision decision, BootSingletons bootSingletons) {
-        return decision.isEnabled() ? bootSingletons.getDetectRunId().getCorrelationId() : null;
+        return decision.isEnabled() && decision.isScanTypeSupported("PACKAGE_MANAGER")
+            ? bootSingletons.getDetectRunId().getCorrelationId()
+            : null;
     }
 
     private Set<String> getDecidedTools(BootSingletons bootSingletons, Map<DetectTool, Set<String>> scanTypeEvidenceMap) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/DetectRun.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/DetectRun.java
@@ -14,6 +14,7 @@ import com.blackduck.integration.configuration.property.types.enumallnone.list.A
 import com.blackduck.integration.detect.configuration.DetectConfigurationFactory;
 import com.blackduck.integration.detect.configuration.DetectProperties;
 import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 import com.blackduck.integration.detect.lifecycle.autonomous.AutonomousManager;
 import com.blackduck.integration.detect.workflow.phonehome.PhoneHomeManager;
 import com.blackduck.integration.detector.base.DetectorType;
@@ -91,7 +92,8 @@ public class DetectRun {
             BdioResult bdio;
             Boolean forceBdio = bootSingletons.getDetectConfigurationFactory().forceBdio();
             logger.debug("Integrated Matching Correlation ID: {}", bootSingletons.getDetectRunId().getCorrelationId());
-            String correlationId = getCorrelationId(operationRunner.getDetectConfigurationFactory(), bootSingletons);
+            CorrelatedScanningDecision correlatedScanningDecision = bootSingletons.getCorrelatedScanningDecision();
+            String correlationId = getCorrelationId(correlatedScanningDecision, bootSingletons);
             if (!universalToolsResult.getDetectCodeLocations().isEmpty()
                     || (productRunData.shouldUseBlackDuckProduct()
                     && !productRunData.getBlackDuckRunData().isOnline()
@@ -137,7 +139,7 @@ public class DetectRun {
                             stepHelper, 
                             bootSingletons.getGson(), 
                             new ScanCountsPayloadCreator(),
-                            correlationId);
+                            correlatedScanningDecision);
                     intelligentModeSteps.runOnline(blackDuckRunData, bdio, nameVersion, productRunData.getDetectToolFilter(), universalToolsResult.getDockerTargetData(), binaryTargets);
                 } else {
                     IntelligentModeStepRunner intelligentModeSteps = new IntelligentModeStepRunner(
@@ -145,7 +147,7 @@ public class DetectRun {
                             stepHelper, 
                             bootSingletons.getGson(), 
                             new ScanCountsPayloadCreator(), 
-                            correlationId);
+                            correlatedScanningDecision);
                     intelligentModeSteps.runOffline(nameVersion, universalToolsResult.getDockerTargetData(), bdio);
                 }
             }
@@ -170,8 +172,8 @@ public class DetectRun {
         phoneHomeManager.savePhoneHomeDetectorTimes(detectorTimes);
     }
 
-    private String getCorrelationId(DetectConfigurationFactory configurationFactory, BootSingletons bootSingletons) {
-        return configurationFactory.isCorrelatedScanningEnabled()? bootSingletons.getDetectRunId().getCorrelationId():null;
+    private String getCorrelationId(CorrelatedScanningDecision decision, BootSingletons bootSingletons) {
+        return decision.isEnabled() ? bootSingletons.getDetectRunId().getCorrelationId() : null;
     }
 
     private Set<String> getDecidedTools(BootSingletons bootSingletons, Map<DetectTool, Set<String>> scanTypeEvidenceMap) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/data/BlackDuckRunData.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/data/BlackDuckRunData.java
@@ -20,6 +20,16 @@ public class BlackDuckRunData {
     private final Optional<DetectPropertiesSetting> serverDetectProperties;
     private Optional<BlackDuckVersion> blackDuckServerVersion;
 
+    private BlackDuckRunData() {
+        this.phoneHomeManager = null;
+        this.blackDuckServerConfig = null;
+        this.blackDuckServicesFactory = null;
+        this.scanMode = null;
+        this.waitAtScanLevel = false;
+        this.serverDetectProperties = Optional.empty();
+        this.blackDuckServerVersion = Optional.empty();
+    }
+
     protected BlackDuckRunData(
         PhoneHomeManager phoneHomeManager,
         BlackDuckConnectivityResult blackDuckConnectivityResult,
@@ -55,7 +65,7 @@ public class BlackDuckRunData {
     }
 
     public static BlackDuckRunData offline() {
-        return new BlackDuckRunData(null, null, null, null, false, Optional.empty());
+        return new BlackDuckRunData();
     }
 
     public static BlackDuckRunData online(

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/data/BlackDuckRunData.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/data/BlackDuckRunData.java
@@ -8,6 +8,7 @@ import com.blackduck.integration.blackduck.version.BlackDuckVersion;
 import com.blackduck.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.blackduck.integration.detect.lifecycle.boot.product.BlackDuckConnectivityResult;
 import com.blackduck.integration.detect.lifecycle.boot.product.version.BlackDuckVersionParser;
+import com.blackduck.integration.detect.workflow.blackduck.settings.DetectPropertiesSetting;
 import com.blackduck.integration.detect.workflow.phonehome.PhoneHomeManager;
 
 public class BlackDuckRunData {
@@ -16,6 +17,7 @@ public class BlackDuckRunData {
     private final BlackDuckServicesFactory blackDuckServicesFactory;
     private final BlackduckScanMode scanMode;
     private final boolean waitAtScanLevel;
+    private final Optional<DetectPropertiesSetting> serverDetectProperties;
     private Optional<BlackDuckVersion> blackDuckServerVersion;
 
     protected BlackDuckRunData(
@@ -23,13 +25,15 @@ public class BlackDuckRunData {
         BlackDuckConnectivityResult blackDuckConnectivityResult,
         BlackDuckServicesFactory blackDuckServicesFactory,
         BlackduckScanMode scanMode,
-        boolean waitAtScanLevel
+        boolean waitAtScanLevel,
+        Optional<DetectPropertiesSetting> serverDetectProperties
     ) {
         this.phoneHomeManager = phoneHomeManager;
         this.blackDuckServerConfig = blackDuckConnectivityResult != null ? blackDuckConnectivityResult.getBlackDuckServerConfig() : null;
         this.blackDuckServicesFactory = blackDuckServicesFactory;
         this.scanMode = scanMode;
         this.waitAtScanLevel = waitAtScanLevel;
+        this.serverDetectProperties = serverDetectProperties;
 
         determineBlackDuckServerVersion(blackDuckConnectivityResult);
     }
@@ -51,7 +55,7 @@ public class BlackDuckRunData {
     }
 
     public static BlackDuckRunData offline() {
-        return new BlackDuckRunData(null, null, null, null, false);
+        return new BlackDuckRunData(null, null, null, null, false, Optional.empty());
     }
 
     public static BlackDuckRunData online(
@@ -59,13 +63,20 @@ public class BlackDuckRunData {
         BlackDuckServicesFactory blackDuckServicesFactory,
         PhoneHomeManager phoneHomeManager,
         BlackDuckConnectivityResult blackDuckConnectivityResult,
-        boolean waitAtScanLevel
+        boolean waitAtScanLevel,
+        Optional<DetectPropertiesSetting> serverDetectProperties
     ) {
-        return new BlackDuckRunData(phoneHomeManager, blackDuckConnectivityResult, blackDuckServicesFactory, scanMode, waitAtScanLevel);
+        return new BlackDuckRunData(phoneHomeManager, blackDuckConnectivityResult, blackDuckServicesFactory, scanMode, waitAtScanLevel, serverDetectProperties);
     }
 
-    public static BlackDuckRunData onlineNoPhoneHome(BlackduckScanMode scanMode, BlackDuckServicesFactory blackDuckServicesFactory, BlackDuckConnectivityResult blackDuckConnectivityResult, boolean waitAtScanLevel) {
-        return new BlackDuckRunData(null, blackDuckConnectivityResult, blackDuckServicesFactory, scanMode, waitAtScanLevel);
+    public static BlackDuckRunData onlineNoPhoneHome(
+        BlackduckScanMode scanMode,
+        BlackDuckServicesFactory blackDuckServicesFactory,
+        BlackDuckConnectivityResult blackDuckConnectivityResult,
+        boolean waitAtScanLevel,
+        Optional<DetectPropertiesSetting> serverDetectProperties
+    ) {
+        return new BlackDuckRunData(null, blackDuckConnectivityResult, blackDuckServicesFactory, scanMode, waitAtScanLevel, serverDetectProperties);
     }
 
     public Boolean isNonPersistent() {
@@ -82,6 +93,10 @@ public class BlackDuckRunData {
 
     public Optional<BlackDuckVersion> getBlackDuckServerVersion() {
         return blackDuckServerVersion;
+    }
+
+    public Optional<DetectPropertiesSetting> getServerDetectProperties() {
+        return serverDetectProperties;
     }
 
     private void determineBlackDuckServerVersion(BlackDuckConnectivityResult blackDuckConnectivityResult) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -81,6 +81,8 @@ import com.blackduck.integration.detect.configuration.enumeration.ExitCodeType;
 import com.blackduck.integration.detect.configuration.enumeration.RapidCompareMode;
 import com.blackduck.integration.detect.lifecycle.OperationException;
 import com.blackduck.integration.detect.lifecycle.autonomous.AutonomousManager;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
+import com.blackduck.integration.detect.workflow.DetectRunId;
 import com.blackduck.integration.detect.lifecycle.run.DetectFontLoaderFactory;
 import com.blackduck.integration.detect.lifecycle.run.data.BlackDuckRunData;
 import com.blackduck.integration.detect.lifecycle.run.data.DockerTargetData;
@@ -253,6 +255,8 @@ public class OperationRunner {
     private final ProjectEventPublisher projectEventPublisher;
     private final DetectExecutableRunner executableRunner;
     private final OperationAuditLog auditLog;
+    private final CorrelatedScanningDecision correlatedScanningDecision;
+    private final DetectRunId detectRunId;
     private static final int[] LIMITED_FIBONACCI_SEQUENCE = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55};
     private static final int MIN_POLLING_INTERVAL_THRESHOLD_IN_SECONDS = 5;
     private static final String DEVELOPER_SCAN_ENDPOINT = ApiDiscovery.DEVELOPER_SCANS_PATH.getPath();
@@ -292,6 +296,8 @@ public class OperationRunner {
         fileFinder = bootSingletons.getFileFinder();
         detectInfo = bootSingletons.getDetectInfo();
         executableRunner = utilitySingletons.getExecutableRunner();
+        correlatedScanningDecision = bootSingletons.getCorrelatedScanningDecision();
+        detectRunId = bootSingletons.getDetectRunId();
 
         OperationSystem operationSystem = utilitySingletons.getOperationSystem();
         codeLocationNameManager = utilitySingletons.getCodeLocationNameManager();
@@ -683,6 +689,7 @@ public class OperationRunner {
     private File createProtobufHeaderFile(String type, NameVersion projectNameVersion, String codeLocationName, File scanFile, ScassScanInitiationResult initResult, File outputDirectory) throws OperationException, IntegrationException {
         try {
             String projectGroupName = calculateProjectGroupOptions().getProjectGroup();
+            String correlationId = getCorrelationIdForScanType("BINARY");
 
             DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
                     UUID.randomUUID().toString(),
@@ -690,7 +697,8 @@ public class OperationRunner {
                     projectNameVersion,
                     projectGroupName,
                     codeLocationName,
-                    scanFile.length());
+                    scanFile.length(),
+                    correlationId);
 
 
             File bdioHeaderFile = detectProtobufBdioHeaderUtil.createProtobufBdioHeader(outputDirectory);
@@ -1082,7 +1090,7 @@ public class OperationRunner {
                 blackDuckRunData.getBlackDuckServicesFactory().getBlackDuckApiClient(),
                 blackDuckRunData.getBlackDuckServicesFactory().createProjectBomService()
             );
-            BlackDuckPostOptions blackDuckPostOptions = detectConfigurationFactory.createBlackDuckPostOptions();
+            BlackDuckPostOptions blackDuckPostOptions = createBlackDuckPostOptions();
             List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = blackDuckPostOptions.getSeveritiesToFailPolicyCheck();
             policyChecker.checkPolicyBySeverity(severitiesToFailPolicyCheck, projectVersionView);
         });
@@ -1095,7 +1103,7 @@ public class OperationRunner {
                 blackDuckRunData.getBlackDuckServicesFactory().getBlackDuckApiClient(),
                 blackDuckRunData.getBlackDuckServicesFactory().createProjectBomService()
             );
-            BlackDuckPostOptions blackDuckPostOptions = detectConfigurationFactory.createBlackDuckPostOptions();
+            BlackDuckPostOptions blackDuckPostOptions = createBlackDuckPostOptions();
             List<String> policyNamesToFailPolicyCheck = blackDuckPostOptions.getPolicyNamesToFailPolicyCheck();
             policyChecker.checkPolicyByName(policyNamesToFailPolicyCheck, projectVersionView);
         });
@@ -1383,7 +1391,7 @@ public class OperationRunner {
 
     public Optional<File> calculateNoticesDirectory() throws OperationException { //TODO Should be a decision in boot
         return auditLog.namedInternal("Decide Notices Report Path", () -> {
-            BlackDuckPostOptions postOptions = detectConfigurationFactory.createBlackDuckPostOptions();
+            BlackDuckPostOptions postOptions = createBlackDuckPostOptions();
             if (postOptions.shouldGenerateNoticesReport()) {
                 return Optional.of(postOptions.getNoticesReportPath().map(Path::toFile)
                     .orElse(directoryManager.getSourceDirectory()));
@@ -1394,7 +1402,7 @@ public class OperationRunner {
 
     public Optional<File> calculateRiskReportPdfFileLocation() throws OperationException { //TODO Should be a decision in boot
         return auditLog.namedInternal("Decide Risk Report Path", () -> {
-            BlackDuckPostOptions postOptions = detectConfigurationFactory.createBlackDuckPostOptions();
+            BlackDuckPostOptions postOptions = createBlackDuckPostOptions();
             if (postOptions.shouldGenerateRiskReportPdf()) {
                 return Optional.of(postOptions.getRiskReportPdfPath().map(Path::toFile)
                     .orElse(directoryManager.getSourceDirectory()));
@@ -1405,7 +1413,7 @@ public class OperationRunner {
 
     public Optional<File> calculateRiskReportJsonFileLocation() throws OperationException { //TODO Should be a decision in boot
         return auditLog.namedInternal("Decide Risk Report Path", () -> {
-            BlackDuckPostOptions postOptions = detectConfigurationFactory.createBlackDuckPostOptions();
+            BlackDuckPostOptions postOptions = createBlackDuckPostOptions();
             if (postOptions.shouldGenerateRiskReportJson()) {
                 return Optional.of(postOptions.getRiskReportJsonPath().map(Path::toFile)
                         .orElse(directoryManager.getSourceDirectory()));
@@ -1479,7 +1487,19 @@ public class OperationRunner {
     }
 
     public BlackDuckPostOptions createBlackDuckPostOptions() {
-        return detectConfigurationFactory.createBlackDuckPostOptions();
+        return detectConfigurationFactory.createBlackDuckPostOptions(correlatedScanningDecision);
+    }
+
+    /**
+     * Gets the correlation ID if correlated scanning is enabled and the scan type is supported.
+     * @param scanType The scan type to check (e.g., "BINARY", "SIGNATURE", "PACKAGE_MANAGER")
+     * @return The correlation ID string if enabled and supported, null otherwise
+     */
+    public String getCorrelationIdForScanType(String scanType) {
+        if (correlatedScanningDecision.isEnabled() && correlatedScanningDecision.isScanTypeSupported(scanType)) {
+            return detectRunId.getCorrelationId();
+        }
+        return null;
     }
 
     public BinaryScanOptions calculateBinaryScanOptions() {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -123,6 +123,7 @@ import com.blackduck.integration.detect.tool.impactanalysis.ImpactAnalysisNaming
 import com.blackduck.integration.detect.tool.impactanalysis.ImpactAnalysisUploadOperation;
 import com.blackduck.integration.detect.tool.impactanalysis.service.ImpactAnalysisBatchOutput;
 import com.blackduck.integration.detect.tool.impactanalysis.service.ImpactAnalysisUploadService;
+import com.blackduck.integration.detect.tool.signaturescanner.BlackDuckSignatureScannerOptions;
 import com.blackduck.integration.detect.tool.signaturescanner.SignatureScanPath;
 import com.blackduck.integration.detect.tool.signaturescanner.SignatureScannerCodeLocationResult;
 import com.blackduck.integration.detect.tool.signaturescanner.SignatureScannerReport;
@@ -1194,10 +1195,11 @@ public class OperationRunner {
             () -> {
                 List<String> exclusions = detectConfigurationFactory.collectSignatureScannerDirectoryExclusions();
                 DetectExcludedDirectoryFilter detectExcludedDirectoryFilter = new DetectExcludedDirectoryFilter(exclusions);
-                return new CalculateScanPathsOperation(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(), directoryManager, fileFinder,
+                BlackDuckSignatureScannerOptions scannerOptions = detectConfigurationFactory.createBlackDuckSignatureScannerOptions(correlatedScanningDecision);
+                return new CalculateScanPathsOperation(scannerOptions, directoryManager, fileFinder,
                     detectExcludedDirectoryFilter::isExcluded
                 )
-                    .determinePathsAndExclusions(projectNameVersion, detectConfigurationFactory.createBlackDuckSignatureScannerOptions().getMaxDepth(), dockerTargetData);
+                    .determinePathsAndExclusions(projectNameVersion, scannerOptions.getMaxDepth(), dockerTargetData);
             }
         );
     }
@@ -1207,12 +1209,12 @@ public class OperationRunner {
         List<SignatureScanPath> scanPaths,
         NameVersion projectNameVersion,
         DockerTargetData dockerTargetData,
-        BlackDuckRunData blackDuckRunData, 
+        BlackDuckRunData blackDuckRunData,
         boolean isScassFallback
     )
         throws OperationException {
         return auditLog.namedPublic("Create Online Signature Scan Batch", "OnlineSigScan",
-            () -> new CreateScanBatchOperation(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(), directoryManager, codeLocationNameManager)
+            () -> new CreateScanBatchOperation(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(correlatedScanningDecision), directoryManager, codeLocationNameManager)
                 .createScanBatchWithBlackDuck(detectRunUuid, projectNameVersion, scanPaths, blackDuckRunData, dockerTargetData, isScassFallback)
         );
     }
@@ -1220,7 +1222,7 @@ public class OperationRunner {
     public ScanBatch createScanBatchOffline(String detectRunUuid, List<SignatureScanPath> scanPaths, NameVersion projectNameVersion, DockerTargetData dockerTargetData)
         throws OperationException {
         return auditLog.namedPublic("Create Offline Signature Scan Batch", "OfflineSigScan",
-            () -> new CreateScanBatchOperation(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(), directoryManager, codeLocationNameManager)
+            () -> new CreateScanBatchOperation(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(correlatedScanningDecision), directoryManager, codeLocationNameManager)
                 .createScanBatchWithoutBlackDuck(detectRunUuid, projectNameVersion, scanPaths, dockerTargetData)
         );
     }
@@ -1232,7 +1234,7 @@ public class OperationRunner {
     public Optional<File> calculateOnlineLocalScannerInstallPath() throws OperationException {
         return auditLog.namedInternal(
             "Calculate Online Local Scanner Path",
-            () -> detectConfigurationFactory.createBlackDuckSignatureScannerOptions().getLocalScannerInstallPath().map(Path::toFile)
+            () -> detectConfigurationFactory.createBlackDuckSignatureScannerOptions(correlatedScanningDecision).getLocalScannerInstallPath().map(Path::toFile)
         );
     }
 
@@ -1242,7 +1244,7 @@ public class OperationRunner {
 
     public ScanBatchRunner createScanBatchRunnerWithBlackDuck(BlackDuckRunData blackDuckRunData, File installDirectory) throws OperationException {
         return auditLog.namedInternal("Create Scan Batch Runner with Black Duck SCA", () -> {
-            ExecutorService executorService = Executors.newFixedThreadPool(detectConfigurationFactory.createBlackDuckSignatureScannerOptions().getParallelProcessors());
+            ExecutorService executorService = Executors.newFixedThreadPool(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(correlatedScanningDecision).getParallelProcessors());
             IntEnvironmentVariables intEnvironmentVariables = IntEnvironmentVariables.includeSystemEnv();
             Optional<BlackDuckVersion> blackDuckVersion = blackDuckRunData.getBlackDuckServerVersion();
 
@@ -1313,7 +1315,7 @@ public class OperationRunner {
 
     public void publishSignatureScanReport(List<SignatureScannerReport> report) throws OperationException {
         auditLog.namedInternal("Publish Signature Scan Report", () -> {
-            Boolean treatSkippedAsFailure = detectConfigurationFactory.createBlackDuckSignatureScannerOptions().getTreatSkippedScansAsSuccess();
+            Boolean treatSkippedAsFailure = detectConfigurationFactory.createBlackDuckSignatureScannerOptions(correlatedScanningDecision).getTreatSkippedScansAsSuccess();
             new PublishSignatureScanReports(exitCodePublisher, statusEventPublisher, treatSkippedAsFailure).publishReports(report);
         });
     }
@@ -1483,7 +1485,7 @@ public class OperationRunner {
     }
 
     private ExecutorService createExecutorServiceForScanner() {
-        return Executors.newFixedThreadPool(detectConfigurationFactory.createBlackDuckSignatureScannerOptions().getParallelProcessors());
+        return Executors.newFixedThreadPool(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(correlatedScanningDecision).getParallelProcessors());
     }
 
     public BlackDuckPostOptions createBlackDuckPostOptions() {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -689,7 +689,7 @@ public class OperationRunner {
     private File createProtobufHeaderFile(String type, NameVersion projectNameVersion, String codeLocationName, File scanFile, ScassScanInitiationResult initResult, File outputDirectory) throws OperationException, IntegrationException {
         try {
             String projectGroupName = calculateProjectGroupOptions().getProjectGroup();
-            String correlationId = getCorrelationIdForScanType("BINARY");
+            String correlationId = getCorrelationIdForScanType(type);
 
             DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
                     UUID.randomUUID().toString(),
@@ -1497,6 +1497,18 @@ public class OperationRunner {
      */
     public String getCorrelationIdForScanType(String scanType) {
         if (correlatedScanningDecision.isEnabled() && correlatedScanningDecision.isScanTypeSupported(scanType)) {
+            return detectRunId.getCorrelationId();
+        }
+        return null;
+    }
+
+    /**
+     * Gets the correlation ID if correlated scanning is enabled (regardless of specific scan type).
+     * Use this for operations that aggregate data across all supported scan types, like uploading scan counts.
+     * @return The correlation ID string if correlated scanning is enabled, null otherwise
+     */
+    public String getCorrelationIdIfEnabled() {
+        if (correlatedScanningDecision.isEnabled()) {
             return detectRunId.getCorrelationId();
         }
         return null;

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/singleton/BootSingletons.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/singleton/BootSingletons.java
@@ -6,6 +6,7 @@ import com.blackduck.integration.configuration.config.PropertyConfiguration;
 import com.blackduck.integration.detect.configuration.DetectConfigurationFactory;
 import com.blackduck.integration.detect.configuration.DetectInfo;
 import com.blackduck.integration.detect.configuration.DetectableOptionFactory;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 import com.blackduck.integration.detect.lifecycle.autonomous.AutonomousManager;
 import com.blackduck.integration.detect.lifecycle.run.data.ProductRunData;
 import com.blackduck.integration.detect.tool.cache.InstalledToolLocator;
@@ -39,6 +40,7 @@ public class BootSingletons {
     private final InstalledToolManager installedToolManager;
     private final InstalledToolLocator installedToolLocator;
     private final AutonomousManager autonomousManager;
+    private final CorrelatedScanningDecision correlatedScanningDecision;
 
     public BootSingletons(
         ProductRunData productRunData,
@@ -55,7 +57,8 @@ public class BootSingletons {
         Configuration configuration,
         InstalledToolManager installedToolManager,
         InstalledToolLocator installedToolLocator,
-        AutonomousManager autonomousManager
+        AutonomousManager autonomousManager,
+        CorrelatedScanningDecision correlatedScanningDecision
     ) {
         this.productRunData = productRunData;
         this.detectRunId = detectRunId;
@@ -72,6 +75,7 @@ public class BootSingletons {
         this.installedToolManager = installedToolManager;
         this.installedToolLocator = installedToolLocator;
         this.autonomousManager = autonomousManager;
+        this.correlatedScanningDecision = correlatedScanningDecision;
     }
 
     public ProductRunData getProductRunData() {
@@ -131,4 +135,6 @@ public class BootSingletons {
     }
 
     public AutonomousManager getAutonomousManager() { return autonomousManager; }
+
+    public CorrelatedScanningDecision getCorrelatedScanningDecision() { return correlatedScanningDecision; }
 }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -126,7 +126,7 @@ public class CommonScanStepRunner {
     
     private UUID createFallbackScanId(OperationRunner operationRunner, String scanType, NameVersion projectNameVersion, String codeLocationName, long fileLength, BlackDuckRunData blackDuckRunData) throws IntegrationException {
         String projectGroupName = operationRunner.calculateProjectGroupOptions().getProjectGroup();
-        String correlationId = operationRunner.getCorrelationIdForScanType("BINARY");
+        String correlationId = operationRunner.getCorrelationIdForScanType(scanType);
 
         DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
             UUID.randomUUID().toString(),

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -126,6 +126,7 @@ public class CommonScanStepRunner {
     
     private UUID createFallbackScanId(OperationRunner operationRunner, String scanType, NameVersion projectNameVersion, String codeLocationName, long fileLength, BlackDuckRunData blackDuckRunData) throws IntegrationException {
         String projectGroupName = operationRunner.calculateProjectGroupOptions().getProjectGroup();
+        String correlationId = operationRunner.getCorrelationIdForScanType("BINARY");
 
         DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
             UUID.randomUUID().toString(),
@@ -133,7 +134,8 @@ public class CommonScanStepRunner {
             projectNameVersion,
             projectGroupName,
             codeLocationName,
-            fileLength);
+            fileLength,
+            correlationId);
         
         File bdioHeaderFile;
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -74,14 +74,19 @@ public class IntelligentModeStepRunner {
         this.correlatedScanningDecision = correlatedScanningDecision;
     }
 
-    private String getCorrelationId() {
+    private String getCorrelationIdForSignatureScan() {
         return operationRunner.getCorrelationIdForScanType("SIGNATURE");
+    }
+
+    private String getCorrelationIdForUpload() {
+        // Upload counts for all supported scan types, so check if correlated scanning is enabled at all
+        return operationRunner.getCorrelationIdIfEnabled();
     }
 
     public void runOffline(NameVersion projectNameVersion, DockerTargetData dockerTargetData, BdioResult bdio) throws OperationException {
         stepHelper.runToolIfIncluded(DetectTool.SIGNATURE_SCAN, "Signature Scanner", () -> { //Internal: Sig scan publishes its own status.
             SignatureScanStepRunner signatureScanStepRunner = new SignatureScanStepRunner(operationRunner, null);
-            signatureScanStepRunner.runSignatureScannerOffline(getCorrelationId(), projectNameVersion, dockerTargetData);
+            signatureScanStepRunner.runSignatureScannerOffline(getCorrelationIdForSignatureScan(), projectNameVersion, dockerTargetData);
         });
         stepHelper.runToolIfIncludedWithCallbacks(
             DetectTool.IMPACT_ANALYSIS,
@@ -134,7 +139,7 @@ public class IntelligentModeStepRunner {
         stepHelper.runToolIfIncluded(DetectTool.SIGNATURE_SCAN, "Signature Scanner", () -> {
             SignatureScanStepRunner signatureScanStepRunner = new SignatureScanStepRunner(operationRunner, blackDuckRunData);
             SignatureScannerCodeLocationResult signatureScannerCodeLocationResult = signatureScanStepRunner.runSignatureScannerOnline(
-                getCorrelationId(),
+                getCorrelationIdForSignatureScan(),
                 projectNameVersion,
                 dockerTargetData,
                 scanIdsToWaitFor,
@@ -167,7 +172,8 @@ public class IntelligentModeStepRunner {
 
         stepHelper.runToolIfIncluded(DetectTool.IAC_SCAN, "IaC Scanner", () -> {
             IacScanStepRunner iacScanStepRunner = new IacScanStepRunner(operationRunner);
-            IacScanCodeLocationData iacScanCodeLocationData = iacScanStepRunner.runIacScanOnline(getCorrelationId(), projectNameVersion, blackDuckRunData);
+            // IAC is not a supported correlated scan type, so pass null for correlation ID
+            IacScanCodeLocationData iacScanCodeLocationData = iacScanStepRunner.runIacScanOnline(null, projectNameVersion, blackDuckRunData);
             codeLocationAccumulator.addNonWaitableCodeLocation(iacScanCodeLocationData.getCodeLocationNames());
             mustWaitAtBomSummaryLevel.set(true);
         });
@@ -319,7 +325,7 @@ public class IntelligentModeStepRunner {
     }
     
     public void uploadCorrelatedScanCounts(BlackDuckRunData blackDuckRunData, CodeLocationAccumulator codeLocationAccumulator) throws OperationException {
-        String correlationId = getCorrelationId();
+        String correlationId = getCorrelationIdForUpload();
         logger.debug("Uploading correlated scan counts to Black Duck SCA (correlation ID: {})", correlationId);
         ScanCountsPayload scanCountsPayload = scanCountsPayloadCreator.createPayloadFromCountsByTool(
             codeLocationAccumulator.getWaitableCodeLocations(),

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -22,6 +22,7 @@ import com.blackduck.integration.blackduck.service.BlackDuckServicesFactory;
 import com.blackduck.integration.blackduck.service.model.ProjectVersionWrapper;
 import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
 import com.blackduck.integration.detect.lifecycle.OperationException;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 import com.blackduck.integration.detect.lifecycle.run.data.BlackDuckRunData;
 import com.blackduck.integration.detect.lifecycle.run.data.DockerTargetData;
 import com.blackduck.integration.detect.lifecycle.run.operation.OperationRunner;
@@ -63,20 +64,24 @@ public class IntelligentModeStepRunner {
     private final StepHelper stepHelper;
     private final Gson gson;
     private final ScanCountsPayloadCreator scanCountsPayloadCreator;
-    private final String detectRunUuid;
+    private final CorrelatedScanningDecision correlatedScanningDecision;
 
-    public IntelligentModeStepRunner(OperationRunner operationRunner, StepHelper stepHelper, Gson gson, ScanCountsPayloadCreator scanCountsPayloadCreator, String detectRunUuid) {
+    public IntelligentModeStepRunner(OperationRunner operationRunner, StepHelper stepHelper, Gson gson, ScanCountsPayloadCreator scanCountsPayloadCreator, CorrelatedScanningDecision correlatedScanningDecision) {
         this.operationRunner = operationRunner;
         this.stepHelper = stepHelper;
         this.gson = gson;
         this.scanCountsPayloadCreator = scanCountsPayloadCreator;
-        this.detectRunUuid = detectRunUuid;
+        this.correlatedScanningDecision = correlatedScanningDecision;
+    }
+
+    private String getCorrelationId() {
+        return operationRunner.getCorrelationIdForScanType("SIGNATURE");
     }
 
     public void runOffline(NameVersion projectNameVersion, DockerTargetData dockerTargetData, BdioResult bdio) throws OperationException {
         stepHelper.runToolIfIncluded(DetectTool.SIGNATURE_SCAN, "Signature Scanner", () -> { //Internal: Sig scan publishes its own status.
             SignatureScanStepRunner signatureScanStepRunner = new SignatureScanStepRunner(operationRunner, null);
-            signatureScanStepRunner.runSignatureScannerOffline(detectRunUuid, projectNameVersion, dockerTargetData);
+            signatureScanStepRunner.runSignatureScannerOffline(getCorrelationId(), projectNameVersion, dockerTargetData);
         });
         stepHelper.runToolIfIncludedWithCallbacks(
             DetectTool.IMPACT_ANALYSIS,
@@ -129,7 +134,7 @@ public class IntelligentModeStepRunner {
         stepHelper.runToolIfIncluded(DetectTool.SIGNATURE_SCAN, "Signature Scanner", () -> {
             SignatureScanStepRunner signatureScanStepRunner = new SignatureScanStepRunner(operationRunner, blackDuckRunData);
             SignatureScannerCodeLocationResult signatureScannerCodeLocationResult = signatureScanStepRunner.runSignatureScannerOnline(
-                detectRunUuid,
+                getCorrelationId(),
                 projectNameVersion,
                 dockerTargetData,
                 scanIdsToWaitFor,
@@ -162,14 +167,14 @@ public class IntelligentModeStepRunner {
 
         stepHelper.runToolIfIncluded(DetectTool.IAC_SCAN, "IaC Scanner", () -> {
             IacScanStepRunner iacScanStepRunner = new IacScanStepRunner(operationRunner);
-            IacScanCodeLocationData iacScanCodeLocationData = iacScanStepRunner.runIacScanOnline(detectRunUuid, projectNameVersion, blackDuckRunData);
+            IacScanCodeLocationData iacScanCodeLocationData = iacScanStepRunner.runIacScanOnline(getCorrelationId(), projectNameVersion, blackDuckRunData);
             codeLocationAccumulator.addNonWaitableCodeLocation(iacScanCodeLocationData.getCodeLocationNames());
             mustWaitAtBomSummaryLevel.set(true);
         });
 
-        if (operationRunner.createBlackDuckPostOptions().isCorrelatedScanningEnabled()) {
+        if (correlatedScanningDecision.isEnabled()) {
             stepHelper.runAsGroup("Upload Correlated Scan Counts", OperationType.INTERNAL, () -> {
-                uploadCorrelatedScanCounts(blackDuckRunData, codeLocationAccumulator, detectRunUuid);
+                uploadCorrelatedScanCounts(blackDuckRunData, codeLocationAccumulator);
             });
         }
         operationRunner.attemptToGenerateComponentLocationAnalysisIfEnabled();
@@ -313,12 +318,17 @@ public class IntelligentModeStepRunner {
         }
     }
     
-    public void uploadCorrelatedScanCounts(BlackDuckRunData blackDuckRunData, CodeLocationAccumulator codeLocationAccumulator, String detectRunUuid) throws OperationException {
-        logger.debug("Uploading correlated scan counts to Black Duck SCA (correlation ID: {})", detectRunUuid);
-        ScanCountsPayload scanCountsPayload = scanCountsPayloadCreator.create(codeLocationAccumulator.getWaitableCodeLocations(), codeLocationAccumulator.getAdditionalCountsByTool());
-        
+    public void uploadCorrelatedScanCounts(BlackDuckRunData blackDuckRunData, CodeLocationAccumulator codeLocationAccumulator) throws OperationException {
+        String correlationId = getCorrelationId();
+        logger.debug("Uploading correlated scan counts to Black Duck SCA (correlation ID: {})", correlationId);
+        ScanCountsPayload scanCountsPayload = scanCountsPayloadCreator.createPayloadFromCountsByTool(
+            codeLocationAccumulator.getWaitableCodeLocations(),
+            codeLocationAccumulator.getAdditionalCountsByTool(),
+            correlatedScanningDecision.getSupportedScanTypes()
+        );
+
         if (scanCountsPayload.isValid()) {
-            operationRunner.uploadCorrelatedScanCounts(blackDuckRunData, detectRunUuid, scanCountsPayload);
+            operationRunner.uploadCorrelatedScanCounts(blackDuckRunData, correlationId, scanCountsPayload);
         } else {
             logger.debug("Upload skipped, there was no correlation data to send.");
         }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/container/PreScassContainerScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/container/PreScassContainerScanStepRunner.java
@@ -71,7 +71,7 @@ public class PreScassContainerScanStepRunner extends AbstractContainerScanStepRu
     }
 
     private UUID initiateScan() throws IOException, IntegrationException, OperationException {
-        String correlationId = operationRunner.getCorrelationIdForScanType("BINARY");
+        String correlationId = operationRunner.getCorrelationIdForScanType(SCAN_TYPE);
 
         DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
             UUID.randomUUID().toString(),

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/container/PreScassContainerScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/container/PreScassContainerScanStepRunner.java
@@ -71,13 +71,16 @@ public class PreScassContainerScanStepRunner extends AbstractContainerScanStepRu
     }
 
     private UUID initiateScan() throws IOException, IntegrationException, OperationException {
+        String correlationId = operationRunner.getCorrelationIdForScanType("BINARY");
+
         DetectProtobufBdioHeaderUtil detectProtobufBdioHeaderUtil = new DetectProtobufBdioHeaderUtil(
             UUID.randomUUID().toString(),
             SCAN_TYPE,
             projectNameVersion,
             projectGroupName,
             getCodeLocationName(),
-            containerImageSizeInBytes);
+            containerImageSizeInBytes,
+            correlationId);
         File bdioHeaderFile = detectProtobufBdioHeaderUtil.createProtobufBdioHeader(containerRunDirectory);
         String operationName = "Upload Container Scan BDIO Header to Initiate Scan";
         UUID scanId = operationRunner.uploadBdioHeaderToInitiateScan(blackDuckRunData, bdioHeaderFile, operationName);

--- a/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/BlackDuckSignatureScannerOptions.java
@@ -10,6 +10,7 @@ import com.blackduck.integration.blackduck.codelocation.signaturescanner.command
 import com.blackduck.integration.blackduck.codelocation.signaturescanner.command.ReducedPersistence;
 import com.blackduck.integration.blackduck.codelocation.signaturescanner.command.SnippetMatching;
 import com.blackduck.integration.detect.configuration.enumeration.RapidCompareMode;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 
 public class BlackDuckSignatureScannerOptions {
     private final List<Path> signatureScannerPaths;
@@ -39,7 +40,7 @@ public class BlackDuckSignatureScannerOptions {
     private final Boolean followSymLinks;
     private final Boolean treatSkippedScansAsSuccess;
     private final Boolean isStateless;
-    private final Boolean correlatedScanningEnabled;
+    private final CorrelatedScanningDecision correlatedScanningDecision;
     private final RapidCompareMode bomCompareMode;
     private final Boolean csvArchive;
 
@@ -59,9 +60,9 @@ public class BlackDuckSignatureScannerOptions {
         Boolean copyrightSearch,
         Boolean followSymLinks,
         Boolean treatSkippedScansAsSuccess,
-        Boolean isStateless, 
+        Boolean isStateless,
         ReducedPersistence reducedPersistence,
-        Boolean correlatedScanningEnabled,
+        CorrelatedScanningDecision correlatedScanningDecision,
         RapidCompareMode bomCompareMode,
         Boolean csvArchive
     ) {
@@ -83,7 +84,7 @@ public class BlackDuckSignatureScannerOptions {
         this.treatSkippedScansAsSuccess = treatSkippedScansAsSuccess;
         this.isStateless = isStateless;
         this.reducedPersistence = reducedPersistence;
-        this.correlatedScanningEnabled = correlatedScanningEnabled;
+        this.correlatedScanningDecision = correlatedScanningDecision;
         this.bomCompareMode = bomCompareMode;
         this.csvArchive = csvArchive;
     }
@@ -156,8 +157,8 @@ public class BlackDuckSignatureScannerOptions {
         return Optional.ofNullable(reducedPersistence);
     }
 
-    public Boolean isCorrelatedScanningEnabled() {
-        return correlatedScanningEnabled;
+    public CorrelatedScanningDecision getCorrelatedScanningDecision() {
+        return correlatedScanningDecision;
     }
     
     public RapidCompareMode getBomCompareMode() {

--- a/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
@@ -107,7 +107,9 @@ public class CreateScanBatchOperation {
 
         // Someday the integrated matching enabled option will (we think) go away, and we'll always provide
         // detectRunUuid as correlationId, but for now it's optional.
-        if (signatureScannerOptions.isCorrelatedScanningEnabled()) {
+        // Use the decision object to check if signature scans are supported for correlated scanning
+        if (signatureScannerOptions.getCorrelatedScanningDecision().isEnabled()
+                && signatureScannerOptions.getCorrelatedScanningDecision().isScanTypeSupported("SIGNATURE")) {
             scanJobBuilder.correlationId(detectRunUuid);
         }
 
@@ -173,7 +175,8 @@ public class CreateScanBatchOperation {
 
     private boolean conditionalCorrelationFilter(boolean toCheck, String toWarn) {
         if (toCheck) {
-            if (signatureScannerOptions.isCorrelatedScanningEnabled()) {
+            if (signatureScannerOptions.getCorrelatedScanningDecision().isEnabled()
+                    && signatureScannerOptions.getCorrelatedScanningDecision().isScanTypeSupported("SIGNATURE")) {
                 logger.warn("{} is not compatible with Integrated Matching feature and will be skipped. Please re-run {} with integrated matching disabled.", toWarn, toWarn.toLowerCase());
             } else {
                 return true;

--- a/src/main/java/com/blackduck/integration/detect/util/bdio/protobuf/DetectProtobufBdioHeaderUtil.java
+++ b/src/main/java/com/blackduck/integration/detect/util/bdio/protobuf/DetectProtobufBdioHeaderUtil.java
@@ -39,7 +39,8 @@ public class DetectProtobufBdioHeaderUtil {
         NameVersion projectNameVersion,
         String projectGroupName,
         String codeLocationName,
-        Long fileSystemSizeInBytes
+        Long fileSystemSizeInBytes,
+        String correlationId
     ) {
         this.scanId = scanId;
         this.scanType = scanType;
@@ -52,7 +53,7 @@ public class DetectProtobufBdioHeaderUtil {
         this.sourceRepository = null;
         this.sourceBranch = null;
         this.projectGroupName = projectGroupName;
-        this.correlationId = null;
+        this.correlationId = correlationId != null ? UUID.fromString(correlationId) : null;
         this.matchConfidenceThreshold = 1L;
         this.baseDir = "/";
         this.withStringSearch = false;

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/BlackDuckPostOptions.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/BlackDuckPostOptions.java
@@ -8,6 +8,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.jetbrains.annotations.Nullable;
 
 import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 
 public class BlackDuckPostOptions {
     private final boolean waitForResults;
@@ -20,7 +21,7 @@ public class BlackDuckPostOptions {
     private final @Nullable Path noticesReportPath;
     private final List<PolicyRuleSeverityType> severitiesToFailPolicyCheck;
     private final List<String> policyNamesToFailPolicyCheck;
-    private final boolean correlatedScanningEnabled;
+    private final CorrelatedScanningDecision correlatedScanningDecision;
 
     public BlackDuckPostOptions(
         boolean waitForResults,
@@ -30,7 +31,7 @@ public class BlackDuckPostOptions {
         @Nullable Path noticesReportPath,
         List<PolicyRuleSeverityType> severitiesToFailPolicyCheck,
         List<String> policyNamesToFailPolicyCheck,
-        boolean correlatedScanningEnabled,
+        CorrelatedScanningDecision correlatedScanningDecision,
         boolean generateRiskReportJson,
         @Nullable Path riskReportJsonPath
     ) {
@@ -41,7 +42,7 @@ public class BlackDuckPostOptions {
         this.noticesReportPath = noticesReportPath;
         this.severitiesToFailPolicyCheck = severitiesToFailPolicyCheck;
         this.policyNamesToFailPolicyCheck = policyNamesToFailPolicyCheck;
-        this.correlatedScanningEnabled = correlatedScanningEnabled;
+        this.correlatedScanningDecision = correlatedScanningDecision;
         this.generateRiskReportJson = generateRiskReportJson;
         this.riskReportJsonPath = riskReportJsonPath;
     }
@@ -99,6 +100,10 @@ public class BlackDuckPostOptions {
     }
 
     public boolean isCorrelatedScanningEnabled() {
-        return correlatedScanningEnabled;
+        return correlatedScanningDecision.isEnabled();
+    }
+
+    public CorrelatedScanningDecision getCorrelatedScanningDecision() {
+        return correlatedScanningDecision;
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/ScanCountsPayloadCreator.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/ScanCountsPayloadCreator.java
@@ -14,11 +14,6 @@ import com.blackduck.integration.detect.workflow.blackduck.integratedmatching.mo
 
 public class ScanCountsPayloadCreator {
 
-    public ScanCountsPayload create(List<WaitableCodeLocationData> createdCodelocations, Map<DetectTool, Integer> additionalCounts) {
-        Map<DetectTool, Integer> countsByTool = collectCountsByTool(createdCodelocations, additionalCounts);
-        return createPayloadFromCountsByTool(countsByTool);
-    }
-
     @NotNull
     public ScanCountsPayload createPayloadFromCountsByTool(
         List<WaitableCodeLocationData> createdCodelocations,
@@ -27,17 +22,6 @@ public class ScanCountsPayloadCreator {
     ) {
         Map<DetectTool, Integer> countsByTool = collectCountsByTool(createdCodelocations, additionalCounts);
         return createPayloadFromCountsByTool(countsByTool, supportedScanTypes);
-    }
-
-    @NotNull
-    private ScanCountsPayload createPayloadFromCountsByTool(final Map<DetectTool, Integer> countsByTool) {
-        int packageManagerScanCount = countsByTool.getOrDefault(DetectTool.DETECTOR, 0)
-            + countsByTool.getOrDefault(DetectTool.BAZEL, 0)
-            + countsByTool.getOrDefault(DetectTool.DOCKER, 0);
-        int signatureScanCount = countsByTool.getOrDefault(DetectTool.SIGNATURE_SCAN, 0);
-        int binaryScanCount = countsByTool.getOrDefault(DetectTool.BINARY_SCAN, 0);
-        ScanCounts scanCounts = new ScanCounts(packageManagerScanCount, signatureScanCount, binaryScanCount);
-        return new ScanCountsPayload(scanCounts);
     }
 
     @NotNull

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/ScanCountsPayloadCreator.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/ScanCountsPayloadCreator.java
@@ -3,6 +3,7 @@ package com.blackduck.integration.detect.workflow.blackduck.integratedmatching;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -19,12 +20,46 @@ public class ScanCountsPayloadCreator {
     }
 
     @NotNull
+    public ScanCountsPayload createPayloadFromCountsByTool(
+        List<WaitableCodeLocationData> createdCodelocations,
+        Map<DetectTool, Integer> additionalCounts,
+        Set<String> supportedScanTypes
+    ) {
+        Map<DetectTool, Integer> countsByTool = collectCountsByTool(createdCodelocations, additionalCounts);
+        return createPayloadFromCountsByTool(countsByTool, supportedScanTypes);
+    }
+
+    @NotNull
     private ScanCountsPayload createPayloadFromCountsByTool(final Map<DetectTool, Integer> countsByTool) {
         int packageManagerScanCount = countsByTool.getOrDefault(DetectTool.DETECTOR, 0)
             + countsByTool.getOrDefault(DetectTool.BAZEL, 0)
             + countsByTool.getOrDefault(DetectTool.DOCKER, 0);
         int signatureScanCount = countsByTool.getOrDefault(DetectTool.SIGNATURE_SCAN, 0);
         int binaryScanCount = countsByTool.getOrDefault(DetectTool.BINARY_SCAN, 0);
+        ScanCounts scanCounts = new ScanCounts(packageManagerScanCount, signatureScanCount, binaryScanCount);
+        return new ScanCountsPayload(scanCounts);
+    }
+
+    @NotNull
+    private ScanCountsPayload createPayloadFromCountsByTool(final Map<DetectTool, Integer> countsByTool, Set<String> supportedScanTypes) {
+        // Filter counts based on supported scan types
+        int packageManagerScanCount = 0;
+        if (supportedScanTypes.contains("PACKAGE_MANAGER")) {
+            packageManagerScanCount = countsByTool.getOrDefault(DetectTool.DETECTOR, 0)
+                + countsByTool.getOrDefault(DetectTool.BAZEL, 0)
+                + countsByTool.getOrDefault(DetectTool.DOCKER, 0);
+        }
+
+        int signatureScanCount = 0;
+        if (supportedScanTypes.contains("SIGNATURE")) {
+            signatureScanCount = countsByTool.getOrDefault(DetectTool.SIGNATURE_SCAN, 0);
+        }
+
+        int binaryScanCount = 0;
+        if (supportedScanTypes.contains("BINARY")) {
+            binaryScanCount = countsByTool.getOrDefault(DetectTool.BINARY_SCAN, 0);
+        }
+
         ScanCounts scanCounts = new ScanCounts(packageManagerScanCount, signatureScanCount, binaryScanCount);
         return new ScanCountsPayload(scanCounts);
     }

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/settings/DetectPropertiesService.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/settings/DetectPropertiesService.java
@@ -1,0 +1,31 @@
+package com.blackduck.integration.detect.workflow.blackduck.settings;
+
+import java.io.IOException;
+
+import com.blackduck.integration.blackduck.api.core.BlackDuckPath;
+import com.blackduck.integration.blackduck.api.core.response.UrlSingleResponse;
+import com.blackduck.integration.blackduck.api.generated.discovery.ApiDiscovery;
+import com.blackduck.integration.blackduck.http.BlackDuckRequestBuilder;
+import com.blackduck.integration.blackduck.service.BlackDuckApiClient;
+import com.blackduck.integration.blackduck.service.request.BlackDuckSingleRequest;
+import com.blackduck.integration.exception.IntegrationException;
+
+public class DetectPropertiesService {
+    private static final BlackDuckPath<DetectPropertiesSetting> DETECT_PROPERTIES_PATH = new BlackDuckPath<>(
+        "/api/settings/detect/properties",
+        DetectPropertiesSetting.class,
+        false
+    );
+    private static final String MIME_TYPE = "application/vnd.blackducksoftware.detect-setting-1+json";
+
+    public DetectPropertiesSetting fetchDetectProperties(ApiDiscovery apiDiscovery, BlackDuckApiClient blackDuckApiClient) throws IntegrationException, IOException {
+        UrlSingleResponse<DetectPropertiesSetting> urlResponse = apiDiscovery.metaSingleResponse(DETECT_PROPERTIES_PATH);
+
+        BlackDuckSingleRequest<DetectPropertiesSetting> spec = new BlackDuckRequestBuilder()
+            .commonGet()
+            .acceptMimeType(MIME_TYPE)
+            .buildBlackDuckRequest(urlResponse);
+
+        return blackDuckApiClient.getResponse(spec);
+    }
+}

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/settings/DetectPropertiesService.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/settings/DetectPropertiesService.java
@@ -16,7 +16,8 @@ public class DetectPropertiesService {
         DetectPropertiesSetting.class,
         false
     );
-    private static final String MIME_TYPE = "application/vnd.blackducksoftware.detect-setting-1+json";
+    private static final String MIME_TYPE = "application/json";
+            //"application/vnd.blackducksoftware.detect-setting-1+json";
 
     public DetectPropertiesSetting fetchDetectProperties(ApiDiscovery apiDiscovery, BlackDuckApiClient blackDuckApiClient) throws IntegrationException, IOException {
         UrlSingleResponse<DetectPropertiesSetting> urlResponse = apiDiscovery.metaSingleResponse(DETECT_PROPERTIES_PATH);

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/settings/DetectPropertiesService.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/settings/DetectPropertiesService.java
@@ -16,8 +16,7 @@ public class DetectPropertiesService {
         DetectPropertiesSetting.class,
         false
     );
-    private static final String MIME_TYPE = "application/json";
-            //"application/vnd.blackducksoftware.detect-setting-1+json";
+    private static final String MIME_TYPE = "application/vnd.blackducksoftware.admin-6+json";
 
     public DetectPropertiesSetting fetchDetectProperties(ApiDiscovery apiDiscovery, BlackDuckApiClient blackDuckApiClient) throws IntegrationException, IOException {
         UrlSingleResponse<DetectPropertiesSetting> urlResponse = apiDiscovery.metaSingleResponse(DETECT_PROPERTIES_PATH);

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/settings/DetectPropertiesSetting.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/settings/DetectPropertiesSetting.java
@@ -1,0 +1,23 @@
+package com.blackduck.integration.detect.workflow.blackduck.settings;
+
+import java.util.List;
+
+import com.blackduck.integration.blackduck.api.core.BlackDuckResponse;
+
+public class DetectPropertiesSetting extends BlackDuckResponse {
+    private final boolean isCorrelatedScanningEnabled;
+    private final List<String> correlatedScanningScanTypes;
+
+    public DetectPropertiesSetting(boolean isCorrelatedScanningEnabled, List<String> correlatedScanningScanTypes) {
+        this.isCorrelatedScanningEnabled = isCorrelatedScanningEnabled;
+        this.correlatedScanningScanTypes = correlatedScanningScanTypes;
+    }
+
+    public boolean isCorrelatedScanningEnabled() {
+        return isCorrelatedScanningEnabled;
+    }
+
+    public List<String> getCorrelatedScanningScanTypes() {
+        return correlatedScanningScanTypes;
+    }
+}

--- a/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticReportHandler.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticReportHandler.java
@@ -151,6 +151,22 @@ public class DiagnosticReportHandler {
         }
     }
 
+    public void appendBlackDuckServerProperties(String scanTypesValue) {
+        try {
+            ReportWriter profileWriter = getReportWriter(ReportTypes.CONFIGURATION);
+            profileWriter.writeSeparator();
+            profileWriter.writeLine("Black Duck SCA Global Properties");
+            profileWriter.writeSeparator();
+            profileWriter.writeLine("--property = value [notes]");
+            profileWriter.writeLine("------------------------------------------------------------");
+            profileWriter.writeLine("detect.blackduck.correlated.scanning.enabled = " + scanTypesValue + " [SCA]");
+            profileWriter.writeLine("------------------------------------------------------------");
+            profileWriter.writeLine("");
+        } catch (Exception e) {
+            logger.error("Failed to write Black Duck server properties to configuration report.", e);
+        }
+    }
+
     private void createReports() {
         for (ReportTypes reportType : ReportTypes.values()) {
             try {

--- a/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticReportHandler.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticReportHandler.java
@@ -151,7 +151,7 @@ public class DiagnosticReportHandler {
         }
     }
 
-    public void appendBlackDuckServerProperties(String scanTypesValue) {
+    public void appendBlackDuckServerProperties(Map<String, String> serverProperties) {
         try {
             ReportWriter profileWriter = getReportWriter(ReportTypes.CONFIGURATION);
             profileWriter.writeSeparator();
@@ -159,7 +159,7 @@ public class DiagnosticReportHandler {
             profileWriter.writeSeparator();
             profileWriter.writeLine("--property = value [notes]");
             profileWriter.writeLine("------------------------------------------------------------");
-            profileWriter.writeLine("detect.blackduck.correlated.scanning.enabled = " + scanTypesValue + " [SCA]");
+            serverProperties.forEach((key, value) -> profileWriter.writeLine(key + " = " + value + " [SCA]"));
             profileWriter.writeLine("------------------------------------------------------------");
             profileWriter.writeLine("");
         } catch (Exception e) {

--- a/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
@@ -127,6 +127,12 @@ public class DiagnosticSystem {
         logger.info("Diagnostic mode has completed.");
     }
 
+    public void appendBlackDuckServerProperties(String scanTypesValue) {
+        if (diagnosticReportHandler != null) {
+            diagnosticReportHandler.appendBlackDuckServerProperties(scanTypesValue);
+        }
+    }
+
     private boolean createZip() {
         List<File> directoriesToCompress = new ArrayList<>();
         directoriesToCompress.add(directoryManager.getRunHomeDirectory());

--- a/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
@@ -127,9 +127,9 @@ public class DiagnosticSystem {
         logger.info("Diagnostic mode has completed.");
     }
 
-    public void appendBlackDuckServerProperties(String scanTypesValue) {
+    public void appendBlackDuckServerProperties(Map<String, String> serverProperties) {
         if (diagnosticReportHandler != null) {
-            diagnosticReportHandler.appendBlackDuckServerProperties(scanTypesValue);
+            diagnosticReportHandler.appendBlackDuckServerProperties(serverProperties);
         }
     }
 

--- a/src/main/java/com/blackduck/integration/detect/workflow/event/Event.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/event/Event.java
@@ -2,6 +2,7 @@ package com.blackduck.integration.detect.workflow.event;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Map;
 import java.util.SortedMap;
 
 import com.blackduck.integration.detect.lifecycle.shutdown.ExitCodeRequest;
@@ -35,4 +36,5 @@ public class Event {
     public static final EventType<UnrecognizedPaths> UnrecognizedPaths = new EventType<>(UnrecognizedPaths.class);
     public static final EventType<SortedMap<String, String>> RawMaskedPropertyValuesCollected = new EventType(SortedMap.class);
     public static final EventType<Collection<Operation>> DetectOperationsComplete = new EventType(Collection.class);
+    public static final EventType<Map<String, String>> BlackDuckServerPropertiesCollected = new EventType(Map.class);
 }

--- a/src/main/java/com/blackduck/integration/detect/workflow/report/output/FormattedOutput.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/report/output/FormattedOutput.java
@@ -51,5 +51,8 @@ public class FormattedOutput {
     @SerializedName("transitiveUpgradeGuidance")
     public List<FormattedResultOutput> transitiveGuidance;
 
+    @SerializedName("blackDuckServerProperties")
+    public Map<String, String> blackDuckServerProperties;
+
 }
 

--- a/src/main/java/com/blackduck/integration/detect/workflow/report/output/FormattedOutputManager.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/report/output/FormattedOutputManager.java
@@ -49,6 +49,7 @@ public class FormattedOutputManager {
     private DetectorToolResult detectorToolResult = null;
     private NameVersion projectNameVersion = null;
     private SortedMap<String, String> rawMaskedPropertyValues = null;
+    private Map<String, String> blackDuckServerProperties = null;
 
     public FormattedOutputManager(EventSystem eventSystem) {
         eventSystem.registerListener(Event.DetectorsComplete, result -> detectorToolResult = result);
@@ -60,6 +61,7 @@ public class FormattedOutputManager {
         eventSystem.registerListener(Event.ProjectNameVersionChosen, nameVersion -> projectNameVersion = nameVersion);
         eventSystem.registerListener(Event.RawMaskedPropertyValuesCollected, keyValueMap -> rawMaskedPropertyValues = keyValueMap);
         eventSystem.registerListener(Event.DetectOperationsComplete, detectOperations::addAll);
+        eventSystem.registerListener(Event.BlackDuckServerPropertiesCollected, props -> blackDuckServerProperties = props);
     }
 
     public FormattedOutput createFormattedOutput(DetectInfo detectInfo, ExitCodeRequest exitCodeRequest, Optional<AutonomousManager> autonomousManagerOptional) {
@@ -113,6 +115,7 @@ public class FormattedOutputManager {
         unrecognizedPaths.keySet().forEach(key -> formattedOutput.unrecognizedPaths.put(key, unrecognizedPaths.get(key).stream().map(File::toString).collect(Collectors.toList())));
 
         formattedOutput.propertyValues = rawMaskedPropertyValues;
+        formattedOutput.blackDuckServerProperties = blackDuckServerProperties;
         if (autonomousManagerOptional.isPresent()) {
             AutonomousManager autonomousManager = autonomousManagerOptional.get();
             if (autonomousManager.getAutonomousScanEnabled()) {

--- a/src/test/java/com/blackduck/integration/detect/boot/ProductBootTest.java
+++ b/src/test/java/com/blackduck/integration/detect/boot/ProductBootTest.java
@@ -21,6 +21,7 @@ import com.blackduck.integration.detect.lifecycle.boot.product.version.BlackDuck
 import com.blackduck.integration.detect.lifecycle.run.data.ProductRunData;
 import com.blackduck.integration.detect.workflow.blackduck.analytics.AnalyticsConfigurationService;
 import com.blackduck.integration.detect.workflow.blackduck.analytics.AnalyticsSetting;
+import com.blackduck.integration.detect.workflow.blackduck.settings.DetectPropertiesService;
 import com.blackduck.integration.exception.IntegrationException;
 
 public class ProductBootTest {
@@ -101,9 +102,17 @@ public class ProductBootTest {
         AnalyticsConfigurationService analyticsConfigurationService = Mockito.mock(AnalyticsConfigurationService.class);
         Mockito.when(analyticsConfigurationService.fetchAnalyticsSetting(Mockito.any(), Mockito.any())).thenReturn(new AnalyticsSetting("analytics", true));
 
+        DetectPropertiesService detectPropertiesService = Mockito.mock(DetectPropertiesService.class);
+        try {
+            Mockito.when(detectPropertiesService.fetchDetectProperties(Mockito.any(), Mockito.any())).thenThrow(new IntegrationException("Endpoint not available"));
+        } catch (Exception e) {
+            // This won't happen in the mock setup
+        }
+
         ProductBoot productBoot = new ProductBoot(
             blackDuckConnectivityChecker,
             analyticsConfigurationService,
+            detectPropertiesService,
             productBootFactory,
             productBootOptions,
             blackDuckVersionChecker

--- a/src/test/java/com/blackduck/integration/detect/boot/ProductBootTest.java
+++ b/src/test/java/com/blackduck/integration/detect/boot/ProductBootTest.java
@@ -106,7 +106,7 @@ public class ProductBootTest {
         try {
             Mockito.when(detectPropertiesService.fetchDetectProperties(Mockito.any(), Mockito.any())).thenThrow(new IntegrationException("Endpoint not available"));
         } catch (Exception e) {
-            // This won't happen in the mock setup
+            Assertions.fail("This should not happen in the mock setup.");
         }
 
         ProductBoot productBoot = new ProductBoot(

--- a/src/test/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactoryTests.java
+++ b/src/test/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactoryTests.java
@@ -24,6 +24,7 @@ import com.blackduck.integration.detect.configuration.enumeration.DefaultSignatu
 import com.blackduck.integration.detect.configuration.enumeration.DefaultDetectorSearchExcludedDirectories;
 import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
 import com.blackduck.integration.detect.configuration.enumeration.RapidCompareMode;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 import com.blackduck.integration.detect.tool.signaturescanner.BlackDuckSignatureScannerOptions;
 import com.blackduck.integration.detect.workflow.blackduck.project.options.ProjectSyncOptions;
 import com.blackduck.integration.rest.credentials.Credentials;
@@ -93,8 +94,8 @@ public class DetectConfigurationFactoryTests {
         DetectConfigurationFactory factory = factoryOf(
                 Pair.of(DetectProperties.DETECT_TOOLS, DetectTool.SIGNATURE_SCAN.toString()),
                 Pair.of(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE, BlackduckScanMode.STATELESS.toString()));
-        
-        BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = factory.createBlackDuckSignatureScannerOptions();
+
+        BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = factory.createBlackDuckSignatureScannerOptions(CorrelatedScanningDecision.defaultDisabled());
 
         Assertions.assertTrue(blackDuckSignatureScannerOptions.getIsStateless());
     }
@@ -103,8 +104,8 @@ public class DetectConfigurationFactoryTests {
     public void testNoPersistenceModeSpecified() {
         DetectConfigurationFactory factory = factoryOf(
                 Pair.of(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE, RapidCompareMode.BOM_COMPARE_STRICT.toString()));
-        
-        BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = factory.createBlackDuckSignatureScannerOptions();
+
+        BlackDuckSignatureScannerOptions blackDuckSignatureScannerOptions = factory.createBlackDuckSignatureScannerOptions(CorrelatedScanningDecision.defaultDisabled());
 
         Assertions.assertTrue(RapidCompareMode.BOM_COMPARE_STRICT.equals(blackDuckSignatureScannerOptions.getBomCompareMode()));
     }

--- a/src/test/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunnerTest.java
+++ b/src/test/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunnerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.blackduck.integration.detect.lifecycle.OperationException;
+import com.blackduck.integration.detect.lifecycle.boot.decision.CorrelatedScanningDecision;
 import com.blackduck.integration.detect.lifecycle.run.data.BlackDuckRunData;
 import com.blackduck.integration.detect.lifecycle.run.operation.OperationRunner;
 import com.blackduck.integration.detect.workflow.blackduck.codelocation.CodeLocationAccumulator;
@@ -28,7 +29,8 @@ public class IntelligentModeStepRunnerTest {
     public void setUp() {
         operationRunner = mock(OperationRunner.class);
         scanCountsPayloadCreator = mock(ScanCountsPayloadCreator.class);
-        intelligentModeStepRunner = new IntelligentModeStepRunner(operationRunner, null, null, scanCountsPayloadCreator, "test-run-uuid");
+        CorrelatedScanningDecision correlatedScanningDecision = CorrelatedScanningDecision.userEnabled();
+        intelligentModeStepRunner = new IntelligentModeStepRunner(operationRunner, null, null, scanCountsPayloadCreator, correlatedScanningDecision);
     }
 
     @Test
@@ -39,9 +41,9 @@ public class IntelligentModeStepRunnerTest {
         ScanCounts scanCounts = new ScanCounts(0, 0, 0);
         ScanCountsPayload scanCountsPayload = new ScanCountsPayload(scanCounts);
 
-        when(scanCountsPayloadCreator.create(any(), any())).thenReturn(scanCountsPayload);
+        when(scanCountsPayloadCreator.createPayloadFromCountsByTool(any(), any(), any())).thenReturn(scanCountsPayload);
 
-        intelligentModeStepRunner.uploadCorrelatedScanCounts(blackDuckRunData, codeLocationAccumulator, "test-run-uuid");
+        intelligentModeStepRunner.uploadCorrelatedScanCounts(blackDuckRunData, codeLocationAccumulator);
 
         verify(operationRunner, never()).uploadCorrelatedScanCounts(any(), any(), any());
     }
@@ -54,9 +56,9 @@ public class IntelligentModeStepRunnerTest {
         ScanCounts scanCounts = new ScanCounts(1, 0, 0);
         ScanCountsPayload scanCountsPayload = new ScanCountsPayload(scanCounts);
 
-        when(scanCountsPayloadCreator.create(any(), any())).thenReturn(scanCountsPayload);
+        when(scanCountsPayloadCreator.createPayloadFromCountsByTool(any(), any(), any())).thenReturn(scanCountsPayload);
 
-        intelligentModeStepRunner.uploadCorrelatedScanCounts(blackDuckRunData, codeLocationAccumulator, "test-run-uuid");
+        intelligentModeStepRunner.uploadCorrelatedScanCounts(blackDuckRunData, codeLocationAccumulator);
 
         verify(operationRunner, times(1)).uploadCorrelatedScanCounts(any(), any(), any()); 
     }

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/ScanCountsPayloadCreatorTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/ScanCountsPayloadCreatorTest.java
@@ -19,7 +19,7 @@ import com.blackduck.integration.detect.workflow.blackduck.integratedmatching.mo
 class ScanCountsPayloadCreatorTest {
 
     @Test
-    void testMultSigScansPlusBinary() {
+    void testMultSigScansWithUnsupportedBinaryIgnored() {
         WaitableCodeLocationData signatureScanWaitableCodeLocationData = Mockito.mock(WaitableCodeLocationData.class);
         Mockito.when(signatureScanWaitableCodeLocationData.getDetectTool()).thenReturn(DetectTool.SIGNATURE_SCAN);
         Set<String> successfulSigScanCodeLocationNames = new HashSet<>();
@@ -44,12 +44,13 @@ class ScanCountsPayloadCreatorTest {
         Map<DetectTool, Integer> additionalCounts = new HashMap<>();
         additionalCounts.put(DetectTool.DETECTOR, 17);
 
-        Set<String> allScanTypes = new HashSet<>(Arrays.asList("PACKAGE_MANAGER", "SIGNATURE", "BINARY"));
-        ScanCountsPayload payload = creator.createPayloadFromCountsByTool(waitableCodeLocationDataList, additionalCounts, allScanTypes);
+        // BINARY is not supported in correlated mode and is filtered out by CorrelatedScanningDecision
+        Set<String> supportedScanTypes = new HashSet<>(Arrays.asList("PACKAGE_MANAGER", "SIGNATURE"));
+        ScanCountsPayload payload = creator.createPayloadFromCountsByTool(waitableCodeLocationDataList, additionalCounts, supportedScanTypes);
 
         assertEquals(17, payload.getScanCounts().getPackageManager());
         assertEquals(2, payload.getScanCounts().getSignature());
-        assertEquals(3, payload.getScanCounts().getBinary());
+        assertEquals(0, payload.getScanCounts().getBinary());
     }
 
     @Test
@@ -90,8 +91,9 @@ class ScanCountsPayloadCreatorTest {
             iacWaitableCodeLocationData);
 
         ScanCountsPayloadCreator creator = new ScanCountsPayloadCreator();
-        Set<String> allScanTypes = new HashSet<>(Arrays.asList("PACKAGE_MANAGER", "SIGNATURE", "BINARY"));
-        ScanCountsPayload payload = creator.createPayloadFromCountsByTool(waitableCodeLocationDataList, new HashMap<>(), allScanTypes);
+        // BINARY is not supported in correlated mode and is filtered out by CorrelatedScanningDecision
+        Set<String> supportedScanTypes = new HashSet<>(Arrays.asList("PACKAGE_MANAGER", "SIGNATURE"));
+        ScanCountsPayload payload = creator.createPayloadFromCountsByTool(waitableCodeLocationDataList, new HashMap<>(), supportedScanTypes);
 
         assertEquals(6, payload.getScanCounts().getPackageManager());
         assertEquals(0, payload.getScanCounts().getSignature());

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/ScanCountsPayloadCreatorTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/ScanCountsPayloadCreatorTest.java
@@ -44,7 +44,8 @@ class ScanCountsPayloadCreatorTest {
         Map<DetectTool, Integer> additionalCounts = new HashMap<>();
         additionalCounts.put(DetectTool.DETECTOR, 17);
 
-        ScanCountsPayload payload = creator.create(waitableCodeLocationDataList, additionalCounts);
+        Set<String> allScanTypes = new HashSet<>(Arrays.asList("PACKAGE_MANAGER", "SIGNATURE", "BINARY"));
+        ScanCountsPayload payload = creator.createPayloadFromCountsByTool(waitableCodeLocationDataList, additionalCounts, allScanTypes);
 
         assertEquals(17, payload.getScanCounts().getPackageManager());
         assertEquals(2, payload.getScanCounts().getSignature());
@@ -89,7 +90,8 @@ class ScanCountsPayloadCreatorTest {
             iacWaitableCodeLocationData);
 
         ScanCountsPayloadCreator creator = new ScanCountsPayloadCreator();
-        ScanCountsPayload payload = creator.create(waitableCodeLocationDataList, new HashMap<>());
+        Set<String> allScanTypes = new HashSet<>(Arrays.asList("PACKAGE_MANAGER", "SIGNATURE", "BINARY"));
+        ScanCountsPayload payload = creator.createPayloadFromCountsByTool(waitableCodeLocationDataList, new HashMap<>(), allScanTypes);
 
         assertEquals(6, payload.getScanCounts().getPackageManager());
         assertEquals(0, payload.getScanCounts().getSignature());


### PR DESCRIPTION
This PR adds support for BlackDuck controlled properties.
                                                                                                                    
Detect will now fetch settings from a new Black Duck endpoint, api/settings/detect/properties, and use those settings to drive behavior. If the endpoint is unavailable (older servers), Detect silently continues without it.    Currently this is limited to correlated scans only.                                                                                             
                                                                                               
The previous simple boolean for correlated scans is replaced with a CorrelatedScanningDecision object that tracks both the server specified correlation state and which scan types are supported.                                                                 
 
Correlation follows a priority order:                                                                    
    a. Offline or non-intelligent scan mode → disabled                                                              
    b. User explicitly set detect.blackduck.correlated.scanning.enabled → honor user setting                        
    c. Server settings available → use server value and its supported scan types                                    
    d. Neither → default disabled                                                                                   
BINARY and CONTAINER scan types are excluded from correlated scanning regardless of source.                     
                                                                                                                                                                                               
 The decision flows through BootSingletons → OperationRunner → individual scan step runners, replacing the       
  previous approach of re-reading the raw property in each location.                                               

Correlation IDs are now gated per scan type (SIGNATURE, PACKAGE_MANAGER) rather than globally. 