### PR TITLE
Maven: Fix mirror calls to Aether and add test scope exclusion support

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/mirror/MavenMirrorConfigurator.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/mirror/MavenMirrorConfigurator.java
@@ -99,10 +99,10 @@ public class MavenMirrorConfigurator {
                         .addPassword(config.getPassword())
                         .build();
 
-                    // Authentication is keyed by the MIRROR URL, not the mirror ID
-                    // When Aether resolves a mirrored repository, it uses the mirror's URL
+                    // Authentication is keyed by the MIRROR ID
+                    // When Aether resolves a mirrored repository, it uses the mirror's ID
                     // to look up authentication credentials
-                    authSelector.add(config.getUrl(), auth);
+                    authSelector.add(config.getId(), auth);
 
                     logger.info("Registered authentication for mirror '{}' (URL: {})",
                         config.getId(), config.getUrl());

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1199,16 +1199,6 @@ public class DetectProperties {
                     .setExample("https://repo1.company.com/maven2,https://nexus.internal.net/repository/maven-public")
                     .build();
 
-    public static final BooleanProperty DETECT_MAVEN_INCLUDE_TEST_SCOPE =
-            BooleanProperty.newBuilder("detect.maven.include.test.scope", true)
-                    .setInfo("Include Test Scope Dependencies", DetectPropertyFromVersion.VERSION_11_1_0)
-                    .setHelp(
-                            "If set to true, Detect will include test-scope dependencies in the dependency resolution.",
-                            "When enabled, both compile and test scope dependencies will be resolved and reported. When disabled, only compile-scope dependencies will be included. This applies to the Maven Resolver detectable (buildless mode). Default is true."
-                    )
-                    .setGroups(DetectGroup.MAVEN, DetectGroup.SOURCE_SCAN)
-                    .build();
-
     public static final NullableStringProperty DETECT_MAVEN_BUILDLESS_MIRROR_URL =
             NullableStringProperty.newBuilder("detect.maven.buildless.mirror.url")
                     .setInfo("Maven Buildless Mirror URL", DetectPropertyFromVersion.VERSION_11_1_0)

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
@@ -245,10 +245,13 @@ public class DetectableOptionFactory {
         List<MavenMirrorConfig> mirrorConfigurations = new MavenMirrorConfigResolver()
             .resolve(cliMirrorUrl, cliMirrorOf, cliMirrorUsername, cliMirrorPassword, settingsFilePath);
 
-        // Read test scope inclusion configuration
-        Boolean includeTestScope = detectConfiguration.getValue(DetectProperties.DETECT_MAVEN_INCLUDE_TEST_SCOPE);
+        // Derive test scope flag from detect.maven.excluded.scopes
+        // If "test" is present in the excluded list, test-scope dependencies are skipped.
+        List<String> resolverExcludedScopes = detectConfiguration.getValue(DetectProperties.DETECT_MAVEN_EXCLUDED_SCOPES);
+        boolean includeTestScope = !resolverExcludedScopes.contains("test");
 
         return new MavenResolverOptions(externalRepositories, proxyConfig, mirrorConfigurations, includeTestScope);
+
     }
 
     public ConanCliOptions createConanCliOptions() {


### PR DESCRIPTION
# Description 
This PR introduces two targeted improvements to the Maven buildless detector:

## Fix — Mirror calls to Aether

Corrected mirror resolution logic to use the repository ID and associated authentication data.

Ensures mirrors are applied consistently and securely during dependency resolution.

## Feat — Test scope exclusion

Added support for excluding test-scope dependencies via the existing detect.maven.excluded.scopes flag.

Provides users with finer control over dependency resolution by allowing test scope to be omitted when desired.