### PR TITLE
Check if correlation scanning was enabled for fallback scenario

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1834,8 +1834,8 @@ public class OperationRunner {
         }
     }
 
-    public boolean isCorrelationScanningEnabled() {
-        return detectConfigurationFactory.isCorrelatedScanningEnabled();
+    public boolean isCorrelationScanningEnabled(String scanType) {
+        return correlatedScanningDecision.isEnabled() && correlatedScanningDecision.isScanTypeSupported(scanType);
     }
 
     public UUID getScanIdFromScanUrl(HttpUrl blackDuckScanUrl) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -228,7 +228,7 @@ public class IntelligentModeStepRunner {
                 }
             }
 
-            if (!operationRunner.isCorrelationScanningEnabled()) {
+            if (!operationRunner.isCorrelationScanningEnabled("PACKAGE_MANAGER")) {
                 invokePreScassPackageManagerWorkflow(blackDuckRunData, bdioResult, scanIdsToWaitFor, codeLocationAccumulator, scanId);
             } else {
                 logger.error("Correlation scanning is enabled. Please verify your SCASS configuration, as it is required for correlation scans to function properly.");

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/SignatureScanStepRunner.java
@@ -64,7 +64,7 @@ public class SignatureScanStepRunner {
         try {
             reports = executeScan(scanBatch, scanBatchRunner, scanPaths, scanIdsToWaitFor, gson, blackDuckRunData.shouldWaitAtScanLevel(), true);
         } catch (SocketException e) {
-            if (!operationRunner.isCorrelationScanningEnabled()) {
+            if (!operationRunner.isCorrelationScanningEnabled("SIGNATURE")) {
                 logger.warn("Initial Signature Scan failed due to connectivity issues. Retrying scan. Please allow the SCASS IPs to increase scanning performance.");
                 scanBatch = operationRunner.createScanBatchOnline(detectRunUuid, scanPaths, projectNameVersion, dockerTargetData, blackDuckRunData, true);
                 reports = executeScan(scanBatch, scanBatchRunner, scanPaths, scanIdsToWaitFor, gson, blackDuckRunData.shouldWaitAtScanLevel(), true);


### PR DESCRIPTION
Fix IDETECT-5094 to avoid fallback when correlation scanning is enabled for Package Manager and Signature Scans.