### PR TITLE
Extend Gradle Support for quackstart.express with Extensible Adapter Pattern

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectable/ai/AiContextAdapter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectable/ai/AiContextAdapter.java
@@ -57,12 +57,43 @@ public interface AiContextAdapter {
      *
      * <p>The {@code context} extracted from the build files is passed so that implementations
      * can include project-specific hints (e.g., list of detected profile names).
-     * The orchestrator handles the actual I/O — this method only defines what to ask.</p>
+     * The orchestrator handles the actual I/O -- this method only defines what to ask.</p>
      *
      * @param context the context previously returned by {@link #extractContext(File)}
      * @return ordered list of questions; never {@code null}
      */
     List<AiQuestion> getQuestions(AiContext context);
+
+    /**
+     * Express mode: derives flag suggestions directly from the project structure
+     * without any user Q&A or LLM call.
+     *
+     * <p>This is the extension point for QuackStart Express. Each adapter that supports
+     * Express mode overrides this method with its own analysis logic. The orchestrator
+     * ({@code AiAssistanceManager.runExpress}) iterates over all registered adapters
+     * and merges their suggestions -- it never needs to know which detectors exist.</p>
+     *
+     * <h3>Current design (rule-based):</h3>
+     * <p>Implementations inspect build files via {@link #extractContext(File)} and apply
+     * deterministic rules to decide which flags are needed. This is fast, requires no
+     * network calls, and works without LLM credentials.</p>
+     *
+     * <h3>Future enhancement (LLM-backed):</h3>
+     * <p>To switch a specific adapter to LLM-backed analysis, replace the body of its
+     * override with an LLM client call. The method signature and return type stay the
+     * same, so the orchestrator and all other adapters are unaffected.</p>
+     *
+     * <p>The default implementation returns an empty suggestion, which signals that
+     * this adapter does not yet support Express mode. The orchestrator silently
+     * skips adapters that return empty suggestions.</p>
+     *
+     * @param sourceDirectory the project root directory
+     * @return an {@link ExpressFlagSuggestion} with recommended flags and explanations;
+     *         never {@code null}
+     */
+    default ExpressFlagSuggestion suggestExpressFlags(File sourceDirectory) {
+        return ExpressFlagSuggestion.empty();
+    }
 }
 
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectable/ai/ExpressFlagSuggestion.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectable/ai/ExpressFlagSuggestion.java
@@ -1,0 +1,43 @@
+package com.blackduck.integration.detectable.detectable.ai;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Lightweight container for Express-mode flag suggestions produced by an
+ * {@link AiContextAdapter} without any user interaction.
+ *
+ * <p>In Express mode, each adapter analyses the project structure and returns
+ * deterministic flag suggestions. This class carries those suggestions back to
+ * the orchestrator ({@code AiAssistanceManager}), which merges them into the
+ * final property source presented to the user.</p>
+ *
+ * <p>This class lives in the {@code detectable} module so that adapters can
+ * return it without depending on the root module. Its structure intentionally
+ * mirrors {@code LlmFlagSuggestion} in the root module so the two paths
+ * (rule-based Express and LLM-based) converge seamlessly in the orchestrator.</p>
+ */
+public class ExpressFlagSuggestion {
+
+    /** Detect property key to the value that should be applied for this scan. */
+    public final Map<String, String> flags;
+
+    /** Detect property key to a human-readable explanation for the flag choice. */
+    public final Map<String, String> explanations;
+
+    public ExpressFlagSuggestion(Map<String, String> flags, Map<String, String> explanations) {
+        this.flags        = flags        != null ? flags        : new LinkedHashMap<>();
+        this.explanations = explanations != null ? explanations : new LinkedHashMap<>();
+    }
+
+    /** Convenience factory that returns an empty (no-op) suggestion. */
+    public static ExpressFlagSuggestion empty() {
+        return new ExpressFlagSuggestion(new LinkedHashMap<>(), new LinkedHashMap<>());
+    }
+
+    /** Returns true if no flags were suggested. */
+    public boolean isEmpty() {
+        return flags.isEmpty();
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/ai/GradleAiContextAdapter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/ai/GradleAiContextAdapter.java
@@ -3,6 +3,7 @@ package com.blackduck.integration.detectable.detectables.gradle.ai;
 import com.blackduck.integration.detectable.detectable.ai.AiContext;
 import com.blackduck.integration.detectable.detectable.ai.AiContextAdapter;
 import com.blackduck.integration.detectable.detectable.ai.AiQuestion;
+import com.blackduck.integration.detectable.detectable.ai.ExpressFlagSuggestion;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +11,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -136,6 +139,115 @@ public class GradleAiContextAdapter implements AiContextAdapter {
             }
         }
     }
+
+    // ── Express mode ────────────────────────────────────────────────────────
+    //
+    // The methods below implement QuackStart Express for Gradle projects.
+    // They are rule-based: no LLM call, no user questions -- just static
+    // analysis of the build files followed by deterministic flag selection.
+    //
+    // FUTURE: to switch to LLM-backed analysis, replace the body of
+    // suggestExpressFlags() with an LLM client call. The ctx.toPromptString()
+    // output and /aiassist/gradle-flags.json catalog are already in place
+    // to support that path. No other method or caller needs to change.
+
+    /**
+     * Derives Express flag suggestions from the Gradle project context without
+     * any user interaction or LLM call.
+     *
+     * <p>This is the main seam for future enhancement. The current implementation
+     * delegates to {@link #deriveExpressFlags(GradleAiContext)} which applies
+     * deterministic rules. To switch to an LLM-backed analysis later, replace
+     * the body of this method with an LLM client call. No callers in the
+     * orchestrator need to change.</p>
+     *
+     * @param sourceDirectory the project root directory
+     * @return flag suggestions based on static analysis of the build files
+     */
+    @Override
+    public ExpressFlagSuggestion suggestExpressFlags(File sourceDirectory) {
+        GradleAiContext ctx = extractContext(sourceDirectory);
+        return deriveExpressFlags(ctx);
+    }
+
+    /**
+     * Rule-based Express flag derivation. Each flag concern is isolated in its
+     * own private method so new rules can be added without modifying existing
+     * logic (Open/Closed Principle).
+     *
+     * <p>To add a new flag rule in the future:</p>
+     * <ol>
+     *   <li>Create a new private {@code applyXxx()} method below</li>
+     *   <li>Add one call to it here</li>
+     * </ol>
+     *
+     * @param ctx the Gradle project context extracted from build files
+     * @return an ExpressFlagSuggestion with all applicable flags and explanations
+     */
+    private ExpressFlagSuggestion deriveExpressFlags(GradleAiContext ctx) {
+        Map<String, String> flags        = new LinkedHashMap<>();
+        Map<String, String> explanations = new LinkedHashMap<>();
+
+        // Apply each flag rule independently
+        applyConfigurationExclusions(ctx, flags, explanations);
+        applyUnresolvedConfigExclusions(ctx, flags, explanations);
+        // FUTURE: add more rules here as needed, for example:
+        // applySubProjectExclusions(ctx, flags, explanations);
+        // applyRootOnlyFlag(ctx, flags, explanations);
+
+        return new ExpressFlagSuggestion(flags, explanations);
+    }
+
+    /**
+     * Rule: exclude debug/test configurations for Android projects,
+     * or test configurations for standard Gradle projects.
+     *
+     * <p>Android projects produce noisy BOMs from debug and test build variants.
+     * Standard projects with testImplementation/testCompile dependencies should
+     * also have those configurations excluded for a clean production BOM.</p>
+     */
+    private void applyConfigurationExclusions(GradleAiContext ctx,
+            Map<String, String> flags, Map<String, String> explanations) {
+
+        if (ctx.isAndroidProject) {
+            // Android projects carry debug and test build variants that inflate the BOM
+            // with non-production dependencies. Excluding them yields a focused scan.
+            flags.put("detect.gradle.excluded.configurations", "debug,test");
+            explanations.put("detect.gradle.excluded.configurations",
+                "Android project detected. Debug and test build variants excluded "
+                + "for a clean production-only BOM.");
+        } else if (ctx.hasTestConfigurations) {
+            // Standard Gradle projects with test dependencies (testImplementation, etc.)
+            // should have those configurations excluded for a production-only BOM.
+            String configs = String.join(",", ctx.detectedTestConfigs);
+            flags.put("detect.gradle.excluded.configurations", configs);
+            explanations.put("detect.gradle.excluded.configurations",
+                "Test configurations detected (" + configs
+                + "). Excluded to produce a production-only BOM.");
+        }
+    }
+
+    /**
+     * Rule: exclude UNRESOLVED configuration types when unresolvable
+     * configurations (compileOnly, annotationProcessor, kapt) are detected.
+     *
+     * <p>Unresolved configurations can produce inaccurate dependency versions
+     * and false positives in the BOM. Excluding them ensures only fully resolved
+     * dependency graphs are included in the scan results.</p>
+     */
+    private void applyUnresolvedConfigExclusions(GradleAiContext ctx,
+            Map<String, String> flags, Map<String, String> explanations) {
+
+        if (ctx.hasUnresolvedConfigurations) {
+            flags.put("detect.gradle.configuration.types.excluded", "UNRESOLVED");
+            explanations.put("detect.gradle.configuration.types.excluded",
+                "Unresolved configurations detected ("
+                + String.join(", ", ctx.detectedUnresolvedConfigs)
+                + "). Excluded to prevent false positives from unresolvable dependency versions.");
+        }
+    }
+
+    // ── Detector identity ─────────────────────────────────────────────────────
 
     @Override
     public String getDetectorName() {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/cli/MavenAiContextAdapter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/cli/MavenAiContextAdapter.java
@@ -3,6 +3,7 @@ package com.blackduck.integration.detectable.detectables.maven.cli;
 import com.blackduck.integration.detectable.detectable.ai.AiContext;
 import com.blackduck.integration.detectable.detectable.ai.AiContextAdapter;
 import com.blackduck.integration.detectable.detectable.ai.AiQuestion;
+import com.blackduck.integration.detectable.detectable.ai.ExpressFlagSuggestion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -12,7 +13,9 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * AI context adapter for the Maven detector.
@@ -150,6 +153,110 @@ public class MavenAiContextAdapter implements AiContextAdapter {
         }
         return modules;
     }
+
+    // ── Express mode ────────────────────────────────────────────────────────
+    //
+    // The methods below implement QuackStart Express for Maven projects.
+    // They use MavenProjectSummarizer (same package) to walk all pom.xml files
+    // recursively, then apply deterministic rules to derive flag suggestions.
+    //
+    // FUTURE: to switch to LLM-backed analysis, replace the body of
+    // suggestExpressFlags() with an LLM client call using
+    // summary.toPromptString() and the /aiassist/maven-flags.json catalog.
+    // No other method or caller needs to change.
+
+    /**
+     * Derives Express flag suggestions by walking all pom.xml files recursively
+     * and applying deterministic rules based on the project structure.
+     *
+     * <p>Uses {@link MavenProjectSummarizer} (same package, no cross-module dependency)
+     * to build a structured summary of all modules, then delegates to
+     * {@link #deriveExpressFlags(MavenProjectSummary)} for rule-based analysis.</p>
+     *
+     * @param sourceDirectory the project root directory
+     * @return flag suggestions based on static analysis of all pom.xml files
+     */
+    @Override
+    public ExpressFlagSuggestion suggestExpressFlags(File sourceDirectory) {
+        MavenProjectSummarizer summarizer = new MavenProjectSummarizer();
+        MavenProjectSummary summary = summarizer.summarize(sourceDirectory);
+        return deriveExpressFlags(summary);
+    }
+
+    /**
+     * Rule-based Express flag derivation from the full Maven project summary.
+     * This logic was previously in AiAssistanceLlmClient.buildExpressMockSuggestion
+     * and has been moved here so each adapter owns its own Express analysis.
+     *
+     * @param summary the structured summary of all Maven modules
+     * @return an ExpressFlagSuggestion with all applicable flags and explanations
+     */
+    private ExpressFlagSuggestion deriveExpressFlags(MavenProjectSummary summary) {
+        Map<String, String> flags        = new LinkedHashMap<>();
+        Map<String, String> explanations = new LinkedHashMap<>();
+
+        List<String> modulesWithTestDeps  = new ArrayList<>();
+        List<String> testOnlyModuleNames  = new ArrayList<>();
+        boolean hasProfiles = false;
+        String  productionProfile = null;
+        String  devProfile        = null;
+
+        for (MavenProjectSummary.ModuleSummary m : summary.getModules()) {
+            // Signal: any module with test-scoped deps
+            if (m.depsByScope.containsKey("test") && !m.depsByScope.get("test").isEmpty()) {
+                modulesWithTestDeps.add(m.artifactId);
+            }
+
+            // Signal: profiles (pick from root module)
+            if (!m.profileCompileDeps.isEmpty() && productionProfile == null) {
+                hasProfiles = true;
+                for (String profileId : m.profileCompileDeps.keySet()) {
+                    if (profileId.toLowerCase().contains("prod")) productionProfile = profileId;
+                    if (profileId.toLowerCase().contains("dev"))  devProfile        = profileId;
+                }
+            }
+
+            // Signal: modules that are test/utility only
+            boolean hasOnlyTestDeps = !m.depsByScope.isEmpty()
+                && !m.depsByScope.containsKey("compile")
+                && m.depsByScope.containsKey("test");
+            boolean nameIndicatesTest = m.artifactId.toLowerCase().contains("test")
+                || m.artifactId.toLowerCase().contains("integration");
+            if ((hasOnlyTestDeps || nameIndicatesTest) && m.parentArtifactId != null) {
+                testOnlyModuleNames.add(m.artifactId);
+            }
+        }
+
+        // Rule: exclude test scopes when test-scoped dependencies are found
+        if (!modulesWithTestDeps.isEmpty()) {
+            flags.put("detect.maven.excluded.scopes", "test");
+            explanations.put("detect.maven.excluded.scopes",
+                "Modules " + String.join(", ", modulesWithTestDeps)
+                + " declare test-scoped dependencies. Excluding them produces a clean production-only BOM.");
+        }
+
+        // Rule: activate production profile when one is detected
+        if (hasProfiles && productionProfile != null) {
+            flags.put("detect.maven.build.command", "-P" + productionProfile);
+            explanations.put("detect.maven.build.command",
+                "The '" + productionProfile + "' profile activates production-specific dependencies"
+                + (devProfile != null ? " (replacing the '" + devProfile + "' dev profile)" : "")
+                + ". Ensures the correct environment dependencies are resolved.");
+        }
+
+        // Rule: exclude test utility modules
+        if (!testOnlyModuleNames.isEmpty()) {
+            flags.put("detect.maven.excluded.modules", String.join(",", testOnlyModuleNames));
+            explanations.put("detect.maven.excluded.modules",
+                "Modules " + String.join(", ", testOnlyModuleNames)
+                + " appear to be test/utility modules. Excluding them prevents their "
+                + "transitive dependencies from appearing in the production BOM.");
+        }
+
+        return new ExpressFlagSuggestion(flags, explanations);
+    }
+
+    // ── Detector identity ─────────────────────────────────────────────────────
 
     @Override
     public String getDetectorName() {

--- a/hackathon/demoGradleProject/api/build.gradle
+++ b/hackathon/demoGradleProject/api/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':core')
+    implementation 'org.springframework.boot:spring-boot-starter-web:3.2.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+    // compileOnly, annotationProcessor, debug, test — declared in root subprojects block
+}
+

--- a/hackathon/demoGradleProject/build.gradle
+++ b/hackathon/demoGradleProject/build.gradle
@@ -1,0 +1,67 @@
+plugins {
+    id 'com.android.application' version '8.3.0' apply false
+}
+
+allprojects {
+    group = 'com.example'
+    version = '1.0.0'
+
+    repositories {
+        mavenCentral()
+        google()
+    }
+}
+
+subprojects {
+    apply plugin: 'java-library'
+
+    // Configurations named EXACTLY 'debug' and 'test' so that
+    // detect.gradle.excluded.configurations = debug,test (exact glob match) removes them in the AI scan.
+    configurations {
+        debug {
+            description = 'Android-style debug-only dependencies'
+            canBeResolved = true
+            canBeConsumed = false
+        }
+        test {
+            description = 'Test-only dependencies'
+            canBeResolved = true
+            canBeConsumed = false
+        }
+    }
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    dependencies {
+        // ── UNRESOLVED configs ────────────────────────────────────────────────
+        // Excluded by: detect.gradle.configuration.types.excluded = UNRESOLVED
+        // compileOnly is marked (n) = not-resolvable → Detect classifies it as UNRESOLVED
+        compileOnly 'org.projectlombok:lombok:1.18.30'
+        compileOnly 'com.google.code.findbugs:annotations:3.0.1'
+        compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+        compileOnly 'org.checkerframework:checker-qual:3.42.0'
+        annotationProcessor 'org.projectlombok:lombok:1.18.30'
+        annotationProcessor 'com.google.dagger:dagger-compiler:2.51.1'
+
+        // ── DEBUG config (Android-style) ──────────────────────────────────────
+        // Excluded by: detect.gradle.excluded.configurations = debug
+        debug 'com.squareup.leakcanary:leakcanary-android:2.12'
+        debug 'com.jakewharton.timber:timber:5.0.1'
+        debug 'com.facebook.stetho:stetho:1.6.0'
+        debug 'com.facebook.stetho:stetho-okhttp3:1.6.0'
+        debug 'com.squareup.okhttp3:logging-interceptor:4.12.0'
+
+        // ── TEST config ───────────────────────────────────────────────────────
+        // Excluded by: detect.gradle.excluded.configurations = test
+        // NOTE: NOT using testImplementation so these deps do NOT leak into
+        // testCompileClasspath (which would NOT be excluded by the exact-match filter)
+        test 'org.junit.jupiter:junit-jupiter:5.10.2'
+        test 'org.mockito:mockito-core:5.11.0'
+        test 'org.assertj:assertj-core:3.25.3'
+        test 'org.hamcrest:hamcrest:2.2'
+        test 'org.junit.platform:junit-platform-launcher:1.10.2'
+    }
+}

--- a/hackathon/demoGradleProject/core/build.gradle
+++ b/hackathon/demoGradleProject/core/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+    implementation 'org.slf4j:slf4j-api:2.0.12'
+    // compileOnly, annotationProcessor, debug, test — declared in root subprojects block
+}

--- a/hackathon/demoGradleProject/integration-tests/build.gradle
+++ b/hackathon/demoGradleProject/integration-tests/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation project(':core')
+    implementation project(':api')
+    implementation project(':test-fixtures')
+    implementation 'org.testcontainers:testcontainers:1.19.7'
+    implementation 'com.h2database:h2:2.2.224'
+}
+

--- a/hackathon/demoGradleProject/settings.gradle
+++ b/hackathon/demoGradleProject/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'demo-app'
+
+include 'core'
+include 'api'
+include 'test-fixtures'
+include 'integration-tests'
+

--- a/hackathon/demoGradleProject/test-fixtures/build.gradle
+++ b/hackathon/demoGradleProject/test-fixtures/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    api project(':core')
+}

--- a/src/main/java/com/blackduck/integration/detect/workflow/aiassist/AiAssistanceManager.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/aiassist/AiAssistanceManager.java
@@ -5,10 +5,9 @@ import com.blackduck.integration.configuration.source.PropertySource;
 import com.blackduck.integration.detectable.detectable.ai.AiContext;
 import com.blackduck.integration.detectable.detectable.ai.AiContextAdapter;
 import com.blackduck.integration.detectable.detectable.ai.AiQuestion;
+import com.blackduck.integration.detectable.detectable.ai.ExpressFlagSuggestion;
 import com.blackduck.integration.detectable.detectables.gradle.ai.GradleAiContextAdapter;
 import com.blackduck.integration.detectable.detectables.maven.cli.MavenAiContextAdapter;
-import com.blackduck.integration.detectable.detectables.maven.cli.MavenProjectSummary;
-import com.blackduck.integration.detectable.detectables.maven.cli.MavenProjectSummarizer;
 import com.blackduck.integration.detect.interactive.InteractiveWriter;
 import com.google.gson.Gson;
 import org.slf4j.Logger;
@@ -51,34 +50,41 @@ public class AiAssistanceManager {
     }
 
     /**
-     * Runs the QuackStart Express pre-scan phase (no questions — full project analysis).
+     * Runs the QuackStart Express pre-scan phase (no questions -- full project analysis).
      *
-     * <p>Flow:</p>
+     * <p>Express mode iterates over all registered {@link AiContextAdapter} instances
+     * and calls {@link AiContextAdapter#suggestExpressFlags(java.io.File)} on each
+     * applicable adapter. Each adapter owns its own analysis logic (rule-based today,
+     * potentially LLM-backed in the future). The orchestrator only handles the UI
+     * (privacy disclaimer, presenting suggestions, accept/reject) -- it never needs
+     * to know which detectors exist or how they derive their flags.</p>
+     *
+     * <p>To add Express support for a new detector:</p>
      * <ol>
-     *   <li>Privacy disclaimer — user must accept before any data is sent</li>
-     *   <li>{@link MavenProjectSummarizer} walks all {@code pom.xml} files recursively</li>
-     *   <li>Structured summary is sent to the LLM (or mock) for flag selection</li>
-     *   <li>Suggested flags are presented with module-specific explanations</li>
-     *   <li>User accepts or rejects</li>
+     *   <li>Override {@code suggestExpressFlags()} in the detector's adapter</li>
+     *   <li>Register the adapter in {@link #buildAdapters()}</li>
      * </ol>
+     * <p>No changes to this method are required.</p>
      *
      * @param sourceDirectory project root
      * @param writer          terminal I/O
-     * @param propertySources raw property sources (used to read LLM credentials)
+     * @param propertySources raw property sources (reserved for future use, e.g. LLM credentials)
      * @return a {@link MapPropertySource} with AI-suggested flags at highest priority
      */
     public MapPropertySource runExpress(File sourceDirectory, InteractiveWriter writer, List<PropertySource> propertySources) {
         writer.println();
         writer.println("╔══════════════════════════════════════════════╗");
-        writer.println("║     QuackStart Express — Full Analysis       ║");
+        writer.println("║     QuackStart Express -- Full Analysis       ║");
         writer.println("╚══════════════════════════════════════════════╝");
         writer.println();
         writer.println("Analysing project at: " + sourceDirectory.getAbsolutePath());
         writer.println();
 
         // ── Privacy disclaimer ────────────────────────────────────────────────
-        writer.println("  ⚠  Express mode: build metadata (module names, scopes, profiles)");
-        writer.println("     will be sent to the LLM. No source code is included.");
+        // Express mode reads build metadata (module names, scopes, configurations)
+        // from the project. No source code is included.
+        writer.println("  NOTE: Express mode analyses build metadata (module names, scopes, configurations).");
+        writer.println("        No source code is read or transmitted.");
         writer.println();
         Boolean proceed = writer.askYesOrNo("Proceed?");
         writer.println();
@@ -88,55 +94,48 @@ public class AiAssistanceManager {
             return new MapPropertySource(PROPERTY_SOURCE_NAME, new LinkedHashMap<>());
         }
 
-        // ── LLM credentials ───────────────────────────────────────────────────
-        String llmApiKey      = System.getenv("DETECT_LLM_API_KEY");
-        String llmApiEndpoint = System.getenv("DETECT_LLM_API_ENDPOINT");
-        String llmName        = System.getenv("DETECT_LLM_MODEL_NAME");
-        boolean llmAvailable  = llmApiKey != null && !llmApiKey.isEmpty()
-                             && llmApiEndpoint != null && !llmApiEndpoint.isEmpty()
-                             && llmName != null && !llmName.isEmpty();
-        if (!llmAvailable) {
-            writer.println("  LLM credentials not configured — running in MOCK mode.");
-            writer.println("   (Set DETECT_LLM_API_KEY, DETECT_LLM_API_ENDPOINT, DETECT_LLM_MODEL_NAME for real LLM suggestions)");
+        // ── Iterate over all registered adapters ──────────────────────────────
+        // Each adapter decides independently whether it is applicable and what
+        // flags to suggest. The orchestrator just merges and presents.
+        Map<String, String> allFlags   = new LinkedHashMap<>();
+        Map<String, String> allExplain = new LinkedHashMap<>();
+
+        for (AiContextAdapter adapter : adapters) {
+            // Skip adapters that are not applicable to this project
+            if (!adapter.isApplicable(sourceDirectory)) {
+                logger.debug("[QuackStart Express] Adapter '{}' not applicable, skipping.", adapter.getDetectorName());
+                continue;
+            }
+
+            writer.println("  Detected: " + adapter.getDetectorName() + " project");
+            writer.println("  Analysing build files...");
             writer.println();
+
+            // Each adapter owns its Express logic via suggestExpressFlags().
+            // Adapters that do not support Express return empty (the default).
+            ExpressFlagSuggestion suggestion = adapter.suggestExpressFlags(sourceDirectory);
+
+            logger.info("[QuackStart Express] {} suggestion: flags={}, explanations={}",
+                    adapter.getDetectorName(), suggestion.flags, suggestion.explanations);
+
+            if (!suggestion.isEmpty()) {
+                allFlags.putAll(suggestion.flags);
+                allExplain.putAll(suggestion.explanations);
+            } else {
+                writer.println("  No Express suggestions for " + adapter.getDetectorName() + ".");
+                writer.println();
+            }
         }
 
-        // ── Maven: check applicable ───────────────────────────────────────────
-        MavenAiContextAdapter mavenAdapter = new MavenAiContextAdapter();
-        if (!mavenAdapter.isApplicable(sourceDirectory)) {
-            writer.println("No Maven project detected (pom.xml not found). Express mode supports Maven only.");
-            writer.println();
-            return new MapPropertySource(PROPERTY_SOURCE_NAME, new LinkedHashMap<>());
-        }
-
-        // ── Summarise all pom.xml files ───────────────────────────────────────
-        MavenProjectSummarizer summarizer = new MavenProjectSummarizer();
-        writer.println(" Detected: MAVEN project");
-        writer.println("  Reading all pom.xml files...");
-        MavenProjectSummary summary = summarizer.summarize(sourceDirectory);
-        writer.println("  Found " + summary.getModules().size() + " module(s).");
-        writer.println("  Sending project summary to LLM for analysis...");
-        writer.println();
-
-        logger.info("[QuackStart Express] Project summary:\n{}", summary.toPromptString());
-
-        // ── Call LLM ──────────────────────────────────────────────────────────
-        AiFlagsMetadataLoader flagsLoader  = new AiFlagsMetadataLoader();
-        String                flagsCatalog = flagsLoader.loadFlagsJson("MAVEN");
-
-        AiAssistanceLlmClient llmClient = new AiAssistanceLlmClient(llmApiKey, llmApiEndpoint, llmName, gson);
-        LlmFlagSuggestion suggestion    = llmClient.suggestFlagsFromProjectSummary(summary, flagsCatalog);
-
-        logger.info("[QuackStart Express] LLM suggestion: flags={}, explanations={}",
-                suggestion.flags, suggestion.explanations);
-
-        if (suggestion.isEmpty()) {
-            writer.println("No AI configuration suggestions for this Maven project.");
+        // ── No suggestions from any adapter ───────────────────────────────────
+        if (allFlags.isEmpty()) {
+            writer.println("No AI configuration suggestions for this project.");
             writer.println();
             return new MapPropertySource(PROPERTY_SOURCE_NAME, new LinkedHashMap<>());
         }
 
-        presentSuggestedCommand(suggestion.flags, suggestion.explanations, writer);
+        // ── Present and confirm ───────────────────────────────────────────────
+        presentSuggestedCommand(allFlags, allExplain, writer);
 
         Boolean accepted = writer.askYesOrNo("Accept this configuration and run the scan?");
         writer.println();
@@ -144,7 +143,7 @@ public class AiAssistanceManager {
         if (Boolean.TRUE.equals(accepted)) {
             writer.println("Configuration accepted. Starting scan with AI-suggested flags.");
             writer.println();
-            return new MapPropertySource(PROPERTY_SOURCE_NAME, suggestion.flags);
+            return new MapPropertySource(PROPERTY_SOURCE_NAME, allFlags);
         } else {
             writer.println("Configuration declined. Running scan with original settings.");
             writer.println();


### PR DESCRIPTION
## Key Updates

- **ExpressFlagSuggestion**  
  Introduced a lightweight flag suggestion container within the detectable module. This mirrors `LlmFlagSuggestion` but is module‑independent, ensuring flexibility without LLM dependencies.

- **AiContextAdapter**  
  Enhanced with a new default method `suggestExpressFlags()`. By default, it returns empty, allowing each adapter to implement its own express logic as needed.

- **Gradle Express Implementation**  
  - Implemented `GradleAiContextAdapter.suggestExpressFlags()` with rule‑based analysis.  
  - Two isolated private rule methods enable straightforward addition of new flags without modifying core logic.

- **Maven Express Migration**  
  Migrated existing Maven mock logic from `AiAssistanceLlmClient` into `MavenAiContextAdapter`, aligning with the adapter‑owned analysis model.

- **Orchestrator Refactor**  
  Refactored `AiAssistanceManager.runExpress()` into a detector‑agnostic loop over all adapters.  
  - Removed Maven‑specific hardcoded logic.  
  - Each adapter now owns its analysis, ensuring modularity and future readiness.
