### PR TITLE
fix(binary-scan): warn instead of fail when no files match configured patterns

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/binary/AbstractBinaryScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/binary/AbstractBinaryScanStepRunner.java
@@ -68,7 +68,11 @@ public abstract class AbstractBinaryScanStepRunner {
                 List<File> multiTargets = operationRunner.getMultiBinaryTargets();
                 multiTargets.forEach(operationRunner::updateBinaryUserTargets);
             } else {
-                operationRunner.publishBinaryFailure("Binary scanner did not find any files matching any pattern.");
+                String message = "Binary scanner did not find any files matching the configured patterns.";
+                if (binaryScanOptions.getSearchDepth() == 0) {
+                    message += " Consider using detect.binary.scan.search.depth if binary files exist in subdirectories.";
+                }
+                logger.warn(message);
             }
         } else if (dockerTargetData != null && dockerTargetData.getContainerFilesystem().isPresent()) {
             logger.info("Binary Scanner will upload docker container file system.");


### PR DESCRIPTION

# Description

 ## Summary

  - Binary scan no longer fails with exit code 11 when detect.binary.scan.file.name.patterns is configured but no matching files are found
  - Changed hard failure to a warning log, allowing the scan to continue and exit cleanly
  - When search depth is at default (0), the warning suggests using detect.binary.scan.search.depth for files in subdirectories

  ## Context

  Projects in CI/CD pipelines often have binary scan patterns (e.g. *.jar) configured globally, but not every project produces matching binaries. Previously, this
  caused FAILURE_BLACKDUCK_FEATURE_ERROR (exit code 11), failing the pipeline unnecessarily.

  Other binary scan paths (no patterns configured, autonomous mode) already handled "no binaries found" gracefully. This change makes the pattern-matching path
  consistent with that behavior.

  ## What's NOT changed

  - Explicit file path (detect.binary.scan.file.path) pointing to a missing/unreadable file still fails — that's a legitimate config error
  - Server upload failures still fail
  - All other scan types are unaffected