### PR TITLE
fix(maven): Apply mirror configuration to all POM downloads + shaded dependency analysis support

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ArtifactDownloader.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ArtifactDownloader.java
@@ -1,0 +1,360 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload.DownloadConfiguration;
+import com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload.FallbackRepositoryDownloader;
+import com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload.HttpArtifactDownloader;
+import com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload.LocalRepositoryChecker;
+import com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload.ParallelDownloadManager;
+import com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload.RemoteRepositoryDownloader;
+import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorConfig;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.JavaRepository;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.graph.Dependency;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Artifact Downloader that orchestrates JAR downloads using a 3-tier resolution strategy.
+ *
+ * <p>Tier-1: Local repositories (custom .m2 location, home ~/.m2/repository, download cache)
+ * <p>Tier-2: POM-declared remote repositories
+ * <p>Tier-3: Maven Central as fallback
+ *
+ * <p>This class follows the Single Responsibility Principle: it only orchestrates resolution.
+ * All actual work is delegated to specialized classes:
+ * <ul>
+ *   <li>{@link LocalRepositoryChecker} - checks local repositories for existing JARs</li>
+ *   <li>{@link RemoteRepositoryDownloader} - downloads from POM-declared repositories</li>
+ *   <li>{@link FallbackRepositoryDownloader} - downloads from Maven Central (or mirror)</li>
+ * </ul>
+ */
+public class ArtifactDownloader {
+
+    private static final Logger logger = LoggerFactory.getLogger(ArtifactDownloader.class);
+
+    private static final String MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2";
+    private static final String MAVEN_CENTRAL_URL_ALT = "https://repo.maven.apache.org/maven2";
+
+    // Delegates
+    private final LocalRepositoryChecker localChecker;
+    private final FallbackRepositoryDownloader fallbackDownloader;
+    private final Map<String, HttpArtifactDownloader> pomRepoDownloaders;
+    private final ParallelDownloadManager parallelDownloadManager;
+
+    // Configuration
+    private final Path resolvedCustomRepositoryPath;
+    private final Path defaultRepositoryPath;
+    private final Path homeM2Repository;
+    private final List<JavaRepository> pomRepositories;
+    private final DownloadConfiguration downloadConfiguration;
+
+    /**
+     * Constructs an ArtifactDownloader with full configuration including POM repositories.
+     *
+     * @param customRepositoryPath Optional custom path to a local Maven repository (.m2 location).
+     * @param defaultRepositoryPath Default download cache path (typically Detect output downloads dir)
+     * @param pomRepositories List of repositories declared in POM files (Tier-2)
+     * @param options User-facing configuration (download flag, custom repo path, mirrors)
+     */
+    public ArtifactDownloader(Path customRepositoryPath, Path defaultRepositoryPath,
+                              List<JavaRepository> pomRepositories, MavenResolverOptions options) {
+
+        logger.info("Initializing ArtifactDownloader...");
+
+        // Initialize delegates
+        this.localChecker = new LocalRepositoryChecker();
+        this.downloadConfiguration = DownloadConfiguration.createDefault();
+
+        // Resolve custom repository path
+        if (customRepositoryPath != null) {
+            logger.info("User-provided custom repository path: {}", customRepositoryPath);
+            this.resolvedCustomRepositoryPath = M2RepositoryPathResolver.resolve(customRepositoryPath);
+            if (this.resolvedCustomRepositoryPath != null) {
+                logger.info("Resolved custom repository path to: {}", this.resolvedCustomRepositoryPath);
+            } else {
+                logger.warn("Could not resolve custom repository path. Custom repository will be skipped.");
+            }
+        } else {
+            this.resolvedCustomRepositoryPath = null;
+            logger.debug("No custom repository path configured");
+        }
+
+        if (defaultRepositoryPath == null) {
+            throw new IllegalArgumentException("Default repository path must not be null");
+        }
+        this.defaultRepositoryPath = defaultRepositoryPath;
+
+        // Resolve home .m2 repository once
+        this.homeM2Repository = localChecker.resolveHomeM2Repository();
+
+        // Deduplicate and filter POM repositories
+        this.pomRepositories = deduplicatePomRepositories(pomRepositories);
+
+        // Apply mirror redirects to POM repository downloaders and fallback downloader
+        List<MavenMirrorConfig> mirrorConfigs = options != null ? options.getMirrorConfigurations() : Collections.<MavenMirrorConfig>emptyList();
+
+        this.pomRepoDownloaders = new LinkedHashMap<>();
+        for (JavaRepository repo : this.pomRepositories) {
+            MavenMirrorConfig mirror = findMatchingMirror(mirrorConfigs, repo.getId());
+            if (mirror != null) {
+                logger.info("Mirror '{}' redirects repository '{}' ({}) to {}", mirror.getId(), repo.getId(), repo.getUrl(), mirror.getUrl());
+                pomRepoDownloaders.put(repo.getId(), new RemoteRepositoryDownloader(mirror.getUrl(), mirror.getUsername(), mirror.getPassword()));
+            } else {
+                pomRepoDownloaders.put(repo.getId(), new RemoteRepositoryDownloader(repo.getUrl()));
+            }
+        }
+
+        MavenMirrorConfig centralMirror = findMatchingMirror(mirrorConfigs, "central");
+        if (centralMirror != null) {
+            logger.info("Mirror '{}' redirects Maven Central fallback to {}", centralMirror.getId(), centralMirror.getUrl());
+            this.fallbackDownloader = new FallbackRepositoryDownloader(centralMirror.getUrl(), centralMirror.getUsername(), centralMirror.getPassword());
+        } else {
+            this.fallbackDownloader = new FallbackRepositoryDownloader();
+        }
+
+        logInitializationSummary();
+
+        this.parallelDownloadManager = new ParallelDownloadManager(null, this.localChecker, this.fallbackDownloader);
+    }
+
+    /**
+     * Constructs an ArtifactDownloader without POM repositories (backward compatibility).
+     */
+    public ArtifactDownloader(Path customRepositoryPath, Path defaultRepositoryPath,
+                              MavenResolverOptions options) {
+        this(customRepositoryPath, defaultRepositoryPath, Collections.emptyList(), options);
+    }
+
+    /**
+     * Downloads JAR files for all dependencies in the list using parallel downloads.
+     *
+     * @param dependencies the list of dependencies to download
+     * @return a map of successfully downloaded artifacts to their local JAR file paths
+     */
+    public Map<Artifact, Path> downloadArtifacts(List<Dependency> dependencies) {
+        Map<Artifact, Path> artifactPathMap = new ConcurrentHashMap<>();
+
+        if (dependencies == null || dependencies.isEmpty()) {
+            logger.info("No dependencies to download. Skipping JAR download phase.");
+            return artifactPathMap;
+        }
+
+        // Pre-filter: skip artifacts with classifiers (e.g., sources, javadoc, test-jar)
+        List<Dependency> downloadable = new ArrayList<>();
+        int classifierSkippedCount = 0;
+        for (Dependency dep : dependencies) {
+            String classifier = dep.getArtifact().getClassifier();
+            if (classifier != null && !classifier.isEmpty()) {
+                logger.info("SKIPPING artifact with classifier '{}': {}", classifier, formatCoords(dep.getArtifact()));
+                classifierSkippedCount++;
+            } else {
+                downloadable.add(dep);
+            }
+        }
+
+        // Build a GAV -> Artifact lookup from the input dependencies list.
+        // This is needed because ParallelDownloadResult returns ArtifactCoordinate (not Artifact),
+        // so we need to map back to the original Artifact objects for the return type.
+        Map<String, Artifact> gavToArtifact = new HashMap<>();
+        for (Dependency dep : downloadable) {
+            Artifact a = dep.getArtifact();
+            String gavKey = a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion();
+            gavToArtifact.put(gavKey, a);
+        }
+
+        // Delegate to ParallelDownloadManager with pre-built mirror-aware downloaders
+        ParallelDownloadManager.ParallelDownloadResult parallelResult =
+            parallelDownloadManager.downloadArtifacts(
+                downloadable,
+                resolvedCustomRepositoryPath,
+                homeM2Repository,
+                defaultRepositoryPath,
+                pomRepoDownloaders,
+                downloadConfiguration
+            );
+
+        // Translate ParallelDownloadResult outcomes back into Map<Artifact, Path>
+        for (ParallelDownloadManager.DownloadOutcome outcome : parallelResult.getOutcomes()) {
+            if ((outcome.getStatus() == ParallelDownloadManager.DownloadOutcome.DownloadStatus.SUCCESS
+                    || outcome.getStatus() == ParallelDownloadManager.DownloadOutcome.DownloadStatus.SKIPPED_LOCAL)
+                    && outcome.getPath() != null && outcome.getCoordinate() != null) {
+                String gavKey = outcome.getCoordinate().getGroupId() + ":"
+                    + outcome.getCoordinate().getArtifactId() + ":"
+                    + outcome.getCoordinate().getVersion();
+                Artifact originalArtifact = gavToArtifact.get(gavKey);
+                if (originalArtifact != null) {
+                    artifactPathMap.put(originalArtifact, outcome.getPath());
+                }
+            }
+        }
+
+        // Build summary lists from parallel outcomes for the existing logDownloadSummary method
+        List<String> failedArtifacts = new ArrayList<>();
+        List<String> unavailableArtifacts = new ArrayList<>();
+        for (ParallelDownloadManager.DownloadOutcome outcome : parallelResult.getOutcomes()) {
+            String coords = outcome.getCoordinate() != null ? outcome.getCoordinate().toString() : "unknown";
+            if (outcome.getStatus() == ParallelDownloadManager.DownloadOutcome.DownloadStatus.FAILED) {
+                failedArtifacts.add(coords + " - " + (outcome.getErrorMessage() != null ? outcome.getErrorMessage() : "Unknown error"));
+            } else if (outcome.getStatus() == ParallelDownloadManager.DownloadOutcome.DownloadStatus.SKIPPED_NOT_FOUND) {
+                unavailableArtifacts.add(coords);
+            }
+        }
+
+        logDownloadSummary(
+            dependencies.size(),
+            parallelResult.getSuccessCount(),
+            parallelResult.getFailureCount(),
+            parallelResult.getSkippedCount() + classifierSkippedCount,
+            artifactPathMap.size(),
+            parallelResult.getTotalTimeMs(),
+            unavailableArtifacts,
+            failedArtifacts
+        );
+
+        return artifactPathMap;
+    }
+
+    /**
+     * Deduplicates POM repositories, removing Maven Central references (handled as Tier-3).
+     */
+    private List<JavaRepository> deduplicatePomRepositories(List<JavaRepository> repositories) {
+        if (repositories == null || repositories.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<JavaRepository> filtered = new ArrayList<>();
+        int mavenCentralSkipped = 0;
+
+        for (JavaRepository repo : repositories) {
+            String url = repo.getUrl();
+            if (url == null || url.isEmpty()) {
+                continue;
+            }
+
+            String normalizedUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+
+            if (normalizedUrl.equals(MAVEN_CENTRAL_URL) || normalizedUrl.equals(MAVEN_CENTRAL_URL_ALT)) {
+                mavenCentralSkipped++;
+                continue;
+            }
+
+            filtered.add(repo);
+        }
+
+        if (mavenCentralSkipped > 0) {
+            logger.debug("Deduplicated {} Maven Central reference(s) from POM repositories", mavenCentralSkipped);
+        }
+
+        return filtered;
+    }
+
+    private void logInitializationSummary() {
+        logger.info(" TIER-1: LOCAL REPOSITORIES ");
+        logger.info("  Custom .m2 repository: {}",
+            resolvedCustomRepositoryPath != null ? resolvedCustomRepositoryPath : "not configured");
+        logger.info("  Home .m2 repository: {}",
+            homeM2Repository != null ? homeM2Repository : "not found");
+        logger.info("  Download cache: {}", defaultRepositoryPath);
+
+        logger.info(" TIER-2: POM REPOSITORIES ");
+        if (pomRepositories.isEmpty()) {
+            logger.info("  No POM-declared repositories configured");
+        } else {
+            logger.info("  {} POM repositories configured:", pomRepositories.size());
+            for (int i = 0; i < pomRepositories.size(); i++) {
+                JavaRepository repo = pomRepositories.get(i);
+                logger.info("    {}. {} ({})", i + 1, repo.getId(), repo.getUrl());
+            }
+        }
+
+        logger.info(" TIER-3: MAVEN CENTRAL ");
+        logger.info("  Maven Central: Always available as fallback");
+
+        logger.info(" DOWNLOAD CONFIGURATION ");
+        logger.info("  {}", downloadConfiguration);
+    }
+
+    private void logDownloadSummary(int total, int success, int failures, int skipped,
+                                    int mapSize, long elapsedMs,
+                                    List<String> unavailable, List<String> failed) {
+        logger.info("JAR DOWNLOAD PHASE SUMMARY");
+        logger.info("========================================");
+        logger.info("Total processed: {}", total);
+        logger.info("  Successfully downloaded: {}", success);
+        logger.info("  Not available (skipped): {}", skipped);
+        logger.info("  Failed with errors: {}", failures);
+        logger.info("  Artifact-to-path map entries: {}", mapSize);
+        logger.info("Time elapsed: {} ms", elapsedMs);
+
+        if (!unavailable.isEmpty()) {
+            logger.info("Artifacts not available in repositories ({}):", unavailable.size());
+            unavailable.forEach(a -> logger.info("  - {}", a));
+        }
+
+        if (!failed.isEmpty()) {
+            logger.error("Failed artifacts requiring attention ({}):", failed.size());
+            failed.forEach(a -> logger.error("  - {}", a));
+        }
+
+        if (failures > 0) {
+            logger.error("JAR DOWNLOAD PHASE COMPLETED WITH ERRORS: {} artifacts failed", failures);
+        } else if (skipped > 0) {
+            logger.info("JAR DOWNLOAD PHASE COMPLETED: {} artifacts unavailable but no errors", skipped);
+        } else {
+            logger.info("JAR DOWNLOAD PHASE COMPLETED SUCCESSFULLY: All {} artifacts downloaded", success);
+        }
+    }
+
+    @Nullable
+    private static MavenMirrorConfig findMatchingMirror(List<MavenMirrorConfig> mirrors, String repoId) {
+        if (mirrors == null || mirrors.isEmpty()) {
+            return null;
+        }
+        for (MavenMirrorConfig mirror : mirrors) {
+            if (matchesMirrorOf(mirror.getMirrorOf(), repoId)) {
+                return mirror;
+            }
+        }
+        return null;
+    }
+
+    private static boolean matchesMirrorOf(String mirrorOf, String repoId) {
+        if (mirrorOf == null || mirrorOf.trim().isEmpty()) {
+            return false;
+        }
+
+        String[] parts = mirrorOf.split(",");
+        boolean included = false;
+        boolean excluded = false;
+
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (trimmed.startsWith("!")) {
+                if (trimmed.substring(1).equals(repoId)) {
+                    excluded = true;
+                }
+            } else if ("*".equals(trimmed) || "external:*".equals(trimmed)) {
+                included = true;
+            } else if (trimmed.equals(repoId)) {
+                included = true;
+            }
+        }
+
+        return included && !excluded;
+    }
+
+    private String formatCoords(Artifact artifact) {
+        return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion();
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ArtifactDownloader.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ArtifactDownloader.java
@@ -7,10 +7,10 @@ import com.blackduck.integration.detectable.detectables.maven.resolver.artifactd
 import com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload.ParallelDownloadManager;
 import com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload.RemoteRepositoryDownloader;
 import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorConfig;
+import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorResolver;
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.JavaRepository;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.Dependency;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,7 +105,7 @@ public class ArtifactDownloader {
 
         this.pomRepoDownloaders = new LinkedHashMap<>();
         for (JavaRepository repo : this.pomRepositories) {
-            MavenMirrorConfig mirror = findMatchingMirror(mirrorConfigs, repo.getId());
+            MavenMirrorConfig mirror = MavenMirrorResolver.findMatchingMirror(mirrorConfigs, repo.getId());
             if (mirror != null) {
                 logger.info("Mirror '{}' redirects repository '{}' ({}) to {}", mirror.getId(), repo.getId(), repo.getUrl(), mirror.getUrl());
                 pomRepoDownloaders.put(repo.getId(), new RemoteRepositoryDownloader(mirror.getUrl(), mirror.getUsername(), mirror.getPassword()));
@@ -114,7 +114,7 @@ public class ArtifactDownloader {
             }
         }
 
-        MavenMirrorConfig centralMirror = findMatchingMirror(mirrorConfigs, "central");
+        MavenMirrorConfig centralMirror = MavenMirrorResolver.findMatchingMirror(mirrorConfigs, "central");
         if (centralMirror != null) {
             logger.info("Mirror '{}' redirects Maven Central fallback to {}", centralMirror.getId(), centralMirror.getUrl());
             this.fallbackDownloader = new FallbackRepositoryDownloader(centralMirror.getUrl(), centralMirror.getUsername(), centralMirror.getPassword());
@@ -315,43 +315,6 @@ public class ArtifactDownloader {
         }
     }
 
-    @Nullable
-    private static MavenMirrorConfig findMatchingMirror(List<MavenMirrorConfig> mirrors, String repoId) {
-        if (mirrors == null || mirrors.isEmpty()) {
-            return null;
-        }
-        for (MavenMirrorConfig mirror : mirrors) {
-            if (matchesMirrorOf(mirror.getMirrorOf(), repoId)) {
-                return mirror;
-            }
-        }
-        return null;
-    }
-
-    private static boolean matchesMirrorOf(String mirrorOf, String repoId) {
-        if (mirrorOf == null || mirrorOf.trim().isEmpty()) {
-            return false;
-        }
-
-        String[] parts = mirrorOf.split(",");
-        boolean included = false;
-        boolean excluded = false;
-
-        for (String part : parts) {
-            String trimmed = part.trim();
-            if (trimmed.startsWith("!")) {
-                if (trimmed.substring(1).equals(repoId)) {
-                    excluded = true;
-                }
-            } else if ("*".equals(trimmed) || "external:*".equals(trimmed)) {
-                included = true;
-            } else if (trimmed.equals(repoId)) {
-                included = true;
-            }
-        }
-
-        return included && !excluded;
-    }
 
     private String formatCoords(Artifact artifact) {
         return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/M2RepositoryPathResolver.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/M2RepositoryPathResolver.java
@@ -1,0 +1,104 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Resolves a user-provided path to a valid Maven local repository directory.
+ *
+ * <p>Resolution strategy:
+ * <ol>
+ *   <li>Normalize the path (resolve relative paths, expand user home "~").</li>
+ *   <li>If the path itself is an existing directory, check whether it looks like
+ *       a repository root (has Maven-style content) or an {@code .m2} directory
+ *       that contains a {@code repository} subdirectory.</li>
+ *   <li>If the path points to an {@code .m2} directory, append {@code repository}.</li>
+ *   <li>Return {@code null} if no valid repository directory can be determined.</li>
+ * </ol>
+ */
+public final class M2RepositoryPathResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(M2RepositoryPathResolver.class);
+
+    private static final String REPOSITORY_SUBDIR = "repository";
+
+    private M2RepositoryPathResolver() {
+        // utility class — no instantiation
+    }
+
+    /**
+     * Resolves the given path to a Maven local repository directory.
+     *
+     * @param inputPath the user-provided path (may point to {@code .m2} or
+     *                  {@code .m2/repository} or any custom repo root)
+     * @return the resolved repository {@link Path} if it exists and is a directory,
+     *         or {@code null} if resolution fails
+     */
+    public static Path resolve(Path inputPath) {
+        if (inputPath == null) {
+            logger.debug("Input path is null; cannot resolve repository path.");
+            return null;
+        }
+
+        // Normalize: handle "~" prefix and make absolute
+        Path normalized = normalizePath(inputPath);
+        logger.debug("Normalized repository path: {} -> {}", inputPath, normalized);
+
+        // Case 1: Path already points to an existing directory
+        if (Files.isDirectory(normalized)) {
+            // If the directory is named "repository", assume it is the repo root
+            if (REPOSITORY_SUBDIR.equals(normalized.getFileName().toString())) {
+                logger.debug("Path already ends with '{}'; using as repository root.", REPOSITORY_SUBDIR);
+                return normalized;
+            }
+
+            // Check if it contains a "repository" subdirectory (i.e., it's an .m2 dir)
+            Path repoSubdir = normalized.resolve(REPOSITORY_SUBDIR);
+            if (Files.isDirectory(repoSubdir)) {
+                logger.debug("Found '{}' subdirectory under provided path; using: {}",
+                        REPOSITORY_SUBDIR, repoSubdir);
+                return repoSubdir;
+            }
+
+            // The directory exists but has no "repository" subdir — treat it as the repo root itself
+            logger.debug("Directory exists but has no '{}' subdirectory; using as-is: {}",
+                    REPOSITORY_SUBDIR, normalized);
+            return normalized;
+        }
+
+        // Case 2: Path does not exist yet — try appending "repository"
+        Path withRepo = normalized.resolve(REPOSITORY_SUBDIR);
+        if (Files.isDirectory(withRepo)) {
+            logger.debug("Original path does not exist, but '{}' does; using: {}",
+                    REPOSITORY_SUBDIR, withRepo);
+            return withRepo;
+        }
+
+        // Case 3: Neither the path nor path/repository exist
+        logger.warn("Resolved path does not exist as a directory: {}", normalized);
+        return null;
+    }
+
+    /**
+     * Normalizes the input path by expanding a leading "~" to the user home
+     * directory and converting to an absolute path.
+     */
+    private static Path normalizePath(Path inputPath) {
+        String pathStr = inputPath.toString();
+
+        // Expand leading ~ to user.home
+        if (pathStr.startsWith("~")) {
+            String userHome = System.getProperty("user.home");
+            if (userHome != null) {
+                pathStr = userHome + pathStr.substring(1);
+                logger.debug("Expanded '~' to user home: {}", pathStr);
+            }
+        }
+
+        return Paths.get(pathStr).toAbsolutePath().normalize();
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/MavenResolverDetectable.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/MavenResolverDetectable.java
@@ -34,7 +34,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Maven Resolver Detectable - Detects and resolves Maven project dependencies.
@@ -284,6 +286,25 @@ public class MavenResolverDetectable extends Detectable {
                 dependencyGraphTest = mavenGraphTransformer.transform(parseResultTest);
             }
 
+            // PHASE 4.5: Shaded dependency detection
+            Map<String, DependencyGraph> shadedSubTreeCache = new HashMap<>();
+            ShadedDependencyScanner shadedDependencyScanner = null;
+            if (mavenResolverOptions != null && mavenResolverOptions.isIncludeShadedDependenciesEnabled()) {
+                logger.info("Shaded dependency detection is enabled. Initializing scanner...");
+                shadedDependencyScanner = new ShadedDependencyScanner(
+                    externalIdFactory, projectBuilder, dependencyResolver,
+                    mavenGraphParser, mavenGraphTransformer,
+                    mavenResolverOptions.getProxyConfig()
+                );
+                shadedDependencyScanner.processShading(
+                    collectResultCompile, collectResultTest,
+                    dependencyGraphCompile, dependencyGraphTest,
+                    localRepoPath, downloadDir,
+                    mavenProject.getRepositories(),
+                    shadedSubTreeCache, mavenResolverOptions
+                );
+            }
+
             // Create CodeLocations for the root project (both compile and test scopes)
             // CodeLocation ties together the dependency graph, external ID, and source path
             List<CodeLocation> codeLocations = new ArrayList<>();
@@ -318,6 +339,11 @@ public class MavenResolverDetectable extends Detectable {
                     .codeLocations(codeLocations)
                     .compileScope(MAVEN_SCOPE_COMPILE)
                     .testScope(MAVEN_SCOPE_TEST)
+                    .shadedDependencyScanner(shadedDependencyScanner)
+                    .shadedSubTreeCache(shadedSubTreeCache)
+                    .includeShadedDependencies(mavenResolverOptions != null && mavenResolverOptions.isIncludeShadedDependenciesEnabled())
+                    .mavenResolverOptions(mavenResolverOptions)
+                    .downloadDir(downloadDir)
                     .build();
 
                 // Process all modules using the module processor

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/MavenResolverDetectable.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/MavenResolverDetectable.java
@@ -18,6 +18,7 @@ import com.blackduck.integration.detectable.detectables.maven.resolver.graph.Mav
 import com.blackduck.integration.detectable.detectables.maven.resolver.graph.MavenParseResult;
 import com.blackduck.integration.detectable.detectables.maven.resolver.module.MavenModuleProcessor;
 import com.blackduck.integration.detectable.detectables.maven.resolver.module.MavenModuleProcessingContext;
+import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorConfig;
 import com.blackduck.integration.detectable.detectables.maven.resolver.output.CodeLocationFactory;
 import com.blackduck.integration.detectable.detectables.maven.resolver.output.DependencyTreeFileWriter;
 import com.blackduck.integration.detectable.detectables.maven.resolver.output.MavenCoordinateFormatter;
@@ -198,7 +199,8 @@ public class MavenResolverDetectable extends Detectable {
             // Create a download directory for parent POMs and BOM imports that need to be fetched from remote repositories
             Path downloadDir = extractionEnvironment.getOutputDirectory().toPath().resolve(DOWNLOADS_DIR_NAME);
             Files.createDirectories(downloadDir);
-            ProjectBuilder projectBuilder = new ProjectBuilder(downloadDir);
+            ProjectBuilder projectBuilder = new ProjectBuilder(downloadDir,
+                mavenResolverOptions != null ? mavenResolverOptions.getMirrorConfigurations() : Collections.<MavenMirrorConfig>emptyList());
             MavenProject mavenProject = projectBuilder.buildProject(pomFile);
 
             // Log the constructed MavenProject details for verification and debugging

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/MavenResolverOptions.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/MavenResolverOptions.java
@@ -1,5 +1,6 @@
 package com.blackduck.integration.detectable.detectables.maven.resolver;
 
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,26 +54,37 @@ public class MavenResolverOptions {
     // Configuration for including test-scope dependencies
     private final boolean includeTestScope;
 
+    // Shaded dependency detection
+    private final boolean includeShadedDependencies;
+
+    // Custom .m2/repository path for JAR downloads (derived from detect.maven.buildless.m2.path)
+    @Nullable
+    private final Path jarRepositoryPath;
+
     /**
-     * Constructs MavenResolverOptions with external repositories, proxy, and mirror configuration.
+     * Constructs MavenResolverOptions with all configuration.
      *
-     * @param externalRepositories  List of external Maven repository URLs to use during resolution.
-     *                              These are used alongside repositories declared in pom.xml.
-     * @param proxyConfig           Proxy configuration (may be null if no proxy is configured).
-     * @param mirrorConfigurations  List of mirror configurations for corporate repository managers.
-     *                              May be empty if no mirrors are configured.
-     * @param includeTestScope      Whether to include test-scope dependencies in resolution.
+     * @param externalRepositories      List of external Maven repository URLs to use during resolution.
+     * @param proxyConfig               Proxy configuration (may be null if no proxy is configured).
+     * @param mirrorConfigurations      List of mirror configurations for corporate repository managers.
+     * @param includeTestScope          Whether to include test-scope dependencies in resolution.
+     * @param includeShadedDependencies Whether to detect shaded dependencies inside JARs.
+     * @param jarRepositoryPath         Custom .m2/repository path for JAR downloads (may be null).
      */
     public MavenResolverOptions(
         List<String> externalRepositories,
         @Nullable MavenProxyConfig proxyConfig,
         List<MavenMirrorConfig> mirrorConfigurations,
-        boolean includeTestScope
+        boolean includeTestScope,
+        boolean includeShadedDependencies,
+        @Nullable Path jarRepositoryPath
     ) {
         this.externalRepositories = externalRepositories != null ? externalRepositories : Collections.emptyList();
         this.proxyConfig = proxyConfig;
         this.mirrorConfigurations = mirrorConfigurations != null ? mirrorConfigurations : Collections.emptyList();
         this.includeTestScope = includeTestScope;
+        this.includeShadedDependencies = includeShadedDependencies;
+        this.jarRepositoryPath = jarRepositoryPath;
     }
 
     /**
@@ -137,6 +149,25 @@ public class MavenResolverOptions {
      */
     public boolean getIncludeTestScope() {
         return includeTestScope;
+    }
+
+    /**
+     * Returns whether shaded dependency detection is enabled.
+     *
+     * @return true if shaded dependencies should be detected inside JARs
+     */
+    public boolean isIncludeShadedDependenciesEnabled() {
+        return includeShadedDependencies;
+    }
+
+    /**
+     * Returns the custom .m2/repository path for JAR downloads.
+     *
+     * @return custom repository path, or null if not configured
+     */
+    @Nullable
+    public Path getJarRepositoryPath() {
+        return jarRepositoryPath;
     }
 }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ShadedDependencyScanner.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ShadedDependencyScanner.java
@@ -1,0 +1,662 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver;
+
+import com.blackduck.integration.bdio.graph.DependencyGraph;
+import com.blackduck.integration.bdio.model.dependency.Dependency;
+import com.blackduck.integration.bdio.model.externalid.ExternalId;
+import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.JavaCoordinates;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.JavaRepository;
+import com.blackduck.integration.detectable.detectables.maven.resolver.graph.MavenGraphParser;
+import com.blackduck.integration.detectable.detectables.maven.resolver.graph.MavenGraphTransformer;
+import com.blackduck.integration.detectable.detectables.maven.resolver.graph.MavenParseResult;
+import com.blackduck.integration.detectable.detectables.maven.resolver.mavendownload.MavenDownloader;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXml;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXmlPlugin;
+import com.blackduck.integration.detectable.detectables.maven.resolver.pom.MavenProject;
+import com.blackduck.integration.detectable.detectables.maven.resolver.pom.ProjectBuilder;
+import com.blackduck.integration.detectable.detectables.maven.resolver.proxy.MavenProxyConfig;
+import com.blackduck.integration.detectable.detectables.maven.resolver.proxy.MavenProxyConfigurator;
+import com.blackduck.integration.detectable.detectables.maven.resolver.resolution.MavenDependencyResolver;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.ShadedDependencyInspector;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.methods.DeltaAnalysisInspector;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.methods.RecursiveMetadataInspector;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.DiscoveredDependency;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.graph.DependencyNode;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+/**
+ * Owns the full shaded dependency detection pipeline:
+ * <ol>
+ *   <li>Extract Aether dependencies from CollectResult</li>
+ *   <li>Pre-filter: check POMs for maven-shade-plugin</li>
+ *   <li>Download JARs</li>
+ *   <li>Scan JARs for shaded dependencies (Delta Analysis + Recursive Metadata)</li>
+ *   <li>Graft discovered shaded dependency sub-trees into BDIO graphs</li>
+ * </ol>
+ *
+ * <p>Both MavenResolverDetectable (root module) and MavenModuleProcessor (sub-modules)
+ * delegate to this class via a single {@link #processShading} call.
+ *
+ * @see DeltaAnalysisInspector
+ * @see RecursiveMetadataInspector
+ */
+public class ShadedDependencyScanner {
+
+    private static final Logger logger = LoggerFactory.getLogger(ShadedDependencyScanner.class);
+    private static final String MAVEN_SCOPE_COMPILE = "compile";
+
+    private final ExternalIdFactory externalIdFactory;
+    private final ProjectBuilder projectBuilder;
+    private final MavenDependencyResolver dependencyResolver;
+    private final MavenGraphParser graphParser;
+    private final MavenGraphTransformer graphTransformer;
+    @Nullable
+    private final MavenProxyConfig proxyConfig;
+
+    public ShadedDependencyScanner(
+            ExternalIdFactory externalIdFactory,
+            ProjectBuilder projectBuilder,
+            MavenDependencyResolver dependencyResolver,
+            MavenGraphParser graphParser,
+            MavenGraphTransformer graphTransformer,
+            @Nullable MavenProxyConfig proxyConfig
+    ) {
+        this.externalIdFactory = externalIdFactory;
+        this.projectBuilder = projectBuilder;
+        this.dependencyResolver = dependencyResolver;
+        this.graphParser = graphParser;
+        this.graphTransformer = graphTransformer;
+        this.proxyConfig = proxyConfig;
+    }
+
+    /**
+     * Runs the full shaded dependency pipeline: extract → pre-filter → download → scan → graft.
+     *
+     * @param compileResult     Compile-scope Aether CollectResult
+     * @param testResult        Test-scope Aether CollectResult (may be null)
+     * @param compileGraph      Compile-scope BDIO DependencyGraph to graft onto
+     * @param testGraph         Test-scope BDIO DependencyGraph to graft onto (may be null)
+     * @param localRepoPath     Path to Aether's local repository (for POM cache reads)
+     * @param downloadDir       Directory for downloading JARs and POMs
+     * @param repositories      Maven repositories declared in the POM
+     * @param shadedSubTreeCache Shared cache for resolved shaded sub-trees (reused across scopes/modules)
+     * @param options           Maven resolver options (custom repo path, feature flags)
+     */
+    public void processShading(
+            CollectResult compileResult,
+            CollectResult testResult,
+            DependencyGraph compileGraph,
+            DependencyGraph testGraph,
+            Path localRepoPath,
+            Path downloadDir,
+            List<JavaRepository> repositories,
+            Map<String, DependencyGraph> shadedSubTreeCache,
+            MavenResolverOptions options
+    ) {
+        try {
+            // Step 1: Extract Aether dependencies from CollectResult trees
+            List<org.eclipse.aether.graph.Dependency> aetherDependencies = new ArrayList<>();
+            Set<String> seenGavs = new HashSet<>();
+
+            if (compileResult != null && compileResult.getRoot() != null) {
+                extractAetherDependenciesFromNode(compileResult.getRoot(), aetherDependencies, seenGavs);
+                logger.debug("Extracted {} dependencies from compile scope", aetherDependencies.size());
+            }
+
+            if (aetherDependencies.isEmpty()) {
+                logger.debug("No dependencies to process for shaded detection");
+                return;
+            }
+
+            // Step 2: Pre-filter — only keep deps whose POM declares maven-shade-plugin
+            aetherDependencies = filterToShadedCandidates(aetherDependencies, localRepoPath);
+            if (aetherDependencies.isEmpty()) {
+                logger.info("No dependencies use maven-shade-plugin, skipping JAR downloads");
+                return;
+            }
+
+            // Steps 3-5 involve network operations — wrap with proxy set/restore
+            MavenProxyConfigurator proxyConfigurator = null;
+            if (proxyConfig != null) {
+                proxyConfigurator = new MavenProxyConfigurator(proxyConfig);
+                proxyConfigurator.configureSystemProxyProperties();
+            }
+
+            try {
+                // Step 3: Download JARs
+                Files.createDirectories(downloadDir);
+                ArtifactDownloader artifactDownloader = new ArtifactDownloader(
+                        options.getJarRepositoryPath(),
+                        downloadDir,
+                        repositories != null ? repositories : new ArrayList<>(),
+                        options
+                );
+
+                logger.info("Starting artifact downloads for {} shaded candidates...", aetherDependencies.size());
+                Map<Artifact, Path> downloadedJars = artifactDownloader.downloadArtifacts(aetherDependencies);
+                logger.info("Downloaded {} JARs", downloadedJars.size());
+
+                if (downloadedJars.isEmpty()) {
+                    logger.debug("No JARs downloaded, skipping shaded detection");
+                    return;
+                }
+
+                // Step 4: Scan JARs for shaded dependencies
+                Map<Artifact, List<DiscoveredDependency>> shadedDepsMap = scanJarsForShadedDependencies(
+                        downloadedJars, compileResult, testResult);
+
+                logger.info("Shaded dependency scan complete. Found {} JARs with shaded dependencies.", shadedDepsMap.size());
+
+                if (shadedDepsMap.isEmpty()) {
+                    return;
+                }
+
+                // Step 5: Graft shaded dependency sub-trees into graphs
+                File downloadDirFile = downloadDir.toFile();
+                File localRepoFile = localRepoPath.toFile();
+                List<JavaRepository> repos = repositories != null ? repositories : new ArrayList<>();
+
+                int addedToCompile = addShadedDependenciesToGraph(
+                        compileGraph, shadedDepsMap, downloadDirFile, localRepoFile, repos, shadedSubTreeCache);
+                logger.info("Grafted {} shaded dependency nodes into compile graph", addedToCompile);
+
+                if (testGraph != null) {
+                    int addedToTest = addShadedDependenciesToGraph(
+                            testGraph, shadedDepsMap, downloadDirFile, localRepoFile, repos, shadedSubTreeCache);
+                    logger.info("Grafted {} shaded dependency nodes into test graph", addedToTest);
+                }
+            } finally {
+                if (proxyConfigurator != null) {
+                    proxyConfigurator.restoreOriginalProxyProperties();
+                }
+            }
+
+        } catch (Exception e) {
+            logger.warn("Failed to process shaded dependencies: {}", e.getMessage());
+            logger.debug("Shaded dependency processing error:", e);
+        }
+    }
+
+    // ==========================================
+    // Step 1: Extract Aether Dependencies
+    // ==========================================
+
+    private void extractAetherDependenciesFromNode(
+            DependencyNode node,
+            List<org.eclipse.aether.graph.Dependency> dependencies,
+            Set<String> seenGavs
+    ) {
+        if (node == null) {
+            return;
+        }
+
+        org.eclipse.aether.graph.Dependency dependency = node.getDependency();
+        if (dependency != null && dependency.getArtifact() != null) {
+            String gavKey = dependency.getArtifact().getGroupId() + ":"
+                    + dependency.getArtifact().getArtifactId() + ":"
+                    + dependency.getArtifact().getVersion();
+            if (seenGavs.add(gavKey)) {
+                dependencies.add(dependency);
+            }
+        }
+
+        if (node.getChildren() != null) {
+            for (DependencyNode child : node.getChildren()) {
+                extractAetherDependenciesFromNode(child, dependencies, seenGavs);
+            }
+        }
+    }
+
+    // ==========================================
+    // Step 2: Pre-filter (maven-shade-plugin check)
+    // ==========================================
+
+    private List<org.eclipse.aether.graph.Dependency> filterToShadedCandidates(
+            List<org.eclipse.aether.graph.Dependency> allDeps,
+            Path localRepoPath
+    ) {
+        int total = allDeps.size();
+        List<org.eclipse.aether.graph.Dependency> candidates = new ArrayList<>();
+        int keptShaded = 0;
+        int keptFailOpen = 0;
+        int skipped = 0;
+
+        XmlMapper xmlMapper = new XmlMapper();
+        xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        for (org.eclipse.aether.graph.Dependency dep : allDeps) {
+            Artifact artifact = dep.getArtifact();
+            if (artifact == null) {
+                continue;
+            }
+
+            String groupId = artifact.getGroupId();
+            String artifactId = artifact.getArtifactId();
+            String version = artifact.getVersion();
+
+            Path pomPath = localRepoPath
+                    .resolve(groupId.replace('.', '/'))
+                    .resolve(artifactId)
+                    .resolve(version)
+                    .resolve(artifactId + "-" + version + ".pom");
+
+            if (!Files.exists(pomPath)) {
+                logger.debug("Pre-filter: POM not found for {}:{}:{}, keeping as candidate (fail open)", groupId, artifactId, version);
+                candidates.add(dep);
+                keptFailOpen++;
+                continue;
+            }
+
+            try {
+                PomXml pomXml = xmlMapper.readValue(pomPath.toFile(), PomXml.class);
+
+                if (hasShadePlugin(pomXml)) {
+                    logger.debug("Pre-filter: maven-shade-plugin found in {}:{}:{}", groupId, artifactId, version);
+                    candidates.add(dep);
+                    keptShaded++;
+                } else {
+                    skipped++;
+                }
+            } catch (Exception e) {
+                logger.debug("Pre-filter: failed to parse POM for {}:{}:{}, keeping as candidate: {}", groupId, artifactId, version, e.getMessage());
+                candidates.add(dep);
+                keptFailOpen++;
+            }
+        }
+
+        logger.info("Pre-filter complete: {} total deps, {} with shade plugin, {} skipped (no plugin), {} kept due to missing/unparseable POM",
+                total, keptShaded, skipped, keptFailOpen);
+        return candidates;
+    }
+
+    private boolean hasShadePlugin(PomXml pomXml) {
+        if (pomXml.getBuild() == null || pomXml.getBuild().getPlugins() == null) {
+            return false;
+        }
+        for (PomXmlPlugin plugin : pomXml.getBuild().getPlugins()) {
+            if ("maven-shade-plugin".equals(plugin.getArtifactId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ==========================================
+    // Step 4: Scan JARs for shaded dependencies
+    // ==========================================
+
+    private Map<Artifact, List<DiscoveredDependency>> scanJarsForShadedDependencies(
+            Map<Artifact, Path> artifactJarPaths,
+            CollectResult compileResult,
+            CollectResult testResult) {
+
+        Map<Artifact, List<DiscoveredDependency>> results = new LinkedHashMap<>();
+
+        if (artifactJarPaths == null || artifactJarPaths.isEmpty()) {
+            logger.info("No JAR files provided for shaded dependency scanning.");
+            return results;
+        }
+
+        int totalJars = artifactJarPaths.size();
+        logger.info("Starting shaded dependency scan for {} JAR file(s)...", totalJars);
+
+        Map<String, Set<String>> aetherDirectChildrenByGa = new HashMap<>();
+        if (compileResult != null && compileResult.getRoot() != null) {
+            buildAetherDirectChildrenMap(compileResult.getRoot(), aetherDirectChildrenByGa);
+        }
+        if (testResult != null && testResult.getRoot() != null) {
+            buildAetherDirectChildrenMap(testResult.getRoot(), aetherDirectChildrenByGa);
+        }
+
+        logger.debug("Built Aether direct children map with {} GA entries.", aetherDirectChildrenByGa.size());
+
+        int processedCount = 0;
+        int jarsWithShadedDeps = 0;
+        int totalShadedDepsFound = 0;
+
+        for (Map.Entry<Artifact, Path> entry : artifactJarPaths.entrySet()) {
+            Artifact artifact = entry.getKey();
+            Path jarPath = entry.getValue();
+            processedCount++;
+
+            String artifactGav = formatArtifactGav(artifact);
+            logger.debug("Scanning JAR {}/{}: {}", processedCount, totalJars, artifactGav);
+
+            if (jarPath == null || !Files.exists(jarPath)) {
+                logger.warn("JAR file not found for {}, skipping shaded dependency scan. Expected path: {}",
+                        artifactGav, jarPath);
+                continue;
+            }
+
+            List<ShadedDependencyInspector> inspectors = new ArrayList<>();
+            inspectors.add(new DeltaAnalysisInspector(aetherDirectChildrenByGa, projectBuilder, artifact));
+            inspectors.add(new RecursiveMetadataInspector(artifact));
+            logger.debug("Created {} inspector(s) for artifact: {}", inspectors.size(), artifactGav);
+
+            try {
+                List<DiscoveredDependency> shadedDeps = scanSingleJar(jarPath, inspectors, artifactGav);
+
+                if (!shadedDeps.isEmpty()) {
+                    results.put(artifact, shadedDeps);
+                    jarsWithShadedDeps++;
+                    totalShadedDepsFound += shadedDeps.size();
+                    logger.debug("Found {} shaded dependency(ies) in: {}", shadedDeps.size(), artifactGav);
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to scan JAR for shaded dependencies: {} - Error: {}", artifactGav, e.getMessage());
+                logger.debug("Stack trace for failed JAR scan:", e);
+            }
+        }
+
+        logger.info("Shaded dependency scan complete.");
+        logger.info("  - JARs scanned: {}", totalJars);
+        logger.info("  - JARs with shaded dependencies: {}", jarsWithShadedDeps);
+        logger.info("  - Total shaded dependencies found: {}", totalShadedDepsFound);
+
+        return results;
+    }
+
+    private List<DiscoveredDependency> scanSingleJar(Path jarPath, List<ShadedDependencyInspector> inspectors,
+                                                      String artifactGav) throws Exception {
+        Map<String, DiscoveredDependency> deduplicatedDeps = new LinkedHashMap<>();
+
+        JarFile jarFile = null;
+        try {
+            jarFile = new JarFile(jarPath.toFile());
+
+            for (ShadedDependencyInspector inspector : inspectors) {
+                String inspectorName = inspector.getClass().getSimpleName();
+                logger.debug("  Running {} on: {}", inspectorName, artifactGav);
+
+                try {
+                    List<DiscoveredDependency> inspectorResults = inspector.detectShadedDependencies(jarFile);
+
+                    if (inspectorResults != null) {
+                        for (DiscoveredDependency dep : inspectorResults) {
+                            String identifier = dep.getIdentifier();
+
+                            if (deduplicatedDeps.containsKey(identifier)) {
+                                DiscoveredDependency existing = deduplicatedDeps.get(identifier);
+                                logger.debug("    Duplicate found: {} (already detected by {})",
+                                        identifier, existing.getDetectionSource());
+                            } else {
+                                deduplicatedDeps.put(identifier, dep);
+                                logger.debug("    Discovered: {} via {}", identifier, dep.getDetectionSource());
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.warn("  Inspector {} failed on {}: {}", inspectorName, artifactGav, e.getMessage());
+                }
+            }
+        } finally {
+            if (jarFile != null) {
+                try {
+                    jarFile.close();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+
+        return new ArrayList<>(deduplicatedDeps.values());
+    }
+
+    // ==========================================
+    // Step 5: Graft shaded dependencies into graphs
+    // ==========================================
+
+    private int addShadedDependenciesToGraph(
+            DependencyGraph mainGraph,
+            Map<Artifact, List<DiscoveredDependency>> shadedDepsMap,
+            File downloadDir,
+            File localRepoPath,
+            List<JavaRepository> repositories,
+            Map<String, DependencyGraph> shadedSubTreeCache) {
+
+        int graftedNodeCount = 0;
+
+        for (Map.Entry<Artifact, List<DiscoveredDependency>> entry : shadedDepsMap.entrySet()) {
+            Artifact parentArtifact = entry.getKey();
+            List<DiscoveredDependency> shadedDeps = entry.getValue();
+
+            logger.debug("Processing {} shaded dependencies for parent artifact: {}:{}:{}",
+                    shadedDeps.size(),
+                    parentArtifact.getGroupId(),
+                    parentArtifact.getArtifactId(),
+                    parentArtifact.getVersion());
+
+            ExternalId parentExternalId = externalIdFactory.createMavenExternalId(
+                    parentArtifact.getGroupId(), parentArtifact.getArtifactId(), parentArtifact.getVersion());
+            Dependency parentDependency = mainGraph.getDependency(parentExternalId);
+
+            if (parentDependency == null) {
+                logger.warn("Parent artifact {}:{}:{} not found in dependency graph. Skipping shaded dependencies for this artifact.",
+                        parentArtifact.getGroupId(), parentArtifact.getArtifactId(), parentArtifact.getVersion());
+                continue;
+            }
+
+            for (DiscoveredDependency shadedDep : shadedDeps) {
+                try {
+                    String identifier = shadedDep.getIdentifier();
+                    if (identifier == null || identifier.isEmpty()) {
+                        logger.warn("Skipping shaded dependency with null/empty identifier in parent: {}",
+                                parentArtifact.getArtifactId());
+                        continue;
+                    }
+
+                    String[] gavParts = identifier.split(":");
+                    if (gavParts.length < 3) {
+                        logger.warn("Skipping shaded dependency with invalid GAV format: {}", identifier);
+                        continue;
+                    }
+
+                    String groupId = gavParts[0];
+                    String artifactId = gavParts[1];
+                    String version = gavParts[2];
+
+                    if (groupId.isEmpty() || artifactId.isEmpty() || version.isEmpty() || "UNKNOWN".equals(version)) {
+                        logger.debug("Skipping shaded dependency with incomplete coordinates: {}", identifier);
+                        continue;
+                    }
+
+                    String gavKey = groupId + ":" + artifactId + ":" + version;
+                    DependencyGraph isolatedShadedGraph = shadedSubTreeCache.get(gavKey);
+
+                    if (isolatedShadedGraph == null) {
+                        logger.debug("Resolving sub-tree for shaded dependency: {}", identifier);
+
+                        JavaCoordinates coords = new JavaCoordinates(groupId, artifactId, version, "pom");
+                        MavenDownloader downloader = new MavenDownloader(repositories, downloadDir.toPath());
+                        File shadedPomFile = downloader.downloadPom(coords);
+
+                        if (shadedPomFile == null || !shadedPomFile.exists()) {
+                            logger.warn("Could not download POM for shaded dependency {}. Sub-tree resolution aborted.", identifier);
+                            ExternalId fallbackId = externalIdFactory.createMavenExternalId(groupId, artifactId, version);
+                            mainGraph.addChildWithParent(new Dependency(artifactId, version, fallbackId), parentDependency);
+                            graftedNodeCount++;
+                            logger.info("Added fallback single node for shaded dependency: {} (parent: {})",
+                                    identifier, parentArtifact.getArtifactId());
+                            continue;
+                        }
+
+                        logger.debug("Successfully downloaded POM for shaded dependency: {}", identifier);
+
+                        MavenProject shadedProject = projectBuilder.buildProject(shadedPomFile);
+                        logger.debug("Built MavenProject for shaded dependency: {} with {} direct dependencies",
+                                identifier, shadedProject.getDependencies().size());
+
+                        CollectResult collectResult = dependencyResolver.resolveDependencies(
+                                shadedPomFile, shadedProject, localRepoPath, MAVEN_SCOPE_COMPILE);
+                        logger.debug("Resolved Aether tree for shaded dependency: {}", identifier);
+
+                        //TODO : RECURSIVE SHADED INSPECTION - FIND SHADED DEPENDENCIES OF THESE SHADED DEPENDENCIES
+                        //Aether only resolves unshaded dependencies, leaving shaded deps as gaps
+                        //in the tree which may result in false negatives for vulnerabilities.
+
+                        //TODO : ADD CYCLE DETECTION BEFORE IMPLEMENTING RECURSIVE SHADED INSPECTION
+                        //If A shades B and B shades A (or any longer chain), recursive inspection
+                        //will loop infinitely or blow the stack. Before making the above TODO work,
+                        //add a Set<String> currentlyInspecting (artifact GAV keys) — skip any artifact
+                        //already in the set to break cycles.
+
+                        MavenParseResult parseResult = graphParser.parse(collectResult);
+                        isolatedShadedGraph = graphTransformer.transform(parseResult);
+                        logger.debug("Transformed shaded dependency {} to BDIO graph with {} root dependencies",
+                                identifier, isolatedShadedGraph.getRootDependencies().size());
+
+                        shadedSubTreeCache.put(gavKey, isolatedShadedGraph);
+                    } else {
+                        logger.debug("Cache hit for shaded dependency sub-tree: {}", gavKey);
+                    }
+
+                    ExternalId shadedDepExternalId = externalIdFactory.createMavenExternalId(groupId, artifactId, version);
+                    Dependency shadedDependencyNode = new Dependency(artifactId, version, shadedDepExternalId);
+                    mainGraph.addChildWithParent(shadedDependencyNode, parentDependency);
+                    graftedNodeCount++;
+                    logger.debug("Added shaded dependency node {} under parent {}", identifier, parentArtifact.getArtifactId());
+
+                    // TODO: [Graph Intersection] Cross-reference isolatedShadedGraph nodes against
+                    // the physical shadedDepsMap to filter out transitives excluded by shade plugin config.
+                    int nodesAdded = graftSubGraph(isolatedShadedGraph, mainGraph, shadedDependencyNode);
+                    graftedNodeCount += nodesAdded;
+                    logger.debug("Grafted {} transitive nodes from shaded dependency {} under {}",
+                            nodesAdded, identifier, identifier);
+
+                } catch (Exception e) {
+                    logger.error("Failed to resolve and graft sub-tree for shaded dependency: {} - Error: {}",
+                            shadedDep.getIdentifier(), e.getMessage());
+                    logger.debug("Stack trace for shaded dependency resolution failure:", e);
+                }
+            }
+        }
+
+        logger.debug("Total grafted node count for this graph: {}", graftedNodeCount);
+        return graftedNodeCount;
+    }
+
+    private int graftSubGraph(DependencyGraph sourceGraph, DependencyGraph destGraph, Dependency destParent) {
+        int count = 0;
+
+        Set<Dependency> sourceRoots = sourceGraph.getRootDependencies();
+        if (sourceRoots == null || sourceRoots.isEmpty()) {
+            logger.debug("Source graph has no root dependencies to graft");
+            return count;
+        }
+
+        logger.debug("Grafting {} root dependencies under parent: {}", sourceRoots.size(), destParent.getName());
+
+        Set<ExternalId> visitedNodes = new HashSet<>();
+
+        for (Dependency sourceRoot : sourceRoots) {
+            destGraph.addChildWithParent(sourceRoot, destParent);
+            count++;
+
+            count += copyGraphEdges(sourceGraph, destGraph, sourceRoot, visitedNodes);
+        }
+
+        return count;
+    }
+
+    private int copyGraphEdges(DependencyGraph sourceGraph, DependencyGraph destGraph,
+                               Dependency currentParent, Set<ExternalId> visitedNodes) {
+        int count = 0;
+
+        ExternalId currentId = currentParent.getExternalId();
+        if (currentId != null && visitedNodes.contains(currentId)) {
+            logger.warn("Cycle detected in dependency graph at node: {}:{}:{}. Skipping to prevent infinite recursion.",
+                    currentId.getGroup(), currentId.getName(), currentId.getVersion());
+            return count;
+        }
+
+        if (currentId != null) {
+            visitedNodes.add(currentId);
+        }
+
+        try {
+            Set<Dependency> children = sourceGraph.getChildrenForParent(currentParent);
+
+            if (children == null || children.isEmpty()) {
+                return count;
+            }
+
+            for (Dependency child : children) {
+                ExternalId childId = child.getExternalId();
+                if (childId != null && visitedNodes.contains(childId)) {
+                    logger.warn("Cycle detected: {} already visited in current path. Skipping child to prevent infinite loop.",
+                            childId.getGroup() + ":" + childId.getName() + ":" + childId.getVersion());
+                    continue;
+                }
+
+                destGraph.addChildWithParent(child, currentParent);
+                count++;
+                logger.trace("Copied edge: {} -> {}", currentParent.getName(), child.getName());
+
+                count += copyGraphEdges(sourceGraph, destGraph, child, visitedNodes);
+            }
+        } finally {
+            if (currentId != null) {
+                visitedNodes.remove(currentId);
+            }
+        }
+
+        return count;
+    }
+
+    // ==========================================
+    // Utilities
+    // ==========================================
+
+    private String formatArtifactGav(Artifact artifact) {
+        return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion();
+    }
+
+    private void buildAetherDirectChildrenMap(DependencyNode node, Map<String, Set<String>> map) {
+        if (node == null || node.getDependency() == null || node.getDependency().getArtifact() == null) {
+            return;
+        }
+
+        Artifact artifact = node.getDependency().getArtifact();
+        String ga = artifact.getGroupId() + ":" + artifact.getArtifactId();
+
+        Set<String> childrenGavs = new HashSet<>();
+        if (node.getChildren() != null) {
+            for (DependencyNode child : node.getChildren()) {
+                if (child.getDependency() != null && child.getDependency().getArtifact() != null) {
+                    Artifact childArtifact = child.getDependency().getArtifact();
+                    childrenGavs.add(childArtifact.getGroupId() + ":" +
+                            childArtifact.getArtifactId() + ":" +
+                            childArtifact.getVersion());
+                }
+            }
+        }
+
+        if (!map.containsKey(ga)) {
+            map.put(ga, childrenGavs);
+        }
+
+        if (node.getChildren() != null) {
+            for (DependencyNode child : node.getChildren()) {
+                buildAetherDirectChildrenMap(child, map);
+            }
+        }
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ShadedDependencyScanner.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ShadedDependencyScanner.java
@@ -21,6 +21,8 @@ import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinsp
 import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.methods.DeltaAnalysisInspector;
 import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.methods.RecursiveMetadataInspector;
 import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.DiscoveredDependency;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.ShadePluginConfig;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.util.ShadePluginConfigExtractor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.eclipse.aether.artifact.Artifact;
@@ -347,9 +349,27 @@ public class ShadedDependencyScanner {
                 continue;
             }
 
+            // Extract shade plugin config from the JAR's embedded pom.xml before creating inspectors.
+            // This provides the explicit <artifactSet><excludes> and <relocations> data needed for
+            // the relocation-aware ghost filter. Both inspectors receive the same config instance.
+            ShadePluginConfig shadePluginConfig = null;
+            try (JarFile configJar = new JarFile(jarPath.toFile())) {
+                shadePluginConfig = ShadePluginConfigExtractor.extract(configJar, artifact);
+                if (shadePluginConfig != null) {
+                    logger.debug("Extracted ShadePluginConfig for {}: {} exclusion(s), {} relocation(s)",
+                            artifactGav,
+                            shadePluginConfig.getExcludedGavPatterns().size(),
+                            shadePluginConfig.getRelocatedPackagePrefixes().size());
+                } else {
+                    logger.debug("No ShadePluginConfig available for {} — inspectors will use legacy class-path fallback", artifactGav);
+                }
+            } catch (Exception e) {
+                logger.debug("Could not extract ShadePluginConfig for {}: {}", artifactGav, e.getMessage());
+            }
+
             List<ShadedDependencyInspector> inspectors = new ArrayList<>();
-            inspectors.add(new DeltaAnalysisInspector(aetherDirectChildrenByGa, projectBuilder, artifact));
-            inspectors.add(new RecursiveMetadataInspector(artifact));
+            inspectors.add(new DeltaAnalysisInspector(aetherDirectChildrenByGa, projectBuilder, artifact, shadePluginConfig));
+            inspectors.add(new RecursiveMetadataInspector(artifact, shadePluginConfig));
             logger.debug("Created {} inspector(s) for artifact: {}", inspectors.size(), artifactGav);
 
             try {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ShadedDependencyScanner.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/ShadedDependencyScanner.java
@@ -10,6 +10,7 @@ import com.blackduck.integration.detectable.detectables.maven.resolver.graph.Mav
 import com.blackduck.integration.detectable.detectables.maven.resolver.graph.MavenGraphTransformer;
 import com.blackduck.integration.detectable.detectables.maven.resolver.graph.MavenParseResult;
 import com.blackduck.integration.detectable.detectables.maven.resolver.mavendownload.MavenDownloader;
+import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorConfig;
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXml;
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXmlPlugin;
 import com.blackduck.integration.detectable.detectables.maven.resolver.pom.MavenProject;
@@ -176,14 +177,15 @@ public class ShadedDependencyScanner {
                 File downloadDirFile = downloadDir.toFile();
                 File localRepoFile = localRepoPath.toFile();
                 List<JavaRepository> repos = repositories != null ? repositories : new ArrayList<>();
+                List<MavenMirrorConfig> mirrorConfigs = options != null ? options.getMirrorConfigurations() : Collections.emptyList();
 
                 int addedToCompile = addShadedDependenciesToGraph(
-                        compileGraph, shadedDepsMap, downloadDirFile, localRepoFile, repos, shadedSubTreeCache);
+                        compileGraph, shadedDepsMap, downloadDirFile, localRepoFile, repos, shadedSubTreeCache, mirrorConfigs);
                 logger.info("Grafted {} shaded dependency nodes into compile graph", addedToCompile);
 
                 if (testGraph != null) {
                     int addedToTest = addShadedDependenciesToGraph(
-                            testGraph, shadedDepsMap, downloadDirFile, localRepoFile, repos, shadedSubTreeCache);
+                            testGraph, shadedDepsMap, downloadDirFile, localRepoFile, repos, shadedSubTreeCache, mirrorConfigs);
                     logger.info("Grafted {} shaded dependency nodes into test graph", addedToTest);
                 }
             } finally {
@@ -450,7 +452,8 @@ public class ShadedDependencyScanner {
             File downloadDir,
             File localRepoPath,
             List<JavaRepository> repositories,
-            Map<String, DependencyGraph> shadedSubTreeCache) {
+            Map<String, DependencyGraph> shadedSubTreeCache,
+            List<MavenMirrorConfig> mirrorConfigs) {
 
         int graftedNodeCount = 0;
 
@@ -505,7 +508,7 @@ public class ShadedDependencyScanner {
                         logger.debug("Resolving sub-tree for shaded dependency: {}", identifier);
 
                         JavaCoordinates coords = new JavaCoordinates(groupId, artifactId, version, "pom");
-                        MavenDownloader downloader = new MavenDownloader(repositories, downloadDir.toPath());
+                        MavenDownloader downloader = new MavenDownloader(repositories, downloadDir.toPath(), mirrorConfigs);
                         File shadedPomFile = downloader.downloadPom(coords);
 
                         if (shadedPomFile == null || !shadedPomFile.exists()) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/ArtifactCoordinate.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/ArtifactCoordinate.java
@@ -1,0 +1,215 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import org.eclipse.aether.artifact.Artifact;
+
+import java.util.Objects;
+
+/**
+ * Immutable representation of Maven artifact coordinates including classifier support.
+ * Single Responsibility: Encapsulate artifact identity with classifier awareness.
+ */
+public class ArtifactCoordinate {
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+    private final String classifier;
+    private final String extension;
+
+    /**
+     * Creates an artifact coordinate from an Aether artifact.
+     */
+    public static ArtifactCoordinate fromAetherArtifact(Artifact artifact) {
+        if (artifact == null) {
+            throw new IllegalArgumentException("Artifact cannot be null");
+        }
+
+        return new ArtifactCoordinate(
+            artifact.getGroupId(),
+            artifact.getArtifactId(),
+            artifact.getVersion(),
+            artifact.getClassifier(),
+            artifact.getExtension()
+        );
+    }
+
+    /**
+     * Creates an artifact coordinate.
+     *
+     * @param groupId The group ID (required)
+     * @param artifactId The artifact ID (required)
+     * @param version The version (required)
+     * @param classifier The classifier (optional, can be null or empty)
+     * @param extension The file extension (optional, defaults to "jar")
+     */
+    public ArtifactCoordinate(String groupId, String artifactId, String version,
+                             String classifier, String extension) {
+        this.groupId = validateRequired(groupId, "groupId");
+        this.artifactId = validateRequired(artifactId, "artifactId");
+        this.version = validateRequired(version, "version");
+        this.classifier = normalizeClassifier(classifier);
+        this.extension = normalizeExtension(extension);
+
+        // Security: validate classifier doesn't contain path separators
+        if (this.classifier != null && containsPathSeparator(this.classifier)) {
+            throw new IllegalArgumentException(
+                "Classifier contains illegal characters: " + this.classifier
+            );
+        }
+    }
+
+    private String validateRequired(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " cannot be null or empty");
+        }
+        return value.trim();
+    }
+
+    private String normalizeClassifier(String classifier) {
+        if (classifier == null || classifier.trim().isEmpty()) {
+            return null;
+        }
+        return classifier.trim();
+    }
+
+    private String normalizeExtension(String extension) {
+        if (extension == null || extension.trim().isEmpty()) {
+            return "jar";
+        }
+        return extension.trim();
+    }
+
+    private boolean containsPathSeparator(String value) {
+        return value.contains("/") || value.contains("\\") ||
+               value.contains("..") || value.contains(":") ||
+               value.contains("*") || value.contains("?");
+    }
+
+    /**
+     * Returns the Maven coordinates string (GAV or GAVC).
+     *
+     * @return Formatted string like "group:artifact:version" or "group:artifact:version:classifier"
+     */
+    public String toCoordinateString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(groupId).append(":");
+        sb.append(artifactId).append(":");
+        sb.append(version);
+
+        if (classifier != null) {
+            sb.append(":").append(classifier);
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns the artifact filename.
+     *
+     * @return Filename like "artifact-version.jar" or "artifact-version-classifier.jar"
+     */
+    public String toFileName() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(artifactId);
+        sb.append("-");
+        sb.append(version);
+
+        if (classifier != null) {
+            sb.append("-");
+            sb.append(classifier);
+        }
+
+        sb.append(".");
+        sb.append(extension);
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns the Maven repository path for this artifact.
+     *
+     * @return Path like "com/example/artifact/1.0/artifact-1.0.jar"
+     */
+    public String toRepositoryPath() {
+        String groupPath = groupId.replace('.', '/');
+        return groupPath + "/" + artifactId + "/" + version + "/" + toFileName();
+    }
+
+    /**
+     * Checks if this coordinate matches another, considering classifier.
+     *
+     * @param other The other coordinate to compare
+     * @return true if all components match exactly
+     */
+    public boolean matches(ArtifactCoordinate other) {
+        if (other == null) {
+            return false;
+        }
+
+        return Objects.equals(groupId, other.groupId) &&
+               Objects.equals(artifactId, other.artifactId) &&
+               Objects.equals(version, other.version) &&
+               Objects.equals(classifier, other.classifier) &&
+               Objects.equals(extension, other.extension);
+    }
+
+    /**
+     * Checks if this coordinate matches the base coordinates (ignoring classifier).
+     *
+     * @param other The other coordinate to compare
+     * @return true if GAV matches (classifier ignored)
+     */
+    public boolean matchesBase(ArtifactCoordinate other) {
+        if (other == null) {
+            return false;
+        }
+
+        return Objects.equals(groupId, other.groupId) &&
+               Objects.equals(artifactId, other.artifactId) &&
+               Objects.equals(version, other.version);
+    }
+
+    // Getters
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getClassifier() {
+        return classifier;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public boolean hasClassifier() {
+        return classifier != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ArtifactCoordinate that = (ArtifactCoordinate) o;
+        return matches(that);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, version, classifier, extension);
+    }
+
+    @Override
+    public String toString() {
+        return toCoordinateString();
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/DiskSpaceChecker.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/DiskSpaceChecker.java
@@ -1,0 +1,63 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Checks available disk space before downloads.
+ */
+public class DiskSpaceChecker {
+    private static final Logger logger = LoggerFactory.getLogger(DiskSpaceChecker.class);
+    private static final long SAFETY_MARGIN_BYTES = 100 * 1024 * 1024; // 100 MB safety margin
+
+    public static class DiskSpaceCheckResult {
+        private final boolean hasEnoughSpace;
+        private final long availableBytes;
+        private final long requiredBytes;
+
+        public DiskSpaceCheckResult(boolean hasEnoughSpace, long availableBytes, long requiredBytes) {
+            this.hasEnoughSpace = hasEnoughSpace;
+            this.availableBytes = availableBytes;
+            this.requiredBytes = requiredBytes;
+        }
+
+        public boolean hasEnoughSpace() {
+            return hasEnoughSpace;
+        }
+
+        public long getAvailableBytes() {
+            return availableBytes;
+        }
+
+        public long getRequiredBytes() {
+            return requiredBytes;
+        }
+    }
+
+    public DiskSpaceCheckResult checkAvailableSpace(Path targetPath, long requiredBytes, long startOffset) {
+        try {
+            FileStore fileStore = Files.getFileStore(targetPath.getParent());
+            long availableBytes = fileStore.getUsableSpace();
+            long bytesNeeded = requiredBytes - startOffset + SAFETY_MARGIN_BYTES;
+
+            boolean hasEnough = availableBytes >= bytesNeeded;
+
+            if (!hasEnough) {
+                logger.warn("Insufficient disk space: available={} KB, required={} KB",
+                    availableBytes / 1024, bytesNeeded / 1024);
+            }
+
+            return new DiskSpaceCheckResult(hasEnough, availableBytes, bytesNeeded);
+
+        } catch (IOException e) {
+            logger.debug("Could not check disk space: {}", e.getMessage());
+            // Assume enough space if we can't check
+            return new DiskSpaceCheckResult(true, -1, requiredBytes);
+        }
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/DownloadConfiguration.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/DownloadConfiguration.java
@@ -1,0 +1,214 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unified configuration for artifact downloads.
+ * Single Responsibility: Encapsulate HTTP and retry settings for downloads.
+ * Open/Closed: Extend via composition with RetryPolicy; sealed against modification.
+ *
+ * <p>This class consolidates all download-related configuration:
+ * <ul>
+ *   <li>HTTP connection settings (connect/read timeouts)</li>
+ *   <li>Retry policy (max retries, backoff delays)</li>
+ * </ul>
+ */
+public final class DownloadConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(DownloadConfiguration.class);
+
+    // Default values matching previous MavenDownloadConstants
+    private static final int DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+    private static final int DEFAULT_READ_TIMEOUT_MS = 60_000;
+    private static final int DEFAULT_MAX_RETRIES = 3;
+    private static final long DEFAULT_RETRY_BACKOFF_INITIAL_MS = 1_000L;
+    private static final long DEFAULT_RETRY_BACKOFF_MAX_MS = 30_000L;
+    private static final int DEFAULT_DOWNLOAD_THREADS = 4;
+
+    // Validation bounds
+    private static final int MAX_TIMEOUT_MS = 600_000; // 10 minutes max
+    private static final int MIN_TIMEOUT_MS = 1;
+
+    private final int connectTimeoutMs;
+    private final int readTimeoutMs;
+    private final int downloadThreads;
+    private final RetryPolicy retryPolicy;
+
+    /**
+     * Private constructor - use builder or factory methods.
+     */
+    private DownloadConfiguration(int connectTimeoutMs, int readTimeoutMs, int downloadThreads, RetryPolicy retryPolicy) {
+        this.connectTimeoutMs = connectTimeoutMs;
+        this.readTimeoutMs = readTimeoutMs;
+        this.downloadThreads = downloadThreads;
+        this.retryPolicy = retryPolicy;
+    }
+
+    /**
+     * Creates default configuration with sensible defaults.
+     * These values are tuned to work across a wide range of network environments.
+     *
+     * @return Default download configuration
+     */
+    public static DownloadConfiguration createDefault() {
+        return new Builder().build();
+    }
+
+    /**
+     * Creates configuration from legacy parameters for backward compatibility.
+     *
+     * @param maxRetries Maximum retry attempts
+     * @param retryDelayMs Initial retry delay in milliseconds
+     * @param connectTimeoutMs Connection timeout in milliseconds
+     * @param readTimeoutMs Read timeout in milliseconds
+     * @return Download configuration
+     * @deprecated Use {@link Builder} instead for new code
+     */
+    @Deprecated
+    public static DownloadConfiguration fromLegacy(int maxRetries, int retryDelayMs, int connectTimeoutMs, int readTimeoutMs) {
+        return new Builder()
+            .connectTimeoutMs(connectTimeoutMs)
+            .readTimeoutMs(readTimeoutMs)
+            .retryPolicy(new RetryPolicy(maxRetries, (long) retryDelayMs, DEFAULT_RETRY_BACKOFF_MAX_MS))
+            .build();
+    }
+
+    /**
+     * Creates configuration from optional user properties.
+     * Falls back to defaults for null or invalid values.
+     *
+     * @param connectTimeout Optional connection timeout
+     * @param readTimeout Optional read timeout
+     * @return Download configuration
+     */
+    public static DownloadConfiguration fromProperties(Integer connectTimeout, Integer readTimeout) {
+        Builder builder = new Builder();
+        if (connectTimeout != null && connectTimeout > 0) {
+            builder.connectTimeoutMs(connectTimeout);
+        }
+        if (readTimeout != null && readTimeout > 0) {
+            builder.readTimeoutMs(readTimeout);
+        }
+        return builder.build();
+    }
+
+    // Getters
+
+    public int getConnectTimeoutMs() {
+        return connectTimeoutMs;
+    }
+
+    public int getReadTimeoutMs() {
+        return readTimeoutMs;
+    }
+
+    public int getDownloadThreads() {
+        return downloadThreads;
+    }
+
+    public RetryPolicy getRetryPolicy() {
+        return retryPolicy;
+    }
+
+    /**
+     * Convenience method to get max retries from retry policy.
+     * @return Maximum retry attempts
+     */
+    public int getMaxRetries() {
+        return retryPolicy.getMaxRetries();
+    }
+
+    /**
+     * Convenience method to get initial backoff from retry policy.
+     * @return Initial retry delay in milliseconds
+     * @deprecated Use {@link #getRetryPolicy()} and call its methods directly
+     */
+    @Deprecated
+    public int getRetryDelayMs() {
+        return (int) retryPolicy.getInitialBackoffMs();
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "DownloadConfiguration{connectTimeout=%dms, readTimeout=%dms, threads=%d, maxRetries=%d, initialBackoff=%dms, maxBackoff=%dms}",
+            connectTimeoutMs, readTimeoutMs, downloadThreads,
+            retryPolicy.getMaxRetries(), retryPolicy.getInitialBackoffMs(), retryPolicy.getMaxBackoffMs()
+        );
+    }
+
+    /**
+     * Builder for DownloadConfiguration.
+     * Allows flexible configuration while maintaining immutability of the result.
+     */
+    public static final class Builder {
+        private int connectTimeoutMs = DEFAULT_CONNECT_TIMEOUT_MS;
+        private int readTimeoutMs = DEFAULT_READ_TIMEOUT_MS;
+        private int downloadThreads = DEFAULT_DOWNLOAD_THREADS;
+        private RetryPolicy retryPolicy;
+
+        public Builder() {
+            // Default retry policy
+            this.retryPolicy = new RetryPolicy(
+                DEFAULT_MAX_RETRIES,
+                DEFAULT_RETRY_BACKOFF_INITIAL_MS,
+                DEFAULT_RETRY_BACKOFF_MAX_MS
+            );
+        }
+
+        public Builder connectTimeoutMs(int connectTimeoutMs) {
+            this.connectTimeoutMs = validateTimeout("connect timeout", connectTimeoutMs);
+            return this;
+        }
+
+        public Builder readTimeoutMs(int readTimeoutMs) {
+            this.readTimeoutMs = validateTimeout("read timeout", readTimeoutMs);
+            return this;
+        }
+
+        public Builder downloadThreads(int downloadThreads) {
+            if (downloadThreads < 1) {
+                logger.warn("Download threads must be at least 1, got {}. Using 1.", downloadThreads);
+                this.downloadThreads = 1;
+            } else if (downloadThreads > 20) {
+                logger.warn("Download threads {} exceeds maximum (20). Using 20.", downloadThreads);
+                this.downloadThreads = 20;
+            } else {
+                this.downloadThreads = downloadThreads;
+            }
+            return this;
+        }
+
+        public Builder retryPolicy(RetryPolicy retryPolicy) {
+            this.retryPolicy = retryPolicy != null ? retryPolicy : RetryPolicy.defaultPolicy();
+            return this;
+        }
+
+        /**
+         * Convenience method to configure retries inline.
+         */
+        public Builder retries(int maxRetries, long initialBackoffMs, long maxBackoffMs) {
+            this.retryPolicy = new RetryPolicy(maxRetries, initialBackoffMs, maxBackoffMs);
+            return this;
+        }
+
+        public DownloadConfiguration build() {
+            logger.debug("Building DownloadConfiguration: connectTimeout={}ms, readTimeout={}ms, threads={}, retryPolicy={}",
+                connectTimeoutMs, readTimeoutMs, downloadThreads, retryPolicy);
+            return new DownloadConfiguration(connectTimeoutMs, readTimeoutMs, downloadThreads, retryPolicy);
+        }
+
+        private int validateTimeout(String name, int value) {
+            if (value < MIN_TIMEOUT_MS) {
+                logger.warn("{} must be positive, got {}. Using {}ms.", name, value, MIN_TIMEOUT_MS);
+                return MIN_TIMEOUT_MS;
+            }
+            if (value > MAX_TIMEOUT_MS) {
+                logger.warn("{} {}ms exceeds maximum ({}ms). Using maximum.", name, value, MAX_TIMEOUT_MS);
+                return MAX_TIMEOUT_MS;
+            }
+            return value;
+        }
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/DownloadResult.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/DownloadResult.java
@@ -1,0 +1,82 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import java.nio.file.Path;
+
+/**
+ * Represents the result of an artifact download attempt.
+ *
+ * <p>Three possible states:
+ * <ul>
+ *   <li><strong>Success:</strong> {@code isSuccess() == true} - artifact downloaded/found</li>
+ *   <li><strong>Not Found:</strong> {@code isNotFound() == true} - 404, artifact doesn't exist (not an error)</li>
+ *   <li><strong>Failure:</strong> {@code isSuccess() == false && isNotFound() == false} - actual error occurred</li>
+ * </ul>
+ */
+public class DownloadResult {
+    private final boolean success;
+    private final boolean notFound;
+    private final String source;
+    private final Path downloadedPath;
+    private final String errorMessage;
+
+    private DownloadResult(boolean success, boolean notFound, String source, Path downloadedPath, String errorMessage) {
+        this.success = success;
+        this.notFound = notFound;
+        this.source = source;
+        this.downloadedPath = downloadedPath;
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * Creates a successful download result.
+     *
+     * @param source The source where the artifact was found (e.g., "maven-central", "home-m2-repository")
+     * @param downloadedPath The path to the downloaded/located artifact
+     * @return A success result
+     */
+    public static DownloadResult success(String source, Path downloadedPath) {
+        return new DownloadResult(true, false, source, downloadedPath, null);
+    }
+
+    /**
+     * Creates a not-found result (404 - artifact doesn't exist in repository).
+     * This is NOT an error - the artifact simply isn't available.
+     *
+     * @param message Description of what was not found
+     * @return A not-found result
+     */
+    public static DownloadResult notFound(String message) {
+        return new DownloadResult(false, true, null, null, message);
+    }
+
+    /**
+     * Creates a failure result (actual error during download).
+     *
+     * @param errorMessage Description of the error
+     * @return A failure result
+     */
+    public static DownloadResult failure(String errorMessage) {
+        return new DownloadResult(false, false, null, null, errorMessage);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public boolean isNotFound() {
+        return notFound;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public Path getDownloadedPath() {
+        return downloadedPath;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/FallbackRepositoryDownloader.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/FallbackRepositoryDownloader.java
@@ -1,0 +1,43 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.exception.ArtifactDownloadException;
+import org.eclipse.aether.artifact.Artifact;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+
+/**
+ * Fallback downloader used as the last-resort tier in JAR resolution.
+ *
+ * <p>By default, delegates to Maven Central. When a mirror is configured
+ * (e.g., a corporate Nexus/Artifactory instance matching {@code central}
+ * or {@code *}), the mirror URL and optional credentials are used instead.
+ */
+public class FallbackRepositoryDownloader implements HttpArtifactDownloader {
+    private static final String MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2";
+    private final RemoteRepositoryDownloader delegate;
+
+    /**
+     * Creates a fallback downloader pointing to Maven Central (no mirror).
+     */
+    public FallbackRepositoryDownloader() {
+        this.delegate = new RemoteRepositoryDownloader(MAVEN_CENTRAL_URL);
+    }
+
+    /**
+     * Creates a fallback downloader pointing to a mirror URL with optional authentication.
+     *
+     * @param mirrorUrl The mirror repository URL to use instead of Maven Central
+     * @param username  Optional authentication username (may be null)
+     * @param password  Optional authentication password (may be null)
+     */
+    public FallbackRepositoryDownloader(String mirrorUrl, @Nullable String username, @Nullable String password) {
+        this.delegate = new RemoteRepositoryDownloader(mirrorUrl, username, password);
+    }
+
+    @Override
+    public DownloadResult download(Artifact artifact, Path targetPath, DownloadConfiguration configuration)
+            throws ArtifactDownloadException {
+        return delegate.download(artifact, targetPath, configuration);
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/HttpArtifactDownloader.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/HttpArtifactDownloader.java
@@ -1,0 +1,26 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.exception.ArtifactDownloadException;
+import org.eclipse.aether.artifact.Artifact;
+
+import java.nio.file.Path;
+
+/**
+ * Interface for downloading Maven artifacts via HTTP.
+ * Interface Segregation Principle: Focused interface for HTTP downloads only.
+ */
+
+public interface HttpArtifactDownloader {
+
+    /**
+     * Downloads an artifact from a Maven repository.
+     *
+     * @param artifact The artifact to download
+     * @param targetPath The path where the artifact should be saved
+     * @param configuration Download configuration including timeouts and retry policy
+     * @return The result of the download operation
+     * @throws ArtifactDownloadException if download fails
+     */
+    DownloadResult download(Artifact artifact, Path targetPath, DownloadConfiguration configuration)
+        throws ArtifactDownloadException;
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/LocalRepositoryChecker.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/LocalRepositoryChecker.java
@@ -1,0 +1,235 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Checks for artifact existence in local Maven repositories with validation.
+ * Single Responsibility: Local artifact resolution without downloads.
+ */
+public class LocalRepositoryChecker {
+
+    private static final Logger logger = LoggerFactory.getLogger(LocalRepositoryChecker.class);
+
+    // JAR/ZIP magic bytes: PK.. (0x50 0x4B 0x03 0x04)
+    private static final byte[] JAR_MAGIC_BYTES = new byte[] { 0x50, 0x4B, 0x03, 0x04 };
+    private static final int MIN_JAR_SIZE_BYTES = 22; // Minimum valid ZIP file size (empty ZIP)
+
+    /**
+     * Resolves the home .m2 repository path (~/.m2/repository).
+     *
+     * @return Path to home .m2 repository, or null if not found
+     */
+    public Path resolveHomeM2Repository() {
+        String userHome = System.getProperty("user.home");
+        if (userHome != null) {
+            Path homeM2 = Paths.get(userHome, ".m2", "repository");
+            if (Files.isDirectory(homeM2)) {
+                logger.debug("Found home .m2 repository: {}", homeM2);
+                return homeM2;
+            }
+        }
+        logger.debug("Home .m2 repository not found");
+        return null;
+    }
+
+    /**
+     * Checks if an artifact exists in a custom repository path.
+     *
+     * @param artifact The artifact to check
+     * @param customPath The custom repository path (can be file or directory)
+     * @return The path to the artifact if found and valid, null otherwise
+     */
+    public Path checkCustomRepository(Artifact artifact, Path customPath) {
+        if (customPath == null) {
+            return null;
+        }
+
+        ArtifactCoordinate coordinate = ArtifactCoordinate.fromAetherArtifact(artifact);
+        logger.debug("[Custom Repository Check] Looking for artifact: {}", coordinate.toCoordinateString());
+
+        // Check if custom path points directly to a JAR file
+        if (Files.isRegularFile(customPath)) {
+            return checkDirectJarFile(coordinate, customPath);
+        }
+
+        // Treat as repository directory
+        if (Files.isDirectory(customPath)) {
+            return checkRepositoryDirectory(coordinate, customPath, "custom");
+        }
+
+        logger.warn("Custom repository path is neither a file nor directory: {}", customPath);
+        return null;
+    }
+
+    /**
+     * Checks if an artifact exists in the default Maven repository.
+     *
+     * @param artifact The artifact to check
+     * @param defaultPath The default repository path (~/.m2/repository)
+     * @return The path to the artifact if found and valid, null otherwise
+     */
+    public Path checkDefaultRepository(Artifact artifact, Path defaultPath) {
+        if (defaultPath == null || !Files.isDirectory(defaultPath)) {
+            return null;
+        }
+
+        ArtifactCoordinate coordinate = ArtifactCoordinate.fromAetherArtifact(artifact);
+        logger.debug("[Default Repository Check] Looking for artifact: {}", coordinate.toCoordinateString());
+
+        return checkRepositoryDirectory(coordinate, defaultPath, "default");
+    }
+
+    /**
+     * Checks if an artifact exists in a repository path (generic).
+     *
+     * @param artifact The artifact to check
+     * @param repositoryPath The repository path
+     * @param repoName Human-readable name for logging
+     * @return The path to the artifact if found and valid, null otherwise
+     */
+    public Path checkRepository(Artifact artifact, Path repositoryPath, String repoName) {
+        if (repositoryPath == null || !Files.isDirectory(repositoryPath)) {
+            return null;
+        }
+
+        ArtifactCoordinate coordinate = ArtifactCoordinate.fromAetherArtifact(artifact);
+        logger.debug("[{} Repository Check] Looking for artifact: {}", repoName, coordinate.toCoordinateString());
+
+        return checkRepositoryDirectory(coordinate, repositoryPath, repoName);
+    }
+
+    /**
+     * Builds the expected JAR path within a Maven repository using standard layout.
+     *
+     * @param artifact The artifact
+     * @param repositoryRoot The repository root path
+     * @return Path to the expected JAR location
+     */
+    public Path buildJarPath(Artifact artifact, Path repositoryRoot) {
+        ArtifactCoordinate coordinate = ArtifactCoordinate.fromAetherArtifact(artifact);
+        return buildRepositoryJarPath(coordinate, repositoryRoot);
+    }
+
+    private Path checkDirectJarFile(ArtifactCoordinate coordinate, Path jarPath) {
+        String expectedFileName = coordinate.toFileName();
+        String actualFileName = jarPath.getFileName().toString();
+
+        if (actualFileName.equals(expectedFileName)) {
+            if (isValidJarFile(jarPath)) {
+                long fileSize = getFileSizeKb(jarPath);
+                logger.info(" FOUND direct JAR file ({}KB)", fileSize);
+                logger.debug("File: {}", jarPath);
+                return jarPath;
+            }
+            logger.warn("JAR file found but is invalid (corrupt or too small): {}", jarPath);
+            return null;
+        } else {
+            logger.warn("JAR filename mismatch in custom repository!");
+            logger.warn("  Artifact: {}", coordinate.toCoordinateString());
+            logger.warn("  Expected filename: {}", expectedFileName);
+            logger.warn("  Actual filename: {}", actualFileName);
+            return null;
+        }
+    }
+
+    private Path checkRepositoryDirectory(ArtifactCoordinate coordinate, Path repositoryPath, String repoType) {
+        Path jarPath = buildRepositoryJarPath(coordinate, repositoryPath);
+        String artifactId = coordinate.toCoordinateString();
+
+        logger.debug("Checking {} repository for: {}", repoType, jarPath);
+
+        if (Files.exists(jarPath)) {
+            if (!Files.isReadable(jarPath)) {
+                logger.warn("JAR exists but is not readable in {} repository: {}", repoType, jarPath);
+                return null;
+            }
+
+            if (!isValidJarFile(jarPath)) {
+                logger.warn("JAR exists but is invalid (corrupt or too small) in {} repository: {}", repoType, jarPath);
+                return null;
+            }
+
+            long fileSize = getFileSizeKb(jarPath);
+            logger.info("FOUND in {} repository ({}KB): {}", repoType, fileSize, artifactId);
+            return jarPath;
+        }
+
+        logger.debug("NOT FOUND in {} repository: {}", repoType, artifactId);
+        return null;
+    }
+
+    /**
+     * Validates that a file is a valid JAR (checks size and magic bytes).
+     *
+     * @param jarPath Path to the file to validate
+     * @return true if file is a valid JAR, false otherwise
+     */
+    public boolean isValidJarFile(Path jarPath) {
+        if (jarPath == null || !Files.exists(jarPath) || !Files.isRegularFile(jarPath)) {
+            return false;
+        }
+
+        try {
+            long fileSize = Files.size(jarPath);
+            if (fileSize < MIN_JAR_SIZE_BYTES) {
+                logger.trace("File too small to be valid JAR: {} bytes", fileSize);
+                return false;
+            }
+        } catch (IOException e) {
+            logger.trace("Cannot read file size: {}", e.getMessage());
+            return false;
+        }
+
+        return verifyJarMagicBytes(jarPath);
+    }
+
+    /**
+     * Verifies that a file has valid JAR/ZIP magic bytes (PK..).
+     */
+    private boolean verifyJarMagicBytes(Path filePath) {
+        try (FileInputStream fis = new FileInputStream(filePath.toFile())) {
+            byte[] header = new byte[4];
+            int bytesRead = fis.read(header);
+
+            if (bytesRead < 4) {
+                return false;
+            }
+
+            return header[0] == JAR_MAGIC_BYTES[0] &&
+                   header[1] == JAR_MAGIC_BYTES[1] &&
+                   header[2] == JAR_MAGIC_BYTES[2] &&
+                   header[3] == JAR_MAGIC_BYTES[3];
+
+        } catch (IOException e) {
+            logger.trace("Failed to read file header: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private Path buildRepositoryJarPath(ArtifactCoordinate coordinate, Path repositoryPath) {
+        String[] pathParts = coordinate.toRepositoryPath().split("/");
+
+        Path result = repositoryPath;
+        for (String part : pathParts) {
+            result = result.resolve(part);
+        }
+
+        return result;
+    }
+
+    private long getFileSizeKb(Path path) {
+        try {
+            return Files.size(path) / 1024;
+        } catch (IOException e) {
+            return 0;
+        }
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/ParallelDownloadManager.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/ParallelDownloadManager.java
@@ -1,0 +1,595 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.exception.ArtifactDownloadException;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.JavaRepository;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.graph.Dependency;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Manages parallel downloads of Maven artifacts with controlled concurrency.
+ * Single Responsibility: Orchestrate concurrent artifact downloads safely.
+ */
+public class ParallelDownloadManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(ParallelDownloadManager.class);
+    private static final int DEFAULT_THREAD_COUNT = 5;
+    private static final int MAX_THREAD_COUNT = 20;
+    private static final int MIN_THREAD_COUNT = 1;
+
+    private final ExecutorService executorService;
+    private final LocalRepositoryChecker localChecker;
+    private final HttpArtifactDownloader httpDownloader;
+    private final int threadCount;
+
+    /**
+     * Result of a parallel download operation.
+     */
+    public static class ParallelDownloadResult {
+        private final int totalArtifacts;
+        private final int successCount;
+        private final int failureCount;
+        private final int skippedCount;
+        private final List<DownloadOutcome> outcomes;
+        private final long totalTimeMs;
+
+        public ParallelDownloadResult(int totalArtifacts, int successCount, int failureCount,
+                                     int skippedCount, List<DownloadOutcome> outcomes, long totalTimeMs) {
+            this.totalArtifacts = totalArtifacts;
+            this.successCount = successCount;
+            this.failureCount = failureCount;
+            this.skippedCount = skippedCount;
+            this.outcomes = new ArrayList<>(outcomes);
+            this.totalTimeMs = totalTimeMs;
+        }
+
+        public boolean isCompleteSuccess() {
+            return failureCount == 0;
+        }
+
+        public int getTotalArtifacts() { return totalArtifacts; }
+        public int getSuccessCount() { return successCount; }
+        public int getFailureCount() { return failureCount; }
+        public int getSkippedCount() { return skippedCount; }
+        public List<DownloadOutcome> getOutcomes() { return new ArrayList<>(outcomes); }
+        public long getTotalTimeMs() { return totalTimeMs; }
+    }
+
+    /**
+     * Outcome of a single artifact download.
+     */
+    public static class DownloadOutcome {
+        private final ArtifactCoordinate coordinate;
+        private final DownloadStatus status;
+        private final String source;
+        private final Path path;
+        private final String errorMessage;
+        private final ArtifactDownloadException exception;
+
+        public enum DownloadStatus {
+            SUCCESS,
+            FAILED,
+            SKIPPED_LOCAL,
+            SKIPPED_NOT_FOUND
+        }
+
+        private DownloadOutcome(ArtifactCoordinate coordinate, DownloadStatus status,
+                               String source, Path path, String errorMessage, ArtifactDownloadException exception) {
+            this.coordinate = coordinate;
+            this.status = status;
+            this.source = source;
+            this.path = path;
+            this.errorMessage = errorMessage;
+            this.exception = exception;
+        }
+
+        public static DownloadOutcome success(ArtifactCoordinate coordinate, String source, Path path) {
+            return new DownloadOutcome(coordinate, DownloadStatus.SUCCESS, source, path, null, null);
+        }
+
+        public static DownloadOutcome failed(ArtifactCoordinate coordinate, String errorMessage, ArtifactDownloadException exception) {
+            return new DownloadOutcome(coordinate, DownloadStatus.FAILED, null, null, errorMessage, exception);
+        }
+
+        public static DownloadOutcome skippedLocal(ArtifactCoordinate coordinate, String source, Path path) {
+            return new DownloadOutcome(coordinate, DownloadStatus.SKIPPED_LOCAL, source, path, null, null);
+        }
+
+        public static DownloadOutcome skippedNotFound(ArtifactCoordinate coordinate, String message) {
+            return new DownloadOutcome(coordinate, DownloadStatus.SKIPPED_NOT_FOUND, null, null, message, null);
+        }
+
+        public ArtifactCoordinate getCoordinate() { return coordinate; }
+        public DownloadStatus getStatus() { return status; }
+        public String getSource() { return source; }
+        public Path getPath() { return path; }
+        public String getErrorMessage() { return errorMessage; }
+        public ArtifactDownloadException getException() { return exception; }
+    }
+
+    /**
+     * Creates a parallel download manager with specified concurrency.
+     *
+     * @param threadCount Number of concurrent download threads (null for default)
+     * @param localChecker Local repository checker
+     * @param httpDownloader HTTP downloader implementation
+     */
+    public ParallelDownloadManager(Integer threadCount, LocalRepositoryChecker localChecker,
+                                  HttpArtifactDownloader httpDownloader) {
+        this.threadCount = validateThreadCount(threadCount);
+        this.localChecker = localChecker;
+        this.httpDownloader = httpDownloader;
+
+        // Create thread pool with custom thread factory for better naming
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r, "maven-download-" + threadNumber.getAndIncrement());
+                t.setDaemon(true);
+                return t;
+            }
+        };
+
+        this.executorService = new ThreadPoolExecutor(
+            this.threadCount,
+            this.threadCount,
+            60L, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            threadFactory,
+            new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+
+        logger.info("Parallel download manager initialized with {} threads", this.threadCount);
+    }
+
+    /**
+     * Downloads artifacts in parallel with controlled concurrency (backward compatibility).
+     * Uses only Tier-1 (local) and Tier-3 (Maven Central) resolution.
+     *
+     * @param dependencies List of dependencies to download
+     * @param customRepoPath Custom repository path (optional)
+     * @param defaultRepoPath Default repository path
+     * @param downloadConfig Download configuration
+     * @return Result containing download outcomes
+     */
+    public ParallelDownloadResult downloadArtifacts(
+            List<Dependency> dependencies,
+            Path customRepoPath,
+            Path defaultRepoPath,
+            DownloadConfiguration downloadConfig) {
+        return downloadArtifacts(dependencies, customRepoPath, null, defaultRepoPath,
+                                new ArrayList<>(), downloadConfig);
+    }
+
+    /**
+     * Downloads artifacts in parallel with 3-tier resolution support.
+     * Resolution order:
+     *   Tier-1: Local repositories (custom, then .m2)
+     *   Tier-2: POM-declared remote repositories
+     *   Tier-3: Maven Central as fallback
+     *
+     * @param dependencies List of dependencies to download
+     * @param customRepoPath Custom repository path (optional)
+     * @param homeM2RepoPath User's home ~/.m2/repository path (optional)
+     * @param defaultRepoPath Default repository path (download cache)
+     * @param pomRepositories List of POM-declared repositories (Tier-2)
+     * @param downloadConfig Download configuration
+     * @return Result containing download outcomes
+     */
+    public ParallelDownloadResult downloadArtifacts(
+            List<Dependency> dependencies,
+            Path customRepoPath,
+            Path homeM2RepoPath,
+            Path defaultRepoPath,
+            List<JavaRepository> pomRepositories,
+            DownloadConfiguration downloadConfig) {
+
+        Map<String, HttpArtifactDownloader> downloaders = new LinkedHashMap<>();
+        if (pomRepositories != null) {
+            for (JavaRepository repo : pomRepositories) {
+                if (repo.getUrl() != null && !repo.getUrl().isEmpty()) {
+                    downloaders.put(repo.getId(), new RemoteRepositoryDownloader(repo.getUrl()));
+                }
+            }
+        }
+        return downloadArtifacts(dependencies, customRepoPath, homeM2RepoPath, defaultRepoPath,
+                                 downloaders, downloadConfig);
+    }
+
+    /**
+     * Downloads artifacts in parallel with pre-built, mirror-aware downloaders for Tier-2 repos.
+     *
+     * @param dependencies List of dependencies to download
+     * @param customRepoPath Custom repository path (optional)
+     * @param homeM2RepoPath User's home ~/.m2/repository path (optional)
+     * @param defaultRepoPath Default repository path (download cache)
+     * @param pomRepoDownloaders Pre-built downloaders keyed by repo label (already mirror-redirected)
+     * @param downloadConfig Download configuration
+     * @return Result containing download outcomes
+     */
+    public ParallelDownloadResult downloadArtifacts(
+            List<Dependency> dependencies,
+            Path customRepoPath,
+            Path homeM2RepoPath,
+            Path defaultRepoPath,
+            Map<String, HttpArtifactDownloader> pomRepoDownloaders,
+            DownloadConfiguration downloadConfig) {
+
+        if (dependencies == null || dependencies.isEmpty()) {
+            return new ParallelDownloadResult(0, 0, 0, 0, new ArrayList<>(), 0);
+        }
+
+        logger.info("========================================");
+        logger.info("STARTING PARALLEL ARTIFACT DOWNLOAD");
+        logger.info("========================================");
+        logger.info("Total artifacts: {}", dependencies.size());
+        logger.info("Concurrent threads: {}", threadCount);
+        logger.info("POM repositories: {}", pomRepoDownloaders != null ? pomRepoDownloaders.size() : 0);
+
+        long startTime = System.currentTimeMillis();
+        List<DownloadOutcome> outcomes = new CopyOnWriteArrayList<>();
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        AtomicInteger skippedCount = new AtomicInteger(0);
+        AtomicBoolean cancelFlag = new AtomicBoolean(false);
+
+        // Create futures for all downloads
+        List<CompletableFuture<DownloadOutcome>> futures = new ArrayList<>();
+
+        for (Dependency dependency : dependencies) {
+            CompletableFuture<DownloadOutcome> future = CompletableFuture.supplyAsync(() -> {
+                // Check cancellation flag
+                if (cancelFlag.get()) {
+                    ArtifactCoordinate coord = ArtifactCoordinate.fromAetherArtifact(dependency.getArtifact());
+                    return DownloadOutcome.failed(coord, "Download cancelled", null);
+                }
+
+                return downloadSingleArtifact(
+                    dependency.getArtifact(),
+                    customRepoPath,
+                    homeM2RepoPath,
+                    defaultRepoPath,
+                    pomRepoDownloaders,
+                    downloadConfig,
+                    cancelFlag
+                );
+            }, executorService);
+
+            // Handle outcome
+            future = future.whenComplete((outcome, throwable) -> {
+                if (throwable != null) {
+                    logger.error("Unexpected error in download task", throwable);
+                    ArtifactCoordinate coord = ArtifactCoordinate.fromAetherArtifact(dependency.getArtifact());
+                    outcome = DownloadOutcome.failed(coord, "Unexpected error: " + throwable.getMessage(), null);
+                }
+
+                if (outcome != null) {
+                    outcomes.add(outcome);
+
+                    switch (outcome.getStatus()) {
+                        case SUCCESS:
+                            successCount.incrementAndGet();
+                            logger.info("[{}/{}] SUCCESS: {}",
+                                successCount.get() + failureCount.get() + skippedCount.get(),
+                                dependencies.size(),
+                                outcome.getCoordinate());
+                            break;
+
+                        case FAILED:
+                            failureCount.incrementAndGet();
+                            // Log failure details and continue — do not cancel remaining downloads.
+                            // A single artifact missing from a repo should not stop other JARs from being scanned.
+                            String failureReason = (outcome.getException() != null)
+                                ? "[" + outcome.getException().getCategory() + "] " + outcome.getException().getSanitizedMessage()
+                                : (outcome.getErrorMessage() != null ? outcome.getErrorMessage() : "Unknown error");
+                            logger.warn("[{}/{}] DOWNLOAD FAILED (continuing with remaining): {} - Reason: {}",
+                                successCount.get() + failureCount.get() + skippedCount.get(),
+                                dependencies.size(),
+                                outcome.getCoordinate(),
+                                failureReason);
+                            if (outcome.getException() != null) {
+                                logger.debug("Failure details for {}:", outcome.getCoordinate(), outcome.getException());
+                            }
+                            break;
+
+                        case SKIPPED_LOCAL:
+                        case SKIPPED_NOT_FOUND:
+                            skippedCount.incrementAndGet();
+                            logger.info("[{}/{}] SKIPPED: {} - {}",
+                                successCount.get() + failureCount.get() + skippedCount.get(),
+                                dependencies.size(),
+                                outcome.getCoordinate(),
+                                outcome.getStatus());
+                            break;
+                    }
+                }
+            });
+
+            futures.add(future);
+        }
+
+        // Wait for all downloads to complete or fail
+        try {
+            CompletableFuture<Void> allFutures = CompletableFuture.allOf(
+                futures.toArray(new CompletableFuture[0])
+            );
+
+            // Wait with timeout to prevent hanging
+            allFutures.get(30, TimeUnit.MINUTES);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Download interrupted");
+            cancelFlag.set(true);
+            cancelRemainingTasks(futures);
+        } catch (ExecutionException e) {
+            logger.error("Download execution failed", e.getCause());
+            cancelFlag.set(true);
+            cancelRemainingTasks(futures);
+        } catch (TimeoutException e) {
+            logger.error("Download timeout after 30 minutes");
+            cancelFlag.set(true);
+            cancelRemainingTasks(futures);
+        }
+
+        long elapsedTime = System.currentTimeMillis() - startTime;
+
+        // Generate result
+        ParallelDownloadResult result = new ParallelDownloadResult(
+            dependencies.size(),
+            successCount.get(),
+            failureCount.get(),
+            skippedCount.get(),
+            outcomes,
+            elapsedTime
+        );
+
+        // Log summary
+        logger.info("PARALLEL DOWNLOAD SUMMARY");
+        logger.info("Total processed: {}", result.getTotalArtifacts());
+        logger.info("  Successfully downloaded: {}", result.getSuccessCount());
+        logger.info("  Skipped: {}", result.getSkippedCount());
+        logger.info("  Failed: {}", result.getFailureCount());
+        logger.info("Time elapsed: {} ms ({} ms/artifact avg)",
+            result.getTotalTimeMs(),
+            result.getTotalArtifacts() > 0 ? result.getTotalTimeMs() / result.getTotalArtifacts() : 0);
+        return result;
+    }
+
+    /**
+     * Downloads a single artifact using 3-tier resolution with log buffering.
+     * All artifact-specific logs are buffered and flushed atomically to prevent
+     * interleaving of log output from concurrent download threads.
+     */
+    private DownloadOutcome downloadSingleArtifact(
+            Artifact artifact,
+            Path customRepoPath,
+            Path homeM2RepoPath,
+            Path defaultRepoPath,
+            Map<String, HttpArtifactDownloader> pomRepoDownloaders,
+            DownloadConfiguration downloadConfig,
+            AtomicBoolean cancelFlag) {
+
+        List<String> messageBuffer = new ArrayList<>();
+        DownloadOutcome outcome = doDownloadSingleArtifact(
+            artifact, customRepoPath, homeM2RepoPath, defaultRepoPath,
+            pomRepoDownloaders, downloadConfig,
+            cancelFlag, messageBuffer);
+
+        // Flush buffer atomically to prevent log interleaving between threads
+        if (!messageBuffer.isEmpty()) {
+            synchronized (logger) {
+                for (String line : messageBuffer) {
+                    logger.info("[DOWNLOAD] {}", line);
+                }
+            }
+        }
+
+        return outcome;
+    }
+
+    /**
+     * Internal implementation of single artifact download with buffered logging.
+     * Resolution order:
+     *   Tier-1: Local repositories (custom, then .m2)
+     *   Tier-2: POM-declared remote repositories (pre-built, mirror-aware)
+     *   Tier-3: Fallback downloader (Maven Central or mirror)
+     */
+    private DownloadOutcome doDownloadSingleArtifact(
+            Artifact artifact,
+            Path customRepoPath,
+            Path homeM2RepoPath,
+            Path defaultRepoPath,
+            Map<String, HttpArtifactDownloader> pomRepoDownloaders,
+            DownloadConfiguration downloadConfig,
+            AtomicBoolean cancelFlag,
+            List<String> messageBuffer) {
+
+        ArtifactCoordinate coordinate = ArtifactCoordinate.fromAetherArtifact(artifact);
+        String threadName = Thread.currentThread().getName();
+
+        try {
+            // Check cancellation
+            if (cancelFlag.get()) {
+                return DownloadOutcome.failed(coordinate, "Cancelled", null);
+            }
+
+            messageBuffer.add(String.format("[%s] Processing: %s", threadName, coordinate));
+
+            // Check custom repository
+            if (customRepoPath != null) {
+                Path customJar = localChecker.checkCustomRepository(artifact, customRepoPath);
+                if (customJar != null) {
+                    messageBuffer.add(String.format("[%s] Found in custom repository: %s", threadName, coordinate));
+                    return DownloadOutcome.skippedLocal(coordinate, "custom-repository", customJar);
+                }
+            }
+
+            // Check home ~/.m2/repository
+            if (homeM2RepoPath != null) {
+                Path homeJar = localChecker.checkDefaultRepository(artifact, homeM2RepoPath);
+                if (homeJar != null) {
+                    messageBuffer.add(String.format("[%s] Found in home .m2 repository: %s", threadName, coordinate));
+                    return DownloadOutcome.skippedLocal(coordinate, "home-m2-repository", homeJar);
+                }
+            }
+
+            // Check download cache
+            Path defaultJar = localChecker.checkDefaultRepository(artifact, defaultRepoPath);
+            if (defaultJar != null) {
+                messageBuffer.add(String.format("[%s] Found in download cache: %s", threadName, coordinate));
+                return DownloadOutcome.skippedLocal(coordinate, "download-cache", defaultJar);
+            }
+
+            // Check cancellation before download
+            if (cancelFlag.get()) {
+                return DownloadOutcome.failed(coordinate, "Cancelled before download", null);
+            }
+
+            Path targetPath = buildRepositoryJarPath(artifact, defaultRepoPath);
+
+            // ========== TIER-2: POM-DECLARED REPOSITORIES ==========
+            if (pomRepoDownloaders != null && !pomRepoDownloaders.isEmpty()) {
+                messageBuffer.add(String.format("[%s] Checking %d POM repositories for: %s",
+                    threadName, pomRepoDownloaders.size(), coordinate));
+
+                for (Map.Entry<String, HttpArtifactDownloader> entry : pomRepoDownloaders.entrySet()) {
+                    if (cancelFlag.get()) {
+                        return DownloadOutcome.failed(coordinate, "Cancelled during POM repository checks", null);
+                    }
+
+                    String repoLabel = entry.getKey();
+                    HttpArtifactDownloader remoteDownloader = entry.getValue();
+
+                    try {
+                        messageBuffer.add(String.format("[%s] Trying POM repository: %s for %s",
+                            threadName, repoLabel, coordinate));
+
+                        DownloadResult pomResult = remoteDownloader.download(
+                            artifact, targetPath, downloadConfig
+                        );
+
+                        if (pomResult.isSuccess()) {
+                            messageBuffer.add(String.format("[%s] Found in POM repository %s: %s",
+                                threadName, repoLabel, coordinate));
+                            return DownloadOutcome.success(coordinate,
+                                "pom-repository:" + repoLabel, pomResult.getDownloadedPath());
+                        }
+                    } catch (ArtifactDownloadException e) {
+                        if (e.getMessage() != null && e.getMessage().contains("404")) {
+                            messageBuffer.add(String.format("[%s] Not found in %s: %s", threadName, repoLabel, coordinate));
+                        } else {
+                            messageBuffer.add(String.format("[%s] Error downloading from %s: %s",
+                                threadName, repoLabel, e.getSanitizedMessage()));
+                        }
+                    } catch (Exception e) {
+                        messageBuffer.add(String.format("[%s] Unexpected error with repository %s: %s",
+                            threadName, repoLabel, e.getMessage()));
+                    }
+                }
+
+                messageBuffer.add(String.format("[%s] Not found in any POM repository, falling back to fallback downloader: %s",
+                    threadName, coordinate));
+            }
+
+            // ========== TIER-3: FALLBACK (MAVEN CENTRAL OR MIRROR) ==========
+            messageBuffer.add(String.format("[%s] Downloading from fallback repository: %s", threadName, coordinate));
+            DownloadResult result = httpDownloader.download(
+                artifact, targetPath, downloadConfig
+            );
+
+            if (result.isSuccess()) {
+                messageBuffer.add(String.format("[%s] Downloaded successfully: %s", threadName, coordinate));
+                return DownloadOutcome.success(coordinate, result.getSource(), result.getDownloadedPath());
+            } else {
+                if (result.isNotFound()) {
+                    return DownloadOutcome.skippedNotFound(coordinate, result.getErrorMessage());
+                }
+                return DownloadOutcome.failed(coordinate, result.getErrorMessage(), null);
+            }
+
+        } catch (ArtifactDownloadException e) {
+            messageBuffer.add(String.format("[%s] Download failed for %s: %s", threadName, coordinate, e.getSanitizedMessage()));
+            return DownloadOutcome.failed(coordinate, e.getSanitizedMessage(), e);
+        } catch (Exception e) {
+            messageBuffer.add(String.format("[%s] Unexpected error for %s: %s", threadName, coordinate, e.getMessage()));
+            return DownloadOutcome.failed(coordinate, "Unexpected error: " + e.getMessage(), null);
+        }
+    }
+
+    /**
+     * Cancels remaining tasks.
+     */
+    private void cancelRemainingTasks(List<CompletableFuture<DownloadOutcome>> futures) {
+        for (CompletableFuture<DownloadOutcome> future : futures) {
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * Shuts down the thread pool gracefully.
+     */
+    public void shutdown() {
+        logger.info("Shutting down parallel download manager");
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+                logger.warn("Thread pool did not terminate in 60 seconds, forcing shutdown");
+                executorService.shutdownNow();
+                if (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+                    logger.error("Thread pool did not terminate after forced shutdown");
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Shutdown interrupted", e);
+            executorService.shutdownNow();
+        }
+    }
+
+    private int validateThreadCount(Integer threadCount) {
+        if (threadCount == null) {
+            return DEFAULT_THREAD_COUNT;
+        }
+
+        if (threadCount < MIN_THREAD_COUNT) {
+            logger.warn("Thread count {} is below minimum {}, using minimum",
+                threadCount, MIN_THREAD_COUNT);
+            return MIN_THREAD_COUNT;
+        }
+
+        if (threadCount > MAX_THREAD_COUNT) {
+            logger.warn("Thread count {} exceeds maximum {}, using maximum",
+                threadCount, MAX_THREAD_COUNT);
+            return MAX_THREAD_COUNT;
+        }
+
+        return threadCount;
+    }
+
+    private Path buildRepositoryJarPath(Artifact artifact, Path repositoryPath) {
+        ArtifactCoordinate coordinate = ArtifactCoordinate.fromAetherArtifact(artifact);
+        String[] pathParts = coordinate.toRepositoryPath().split("/");
+
+        Path result = repositoryPath;
+        for (String part : pathParts) {
+            result = result.resolve(part);
+        }
+
+        return result;
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/PartialDownloadManager.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/PartialDownloadManager.java
@@ -1,0 +1,286 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Manages partial downloads and resume functionality using HTTP Range requests.
+ * Single Responsibility: Handle partial download state and resume logic.
+ */
+public class PartialDownloadManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(PartialDownloadManager.class);
+    private static final String PARTIAL_SUFFIX = ".partial";
+    private static final Duration STALE_THRESHOLD = Duration.ofHours(24);
+
+    /**
+     * Information about a partial download that can be resumed.
+     */
+    public static class PartialDownloadInfo {
+        private final Path partialFile;
+        private final long bytesDownloaded;
+        private final boolean isResumable;
+        private final String reason;
+
+        private PartialDownloadInfo(Path partialFile, long bytesDownloaded, boolean isResumable, String reason) {
+            this.partialFile = partialFile;
+            this.bytesDownloaded = bytesDownloaded;
+            this.isResumable = isResumable;
+            this.reason = reason;
+        }
+
+        public static PartialDownloadInfo resumable(Path partialFile, long bytesDownloaded) {
+            return new PartialDownloadInfo(partialFile, bytesDownloaded, true, null);
+        }
+
+        public static PartialDownloadInfo notResumable(String reason) {
+            return new PartialDownloadInfo(null, 0, false, reason);
+        }
+
+        public Path getPartialFile() {
+            return partialFile;
+        }
+
+        public long getBytesDownloaded() {
+            return bytesDownloaded;
+        }
+
+        public boolean isResumable() {
+            return isResumable;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+    }
+
+    /**
+     * Checks for an existing partial download and determines if it can be resumed.
+     *
+     * @param targetPath The final destination path for the download
+     * @return PartialDownloadInfo indicating if resume is possible
+     */
+    public PartialDownloadInfo checkPartialDownload(Path targetPath) {
+        if (targetPath == null) {
+            return PartialDownloadInfo.notResumable("Target path is null");
+        }
+
+        // Normalize path to prevent directory traversal
+        Path normalizedTarget;
+        try {
+            normalizedTarget = targetPath.normalize().toAbsolutePath();
+        } catch (Exception e) {
+            logger.warn("Failed to normalize target path, cannot check for partial download: {}", e.getMessage());
+            return PartialDownloadInfo.notResumable("Path normalization failed");
+        }
+
+        // Check for partial file
+        Path partialFile = getPartialFilePath(normalizedTarget);
+
+        if (!Files.exists(partialFile)) {
+            logger.debug("No partial download found for: {}", sanitizePath(normalizedTarget));
+            return PartialDownloadInfo.notResumable("No partial file exists");
+        }
+
+        try {
+            // Check file attributes
+            BasicFileAttributes attrs = Files.readAttributes(partialFile, BasicFileAttributes.class);
+            long fileSize = attrs.size();
+
+            if (fileSize == 0) {
+                logger.debug("Partial file is empty, removing: {}", sanitizePath(partialFile));
+                Files.deleteIfExists(partialFile);
+                return PartialDownloadInfo.notResumable("Partial file was empty");
+            }
+
+            // Check if partial file is stale
+            Instant lastModified = attrs.lastModifiedTime().toInstant();
+            Duration age = Duration.between(lastModified, Instant.now());
+
+            if (age.compareTo(STALE_THRESHOLD) > 0) {
+                logger.info("Partial download is stale ({}h old), removing: {}",
+                    age.toHours(), sanitizePath(partialFile));
+                Files.deleteIfExists(partialFile);
+                return PartialDownloadInfo.notResumable("Partial file was stale");
+            }
+
+            // Validate file is readable
+            if (!Files.isReadable(partialFile) || !Files.isWritable(partialFile)) {
+                logger.warn("Partial file exists but is not accessible, removing: {}", sanitizePath(partialFile));
+                Files.deleteIfExists(partialFile);
+                return PartialDownloadInfo.notResumable("Partial file not accessible");
+            }
+
+            logger.info("Found resumable partial download: {} bytes already downloaded", fileSize);
+            return PartialDownloadInfo.resumable(partialFile, fileSize);
+
+        } catch (IOException e) {
+            logger.warn("Error checking partial download, will start fresh: {}", e.getMessage());
+            try {
+                Files.deleteIfExists(partialFile);
+            } catch (IOException deleteError) {
+                logger.debug("Failed to delete partial file: {}", deleteError.getMessage());
+            }
+            return PartialDownloadInfo.notResumable("Error checking partial file");
+        }
+    }
+
+    /**
+     * Creates a path for the partial download file.
+     *
+     * @param targetPath The final destination path
+     * @return Path to the partial file
+     */
+    public Path getPartialFilePath(Path targetPath) {
+        return targetPath.resolveSibling(targetPath.getFileName() + PARTIAL_SUFFIX);
+    }
+
+    /**
+     * Validates if server supports range requests based on response headers.
+     *
+     * @param responseCode HTTP response code
+     * @param acceptRanges Accept-Ranges header value
+     * @param contentRange Content-Range header value
+     * @return true if server supports resuming
+     */
+    public boolean validateRangeSupport(int responseCode, String acceptRanges, String contentRange) {
+        // Check for 206 Partial Content response
+        if (responseCode == 206) {
+            if (contentRange != null && contentRange.startsWith("bytes ")) {
+                logger.debug("Server supports range requests (206 with Content-Range)");
+                return true;
+            }
+        }
+
+        // Check Accept-Ranges header for non-206 responses
+        if (responseCode == 200 && acceptRanges != null && acceptRanges.contains("bytes")) {
+            logger.debug("Server indicates range support via Accept-Ranges header");
+            return true;
+        }
+
+        logger.debug("Server does not support range requests (code: {}, Accept-Ranges: {})",
+            responseCode, acceptRanges);
+        return false;
+    }
+
+    /**
+     * Cleans up partial download file.
+     *
+     * @param partialFile Path to the partial file
+     */
+    public void cleanupPartialFile(Path partialFile) {
+        if (partialFile == null) {
+            return;
+        }
+
+        try {
+            if (Files.exists(partialFile)) {
+                Files.delete(partialFile);
+                logger.debug("Cleaned up partial file: {}", sanitizePath(partialFile));
+            }
+        } catch (IOException e) {
+            logger.warn("Failed to cleanup partial file {}: {}", sanitizePath(partialFile), e.getMessage());
+        }
+    }
+
+    /**
+     * Moves partial file to final destination atomically.
+     *
+     * @param partialFile Source partial file
+     * @param targetPath Final destination
+     * @throws IOException if move fails
+     */
+    public void promotePartialToFinal(Path partialFile, Path targetPath) throws IOException {
+        if (partialFile == null || targetPath == null) {
+            throw new IllegalArgumentException("Paths cannot be null");
+        }
+
+        // Ensure paths are normalized
+        Path normalizedPartial = partialFile.normalize().toAbsolutePath();
+        Path normalizedTarget = targetPath.normalize().toAbsolutePath();
+
+        // Security check: ensure paths are in expected directories
+        if (!normalizedPartial.getParent().equals(normalizedTarget.getParent())) {
+            throw new SecurityException("Partial and target files must be in the same directory");
+        }
+
+        try {
+            Files.move(normalizedPartial, normalizedTarget,
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+            logger.debug("Promoted partial download to final: {}", sanitizePath(normalizedTarget));
+        } catch (IOException e) {
+            logger.error("Failed to promote partial file to final: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * Builds HTTP Range header value for resume.
+     *
+     * @param startByte The byte offset to start from
+     * @return Range header value
+     */
+    public String buildRangeHeader(long startByte) {
+        if (startByte < 0) {
+            throw new IllegalArgumentException("Start byte cannot be negative");
+        }
+
+        // Validate reasonable range to prevent abuse
+        if (startByte > 10L * 1024 * 1024 * 1024) { // 10GB max
+            throw new IllegalArgumentException("Start byte exceeds maximum allowed range");
+        }
+
+        return "bytes=" + startByte + "-";
+    }
+
+    /**
+     * Parses Content-Range header to extract total size.
+     *
+     * @param contentRange Content-Range header value
+     * @return Total file size, or -1 if cannot parse
+     */
+    public long parseContentRangeTotal(String contentRange) {
+        if (contentRange == null || !contentRange.startsWith("bytes ")) {
+            return -1;
+        }
+
+        try {
+            // Format: "bytes START-END/TOTAL" or "bytes START-END/*"
+            int slashIndex = contentRange.lastIndexOf('/');
+            if (slashIndex > 0 && slashIndex < contentRange.length() - 1) {
+                String totalStr = contentRange.substring(slashIndex + 1);
+                if (!"*".equals(totalStr)) {
+                    return Long.parseLong(totalStr);
+                }
+            }
+        } catch (NumberFormatException e) {
+            logger.debug("Failed to parse Content-Range total: {}", contentRange);
+        }
+
+        return -1;
+    }
+
+    /**
+     * Sanitizes path for safe logging.
+     */
+    private String sanitizePath(Path path) {
+        if (path == null) {
+            return "<null>";
+        }
+
+        String fileName = path.getFileName() != null ? path.getFileName().toString() : "<unnamed>";
+        Path parent = path.getParent();
+        if (parent != null && parent.getFileName() != null) {
+            return ".../" + parent.getFileName() + "/" + fileName;
+        }
+        return ".../" + fileName;
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/ProgressReportingInputStream.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/ProgressReportingInputStream.java
@@ -1,0 +1,249 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Input stream wrapper that reports download progress at controlled intervals.
+ * Single Responsibility: Track and report download progress.
+ */
+public class ProgressReportingInputStream extends FilterInputStream {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProgressReportingInputStream.class);
+
+    // Progress reporting thresholds
+    private static final long BYTES_PER_REPORT = 1024 * 1024; // 1 MB
+    private static final long TIME_BETWEEN_REPORTS_MS = 2000; // 2 seconds
+    private static final long BYTES_PER_KB = 1024;
+    private static final long BYTES_PER_MB = 1024 * 1024;
+
+    private final String artifactId;
+    private final long totalSize;
+    private final long startOffset;
+    private final AtomicLong bytesRead;
+    private final Instant startTime;
+
+    private long lastReportBytes;
+    private long lastReportTimeMs;
+    private boolean completed;
+
+    /**
+     * Creates a progress-reporting input stream.
+     *
+     * @param inputStream The underlying input stream
+     * @param artifactId Artifact identifier for logging
+     * @param totalSize Total expected size in bytes (-1 if unknown)
+     * @param startOffset Starting byte offset for resumed downloads
+     */
+    public ProgressReportingInputStream(InputStream inputStream, String artifactId,
+                                        long totalSize, long startOffset) {
+        super(inputStream);
+        this.artifactId = sanitizeArtifactId(artifactId);
+        this.totalSize = totalSize;
+        this.startOffset = Math.max(0, startOffset);
+        this.bytesRead = new AtomicLong(0);
+        this.startTime = Instant.now();
+        this.lastReportBytes = 0;
+        this.lastReportTimeMs = System.currentTimeMillis();
+        this.completed = false;
+
+        // Log initial state
+        if (startOffset > 0) {
+            logger.info("  Resuming download from byte {}", formatBytes(startOffset));
+        }
+        if (totalSize > 0) {
+            logger.info("  Total size: {}", formatBytes(totalSize));
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        int byteRead = super.read();
+        if (byteRead != -1) {
+            updateProgress(1);
+        } else {
+            reportCompletion();
+        }
+        return byteRead;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int bytesReadCount = super.read(b, off, len);
+        if (bytesReadCount > 0) {
+            updateProgress(bytesReadCount);
+        } else if (bytesReadCount == -1) {
+            reportCompletion();
+        }
+        return bytesReadCount;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            reportCompletion();
+        } finally {
+            super.close();
+        }
+    }
+
+    /**
+     * Updates progress and reports if thresholds are met.
+     */
+    private void updateProgress(int bytes) {
+        long totalBytesRead = bytesRead.addAndGet(bytes);
+        long currentTimeMs = System.currentTimeMillis();
+
+        // Check if we should report progress
+        boolean shouldReport = false;
+
+        // Report based on bytes threshold
+        if (totalBytesRead - lastReportBytes >= BYTES_PER_REPORT) {
+            shouldReport = true;
+        }
+
+        // Report based on time threshold
+        if (currentTimeMs - lastReportTimeMs >= TIME_BETWEEN_REPORTS_MS) {
+            shouldReport = true;
+        }
+
+        if (shouldReport) {
+            reportProgress(totalBytesRead, currentTimeMs);
+            lastReportBytes = totalBytesRead;
+            lastReportTimeMs = currentTimeMs;
+        }
+    }
+
+    /**
+     * Reports current download progress.
+     */
+    private void reportProgress(long currentBytes, long currentTimeMs) {
+        long totalDownloaded = startOffset + currentBytes;
+
+        // Build progress message
+        StringBuilder message = new StringBuilder();
+        message.append("  Progress: ");
+        message.append(formatBytes(totalDownloaded));
+
+        // Add total size and percentage if known
+        if (totalSize > 0) {
+            double percentage = (totalDownloaded * 100.0) / totalSize;
+            message.append(" / ");
+            message.append(formatBytes(totalSize));
+            message.append(String.format(" (%.1f%%)", percentage));
+        }
+
+        // Calculate and add download speed
+        long elapsedMs = currentTimeMs - startTime.toEpochMilli();
+        if (elapsedMs > 0 && currentBytes > 0) {
+            double bytesPerSecond = (currentBytes * 1000.0) / elapsedMs;
+            message.append(" - ");
+            message.append(formatSpeed(bytesPerSecond));
+        }
+
+        // Add time estimate if possible
+        if (totalSize > 0 && currentBytes > 0 && elapsedMs > 0) {
+            long remainingBytes = totalSize - totalDownloaded;
+            double bytesPerMs = currentBytes / (double) elapsedMs;
+            if (bytesPerMs > 0) {
+                long remainingMs = (long) (remainingBytes / bytesPerMs);
+                if (remainingMs > 0) {
+                    message.append(" - ");
+                    message.append(formatDuration(Duration.ofMillis(remainingMs)));
+                    message.append(" remaining");
+                }
+            }
+        }
+
+        logger.info(message.toString());
+    }
+
+    /**
+     * Reports download completion.
+     */
+    private void reportCompletion() {
+        if (completed) {
+            return;
+        }
+        completed = true;
+
+        long totalBytesRead = bytesRead.get();
+        long totalDownloaded = startOffset + totalBytesRead;
+        Duration totalDuration = Duration.between(startTime, Instant.now());
+
+        StringBuilder message = new StringBuilder();
+        message.append("  Download complete: ");
+        message.append(formatBytes(totalDownloaded));
+
+        if (totalDuration.toMillis() > 0) {
+            message.append(" in ");
+            message.append(formatDuration(totalDuration));
+
+            // Add average speed
+            double avgBytesPerSecond = (totalBytesRead * 1000.0) / totalDuration.toMillis();
+            message.append(" (avg ");
+            message.append(formatSpeed(avgBytesPerSecond));
+            message.append(")");
+        }
+
+        logger.info(message.toString());
+    }
+
+    /**
+     * Formats bytes into human-readable string.
+     */
+    private String formatBytes(long bytes) {
+        if (bytes < BYTES_PER_KB) {
+            return bytes + " B";
+        } else if (bytes < BYTES_PER_MB) {
+            return String.format("%.1f KB", bytes / (double) BYTES_PER_KB);
+        } else {
+            return String.format("%.1f MB", bytes / (double) BYTES_PER_MB);
+        }
+    }
+
+    /**
+     * Formats download speed into human-readable string.
+     */
+    private String formatSpeed(double bytesPerSecond) {
+        if (bytesPerSecond < BYTES_PER_KB) {
+            return String.format("%.0f B/s", bytesPerSecond);
+        } else if (bytesPerSecond < BYTES_PER_MB) {
+            return String.format("%.1f KB/s", bytesPerSecond / BYTES_PER_KB);
+        } else {
+            return String.format("%.1f MB/s", bytesPerSecond / BYTES_PER_MB);
+        }
+    }
+
+    /**
+     * Formats duration into human-readable string.
+     */
+    private String formatDuration(Duration duration) {
+        long seconds = duration.getSeconds();
+        if (seconds < 60) {
+            return seconds + "s";
+        } else if (seconds < 3600) {
+            return String.format("%dm %ds", seconds / 60, seconds % 60);
+        } else {
+            return String.format("%dh %dm", seconds / 3600, (seconds % 3600) / 60);
+        }
+    }
+
+    /**
+     * Sanitizes artifact ID to prevent log injection.
+     */
+    private String sanitizeArtifactId(String artifactId) {
+        if (artifactId == null) {
+            return "unknown";
+        }
+        // Remove any control characters or newlines
+        return artifactId.replaceAll("[\\r\\n\\t]", "");
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/RemoteRepositoryDownloader.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/RemoteRepositoryDownloader.java
@@ -1,0 +1,460 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.exception.ArtifactDownloadException;
+import com.blackduck.integration.detectable.detectables.maven.resolver.exception.DownloadErrorFactory;
+import org.eclipse.aether.artifact.Artifact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Base64;
+
+/**
+ * Downloads artifacts from a remote Maven repository with SNAPSHOT support.
+ * Single Responsibility: Handle HTTP downloads from a specific Maven repository.
+ *
+ * <p>Features:
+ * <ul>
+ *   <li>SNAPSHOT resolution via maven-metadata.xml (timestamped + plain fallback)</li>
+ *   <li>Resumable downloads with Range header support</li>
+ *   <li>Disk space checking before download</li>
+ *   <li>Progress reporting for large files</li>
+ *   <li>Retry logic via {@link RetryPolicy}</li>
+ * </ul>
+ */
+public class RemoteRepositoryDownloader implements HttpArtifactDownloader {
+
+    private static final Logger logger = LoggerFactory.getLogger(RemoteRepositoryDownloader.class);
+
+    private final String baseRepositoryUrl;
+    private final PartialDownloadManager partialDownloadManager;
+    private final DiskSpaceChecker diskSpaceChecker;
+    @Nullable
+    private final String authUsername;
+    @Nullable
+    private final String authPassword;
+
+    /**
+     * Creates a downloader for a specific remote repository without authentication.
+     *
+     * @param baseRepositoryUrl The base URL of the repository (e.g., "https://repo.example.com/maven2")
+     */
+    public RemoteRepositoryDownloader(String baseRepositoryUrl) {
+        this(baseRepositoryUrl, null, null);
+    }
+
+    /**
+     * Creates a downloader for a specific remote repository with optional basic authentication.
+     *
+     * @param baseRepositoryUrl The base URL of the repository
+     * @param username          Optional authentication username (may be null)
+     * @param password          Optional authentication password (may be null)
+     */
+    public RemoteRepositoryDownloader(String baseRepositoryUrl, @Nullable String username, @Nullable String password) {
+        this.baseRepositoryUrl = normalizeUrl(baseRepositoryUrl);
+        this.partialDownloadManager = new PartialDownloadManager();
+        this.diskSpaceChecker = new DiskSpaceChecker();
+        this.authUsername = username;
+        this.authPassword = password;
+    }
+
+    /**
+     * Returns the base repository URL.
+     */
+    public String getBaseRepositoryUrl() {
+        return baseRepositoryUrl;
+    }
+
+    @Override
+    public DownloadResult download(Artifact artifact, Path targetPath, DownloadConfiguration configuration)
+            throws ArtifactDownloadException {
+
+        String artifactId = formatArtifactId(artifact);
+        RetryPolicy retryPolicy = configuration.getRetryPolicy();
+
+        // Build URL with SNAPSHOT support
+        String primaryJarUrl = buildRepositoryUrl(artifact);
+        String plainSnapshotUrl = null;
+        boolean isSnapshot = artifact.getVersion().endsWith("-SNAPSHOT");
+
+        if (isSnapshot) {
+            logger.debug("SNAPSHOT detected for {}. Attempting timestamped resolution...", artifactId);
+            String timestampedUrl = resolveSnapshotUrl(artifact, configuration);
+            if (timestampedUrl != null) {
+                logger.debug("Resolved SNAPSHOT to timestamped URL: {}", timestampedUrl);
+                plainSnapshotUrl = primaryJarUrl; // Keep plain URL as fallback
+                primaryJarUrl = timestampedUrl;
+            } else {
+                logger.debug("Could not resolve SNAPSHOT timestamp. Using default SNAPSHOT URL.");
+            }
+        }
+
+        logger.debug("Remote repository URL: {}", primaryJarUrl);
+
+        // Check for partial download
+        PartialDownloadManager.PartialDownloadInfo partialInfo =
+            partialDownloadManager.checkPartialDownload(targetPath);
+
+        // Track mutable state for resume attempts
+        final long[] startOffset = { 0 };
+        final Path[] downloadPath = { targetPath };
+
+        if (partialInfo.isResumable()) {
+            startOffset[0] = partialInfo.getBytesDownloaded();
+            downloadPath[0] = partialInfo.getPartialFile();
+            logger.debug("Attempting to resume download from byte {}", startOffset[0]);
+        } else if (partialInfo.getPartialFile() != null) {
+            partialDownloadManager.cleanupPartialFile(partialInfo.getPartialFile());
+        }
+
+        // Final URL references for lambda
+        final String finalPrimaryUrl = primaryJarUrl;
+        final String finalPlainSnapshotUrl = plainSnapshotUrl;
+
+        // Use RetryPolicy for retry logic
+        try {
+            return retryPolicy.executeWithRetry(() -> {
+                try {
+                    DownloadResult result = attemptDownload(
+                        artifact, targetPath, downloadPath[0], finalPrimaryUrl, configuration, startOffset[0]
+                    );
+
+                    if (result.isSuccess()) {
+                        if (!downloadPath[0].equals(targetPath) && Files.exists(downloadPath[0])) {
+                            partialDownloadManager.promotePartialToFinal(downloadPath[0], targetPath);
+                        }
+                        return result;
+                    }
+
+                    // If primary URL 404 and we have a plain SNAPSHOT fallback, try it
+                    if (result.isNotFound() && finalPlainSnapshotUrl != null && !finalPrimaryUrl.equals(finalPlainSnapshotUrl)) {
+                        logger.debug("Timestamped SNAPSHOT URL failed (404). Trying plain SNAPSHOT URL...");
+                        DownloadResult fallbackResult = attemptDownload(
+                            artifact, targetPath, downloadPath[0], finalPlainSnapshotUrl, configuration, startOffset[0]
+                        );
+                        if (fallbackResult.isSuccess()) {
+                            if (!downloadPath[0].equals(targetPath) && Files.exists(downloadPath[0])) {
+                                partialDownloadManager.promotePartialToFinal(downloadPath[0], targetPath);
+                            }
+                            return fallbackResult;
+                        }
+                        return fallbackResult;
+                    }
+
+                    if (isNonRetryableError(result)) {
+                        return result;
+                    }
+
+                    throw DownloadErrorFactory.repositoryError(artifactId,
+                        "Download failed: " + result.getErrorMessage(), null);
+
+                } catch (ArtifactDownloadException e) {
+                    if (e.getMessage() != null && e.getMessage().contains("404")) {
+                        return DownloadResult.notFound("Artifact not found in repository (404)");
+                    }
+
+                    if (e.getCategory() == ArtifactDownloadException.ErrorCategory.RANGE_NOT_SUPPORTED_ERROR ||
+                        e.getCategory() == ArtifactDownloadException.ErrorCategory.PARTIAL_DOWNLOAD_ERROR) {
+                        partialDownloadManager.cleanupPartialFile(downloadPath[0]);
+                        startOffset[0] = 0;
+                        downloadPath[0] = targetPath;
+                    }
+
+                    throw e;
+                } catch (IOException e) {
+                    throw DownloadErrorFactory.fileSystemError(artifactId,
+                        "Failed to promote partial download to final location", e);
+                }
+            }, "download from " + baseRepositoryUrl);
+
+        } catch (ArtifactDownloadException e) {
+            if (e.getMessage() != null && e.getMessage().contains("404")) {
+                return DownloadResult.notFound("Artifact not found in repository (404)");
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Resolves a SNAPSHOT artifact's timestamped version via maven-metadata.xml.
+     *
+     * @param artifact The SNAPSHOT artifact
+     * @param configuration Download configuration for timeouts
+     * @return The full URL to the timestamped JAR, or null if resolution fails
+     */
+    private String resolveSnapshotUrl(Artifact artifact, DownloadConfiguration configuration) {
+        String groupPath = artifact.getGroupId().replace('.', '/');
+        String metadataUrl = baseRepositoryUrl + "/" + groupPath + "/"
+            + artifact.getArtifactId() + "/"
+            + artifact.getVersion() + "/maven-metadata.xml";
+
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(metadataUrl);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(configuration.getConnectTimeoutMs());
+            connection.setReadTimeout(configuration.getReadTimeoutMs());
+            connection.setRequestProperty("User-Agent", "Black Duck Detect Maven Resolver");
+            applyBasicAuth(connection);
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                logger.debug("SNAPSHOT metadata not available (HTTP {}): {}", responseCode, metadataUrl);
+                return null;
+            }
+
+            String metadataContent;
+            try (InputStream in = connection.getInputStream()) {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                byte[] buffer = new byte[4096];
+                int bytesRead;
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    baos.write(buffer, 0, bytesRead);
+                }
+                metadataContent = baos.toString("UTF-8");
+            }
+
+            String timestamp = extractXmlValue(metadataContent, "timestamp");
+            String buildNumber = extractXmlValue(metadataContent, "buildNumber");
+
+            if (timestamp != null && buildNumber != null) {
+                String baseVersion = artifact.getVersion().replace("-SNAPSHOT", "");
+                StringBuilder fileName = new StringBuilder();
+                fileName.append(artifact.getArtifactId());
+                fileName.append("-").append(baseVersion);
+                fileName.append("-").append(timestamp);
+                fileName.append("-").append(buildNumber);
+
+                String classifier = artifact.getClassifier();
+                if (classifier != null && !classifier.isEmpty()) {
+                    fileName.append("-").append(classifier);
+                }
+                fileName.append(".jar");
+
+                String timestampedUrl = baseRepositoryUrl + "/" + groupPath + "/"
+                    + artifact.getArtifactId() + "/"
+                    + artifact.getVersion() + "/"
+                    + fileName.toString();
+
+                logger.debug("Resolved SNAPSHOT: timestamp={}, buildNumber={}", timestamp, buildNumber);
+                return timestampedUrl;
+            }
+
+        } catch (Exception e) {
+            logger.debug("Failed to resolve SNAPSHOT metadata: {}", e.getMessage());
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts a simple XML element value (no attributes, no namespaces).
+     */
+    private String extractXmlValue(String xml, String tagName) {
+        String openTag = "<" + tagName + ">";
+        String closeTag = "</" + tagName + ">";
+        int start = xml.indexOf(openTag);
+        int end = xml.indexOf(closeTag);
+        if (start >= 0 && end > start) {
+            return xml.substring(start + openTag.length(), end).trim();
+        }
+        return null;
+    }
+
+    private DownloadResult attemptDownload(Artifact artifact, Path targetPath, Path downloadPath,
+                                          String jarUrl, DownloadConfiguration config, long startOffset)
+            throws ArtifactDownloadException {
+
+        String artifactId = formatArtifactId(artifact);
+        HttpURLConnection connection = null;
+
+        try {
+            URL url = new URL(jarUrl);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(config.getConnectTimeoutMs());
+            connection.setReadTimeout(config.getReadTimeoutMs());
+            connection.setRequestProperty("User-Agent", "Black Duck Detect Maven Resolver");
+            applyBasicAuth(connection);
+
+            if (startOffset > 0) {
+                String rangeHeader = partialDownloadManager.buildRangeHeader(startOffset);
+                connection.setRequestProperty("Range", rangeHeader);
+                logger.debug("Requesting range: {}", rangeHeader);
+            }
+
+            int responseCode = connection.getResponseCode();
+
+            if (startOffset > 0) {
+                if (responseCode == 206) {
+                    logger.debug("Server supports resume (206 Partial Content)");
+                } else if (responseCode == 200) {
+                    throw DownloadErrorFactory.rangeNotSupportedError(artifactId,
+                        "Server returned 200 (not 206) for range request — this server does not support resume");
+                } else {
+                    throw DownloadErrorFactory.rangeNotSupportedError(artifactId,
+                        "Server returned unexpected response to range request: " + responseCode);
+                }
+            }
+
+            if (responseCode == HttpURLConnection.HTTP_OK || responseCode == 206) {
+                long contentLength = connection.getContentLengthLong();
+
+                if (responseCode == 206) {
+                    String contentRange = connection.getHeaderField("Content-Range");
+                    long totalSize = partialDownloadManager.parseContentRangeTotal(contentRange);
+                    if (totalSize > 0) {
+                        contentLength = totalSize;
+                    }
+                }
+
+                if (contentLength > 0) {
+                    DiskSpaceChecker.DiskSpaceCheckResult spaceCheck =
+                        diskSpaceChecker.checkAvailableSpace(targetPath, contentLength, startOffset);
+
+                    if (!spaceCheck.hasEnoughSpace()) {
+                        throw DownloadErrorFactory.insufficientDiskSpaceError(
+                            artifactId,
+                            spaceCheck.getAvailableBytes(),
+                            spaceCheck.getRequiredBytes()
+                        );
+                    }
+                }
+
+                logger.debug("HTTP {} - Downloading JAR ({} KB) from {}",
+                    responseCode,
+                    contentLength > 0 ? contentLength / 1024 : "unknown size",
+                    baseRepositoryUrl);
+
+                Files.createDirectories(targetPath.getParent());
+
+                Path actualDownloadPath = (startOffset > 0) ? downloadPath :
+                    partialDownloadManager.getPartialFilePath(targetPath);
+
+                long bytesWritten = downloadWithProgress(
+                    connection, actualDownloadPath, artifactId, contentLength, startOffset
+                );
+
+                if (contentLength > 0 && startOffset == 0 && bytesWritten != contentLength) {
+                    Files.deleteIfExists(actualDownloadPath);
+                    throw DownloadErrorFactory.networkError(artifactId,
+                        String.format("Incomplete download: expected %d bytes, received %d bytes",
+                            contentLength, bytesWritten), null);
+                }
+
+                logger.info("DOWNLOAD SUCCESSFUL from {} - {} KB downloaded",
+                    baseRepositoryUrl, bytesWritten / 1024);
+
+                if (!actualDownloadPath.equals(targetPath)) {
+                    partialDownloadManager.promotePartialToFinal(actualDownloadPath, targetPath);
+                }
+
+                return DownloadResult.success(baseRepositoryUrl, targetPath);
+
+            } else if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                logger.debug("JAR NOT AVAILABLE - HTTP 404 from {}", baseRepositoryUrl);
+                return DownloadResult.notFound("Artifact JAR not found in repository (404)");
+
+            } else {
+                throw DownloadErrorFactory.fromHttpError(artifactId, responseCode);
+            }
+
+        } catch (IOException e) {
+            throw DownloadErrorFactory.fromIOException(artifactId, e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private long downloadWithProgress(HttpURLConnection connection, Path targetPath,
+                                      String artifactId, long totalSize, long startOffset)
+            throws IOException {
+
+        StandardOpenOption[] openOptions = (startOffset > 0) ?
+            new StandardOpenOption[] { StandardOpenOption.CREATE, StandardOpenOption.APPEND } :
+            new StandardOpenOption[] { StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+                                       StandardOpenOption.TRUNCATE_EXISTING };
+
+        try (InputStream inputStream = connection.getInputStream();
+             ProgressReportingInputStream progressStream = new ProgressReportingInputStream(
+                 inputStream, artifactId, totalSize, startOffset);
+             OutputStream outputStream = Files.newOutputStream(targetPath, openOptions)) {
+
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            long totalBytesWritten = 0;
+
+            while ((bytesRead = progressStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, bytesRead);
+                totalBytesWritten += bytesRead;
+            }
+
+            return totalBytesWritten;
+        }
+    }
+
+    private boolean isNonRetryableError(DownloadResult result) {
+        if (result.isNotFound()) {
+            return true;
+        }
+        return result.getErrorMessage() != null &&
+            (result.getErrorMessage().contains("403") ||
+             result.getErrorMessage().contains("401"));
+    }
+
+    private String buildRepositoryUrl(Artifact artifact) {
+        String groupPath = artifact.getGroupId().replace('.', '/');
+        String version = artifact.getVersion();
+
+        StringBuilder fileName = new StringBuilder();
+        fileName.append(artifact.getArtifactId());
+        fileName.append("-").append(version);
+
+        String classifier = artifact.getClassifier();
+        if (classifier != null && !classifier.isEmpty()) {
+            fileName.append("-").append(classifier);
+        }
+
+        fileName.append(".jar");
+
+        return String.format("%s/%s/%s/%s/%s",
+            baseRepositoryUrl, groupPath, artifact.getArtifactId(), version, fileName.toString());
+    }
+
+    private String formatArtifactId(Artifact artifact) {
+        return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion();
+    }
+
+    private void applyBasicAuth(HttpURLConnection connection) {
+        if (authUsername != null && !authUsername.isEmpty() && authPassword != null) {
+            String credentials = authUsername + ":" + authPassword;
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            connection.setRequestProperty("Authorization", "Basic " + encoded);
+        }
+    }
+
+    private String normalizeUrl(String url) {
+        if (url == null) {
+            return "";
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/RepositoryPathValidator.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/RepositoryPathValidator.java
@@ -1,0 +1,177 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Validates Maven repository paths for security and accessibility.
+ * Single Responsibility: Path validation and normalization.
+ */
+public class RepositoryPathValidator {
+
+    private static final Logger logger = LoggerFactory.getLogger(RepositoryPathValidator.class);
+
+    /**
+     * Validates a custom repository path at startup.
+     * Performs security checks and ensures path is accessible.
+     *
+     * @param customPath The path to validate (can be null)
+     * @return The normalized, validated path or null if no custom path provided
+     * @throws IllegalStateException if path is invalid with actionable error message
+     */
+    public Path validateCustomRepositoryPath(Path customPath) {
+        if (customPath == null) {
+            logger.debug("No custom repository path configured");
+            return null;
+        }
+
+        logger.info("Validating custom repository path configuration...");
+
+        try {
+            // Normalize path to resolve any . and .. components
+            Path normalizedPath = customPath.normalize().toAbsolutePath();
+
+            // Security check: detect directory traversal attempts
+            // Check if the original path contains traversal sequences before normalization
+            String originalPath = customPath.toString();
+            if (originalPath.contains("..") || originalPath.contains("./")) {
+                // Additional check: ensure the normalized path doesn't escape expected boundaries
+                // This catches attempts like "../../../etc/passwd"
+                Path currentDir = Paths.get("").toAbsolutePath();
+                Path parentDir = currentDir.getParent();
+
+                if (parentDir != null && !normalizedPath.startsWith(currentDir) &&
+                    !normalizedPath.startsWith(parentDir)) {
+                    throw new IllegalStateException(
+                        "Invalid custom repository path: Path contains directory traversal sequences that " +
+                        "escape the expected working directory boundaries. " +
+                        "Please provide a path within the current directory tree."
+                    );
+                }
+
+                // Log warning for any traversal attempts, even if they don't escape boundaries
+                logger.warn("Custom repository path contains directory traversal sequences: {}. " +
+                           "Resolved to: {}", originalPath, sanitizePath(normalizedPath));
+            }
+
+            // Check if path exists
+            if (!Files.exists(normalizedPath)) {
+                throw new IllegalStateException(
+                    String.format("Custom repository path does not exist: %s. " +
+                        "Please ensure the path exists or remove the configuration.",
+                        sanitizePath(normalizedPath))
+                );
+            }
+
+            // Check if path is readable
+            if (!Files.isReadable(normalizedPath)) {
+                throw new IllegalStateException(
+                    String.format("Custom repository path is not readable: %s. " +
+                        "Please check file system permissions.",
+                        sanitizePath(normalizedPath))
+                );
+            }
+
+            // If it's a file, that's valid (direct JAR reference)
+            if (Files.isRegularFile(normalizedPath)) {
+                logger.info("Custom repository path validated: Direct JAR file reference");
+                return normalizedPath;
+            }
+
+            // If it's a directory, ensure it's actually a directory
+            if (!Files.isDirectory(normalizedPath)) {
+                throw new IllegalStateException(
+                    String.format("Custom repository path is neither a file nor a directory: %s. " +
+                        "Please provide a valid directory path or JAR file path.",
+                        sanitizePath(normalizedPath))
+                );
+            }
+
+            logger.info("Custom repository path validated successfully: Maven repository directory");
+            return normalizedPath;
+
+        } catch (SecurityException e) {
+            throw new IllegalStateException(
+                "Security manager denied access to custom repository path. " +
+                "Please check security policy configuration.", e
+            );
+        }
+    }
+
+    /**
+     * Validates the default Maven repository path (~/.m2/repository).
+     * Ensures it exists, is writable, and has sufficient permissions.
+     *
+     * @param defaultPath The default repository path
+     * @throws IllegalStateException if path cannot be created or is not writable
+     */
+    public void validateDefaultRepositoryPath(Path defaultPath) {
+        if (defaultPath == null) {
+            throw new IllegalStateException(
+                "Default Maven repository path cannot be null. " +
+                "Please ensure HOME environment variable is set."
+            );
+        }
+
+        try {
+            // Create directories if they don't exist
+            Files.createDirectories(defaultPath);
+            logger.debug("Default Maven repository initialized at: {}", sanitizePath(defaultPath));
+
+            // Verify write permissions
+            if (!Files.isWritable(defaultPath)) {
+                throw new IllegalStateException(
+                    String.format("Default Maven repository is not writable: %s. " +
+                        "Please check file system permissions or disk space.",
+                        sanitizePath(defaultPath))
+                );
+            }
+
+            // Check if we can actually create a temp file (tests actual write capability)
+            Path testFile = defaultPath.resolve(".detect-write-test-" + System.nanoTime());
+            try {
+                Files.createFile(testFile);
+                Files.delete(testFile);
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                    String.format("Cannot write to default Maven repository: %s. " +
+                        "Disk might be full or permissions might be restricted. Error: %s",
+                        sanitizePath(defaultPath), e.getMessage()), e
+                );
+            }
+
+            logger.debug("Write permissions verified for: {}", sanitizePath(defaultPath));
+
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                String.format("Failed to create default Maven repository directory: %s. " +
+                    "Please check file system permissions and disk space. Error: %s",
+                    sanitizePath(defaultPath), e.getMessage()), e
+            );
+        }
+    }
+
+    /**
+     * Sanitizes a path for safe logging (removes sensitive information).
+     * Shows only the last 2-3 components of the path.
+     */
+    private String sanitizePath(Path path) {
+        if (path == null) {
+            return "<null>";
+        }
+
+        int nameCount = path.getNameCount();
+        if (nameCount <= 3) {
+            return ".../" + path.getFileName();
+        }
+
+        // Show last 3 components
+        Path subpath = path.subpath(nameCount - 3, nameCount);
+        return ".../" + subpath.toString();
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/RetryPolicy.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/artifactdownload/RetryPolicy.java
@@ -1,0 +1,340 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.artifactdownload;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.exception.ArtifactDownloadException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Random;
+
+/**
+ * Configurable retry policy for artifact downloads.
+ * Single Responsibility: Determine retry behavior and delays.
+ */
+public class RetryPolicy {
+
+    private static final Logger logger = LoggerFactory.getLogger(RetryPolicy.class);
+
+    private static final int DEFAULT_RETRY_COUNT = 3;
+    private static final long DEFAULT_INITIAL_BACKOFF_MS = 1000;
+    private static final long DEFAULT_MAX_BACKOFF_MS = 30000;
+    private static final double BACKOFF_MULTIPLIER = 2.0;
+    private static final double JITTER_FACTOR = 0.2;
+
+    private final int maxRetries;
+    private final long initialBackoffMs;
+    private final long maxBackoffMs;
+    private final Random random;
+
+    /**
+     * Creates a retry policy with default settings.
+     */
+    public static RetryPolicy defaultPolicy() {
+        return new RetryPolicy(null, null, null);
+    }
+
+    /**
+     * Creates a retry policy with custom settings.
+     *
+     * @param retryCount Maximum number of retries (null for default)
+     * @param initialBackoffMs Initial backoff in milliseconds (null for default)
+     * @param maxBackoffMs Maximum backoff in milliseconds (null for default)
+     */
+    public RetryPolicy(Integer retryCount, Long initialBackoffMs, Long maxBackoffMs) {
+        this.maxRetries = validateRetryCount(retryCount);
+        this.initialBackoffMs = validateInitialBackoff(initialBackoffMs);
+        this.maxBackoffMs = validateMaxBackoff(maxBackoffMs, this.initialBackoffMs);
+        this.random = new Random();
+
+        logger.debug("Retry policy configured: maxRetries={}, initialBackoff={}ms, maxBackoff={}ms",
+            this.maxRetries, this.initialBackoffMs, this.maxBackoffMs);
+    }
+
+    /**
+     * Determines if an exception is retryable.
+     *
+     * @param exception The exception to check
+     * @return true if the operation should be retried
+     */
+    public boolean isRetryable(ArtifactDownloadException exception) {
+        if (exception == null) {
+            return false;
+        }
+
+        switch (exception.getCategory()) {
+            case NETWORK_ERROR:
+                // Always retry network errors
+                return true;
+
+            case REPOSITORY_ERROR:
+                // Check specific error messages
+                String message = exception.getMessage();
+                if (message != null) {
+                    String lowerMessage = message.toLowerCase();
+
+                    // Retry on server errors (5xx)
+                    if (lowerMessage.contains("500") || lowerMessage.contains("502") ||
+                        lowerMessage.contains("503") || lowerMessage.contains("504")) {
+                        return true;
+                    }
+
+                    // Retry on timeout (408)
+                    if (lowerMessage.contains("408") || lowerMessage.contains("timeout")) {
+                        return true;
+                    }
+
+                    // Retry on rate limiting (429)
+                    if (lowerMessage.contains("429") || lowerMessage.contains("rate limit")) {
+                        return true;
+                    }
+
+                    // Don't retry on client errors (4xx except 408, 429)
+                    if (lowerMessage.contains("401") || lowerMessage.contains("403") ||
+                        lowerMessage.contains("404") || lowerMessage.contains("405") ||
+                        lowerMessage.contains("406") || lowerMessage.contains("409")) {
+                        return false;
+                    }
+                }
+                return false;
+
+            case PARTIAL_DOWNLOAD_ERROR:
+                // Retry partial download errors (might be transient)
+                return true;
+
+            case FILE_SYSTEM_ERROR:
+            case CONFIGURATION_ERROR:
+            case RANGE_NOT_SUPPORTED_ERROR:
+            case INSUFFICIENT_DISK_SPACE_ERROR:
+                // Don't retry these categories
+                return false;
+
+            case UNKNOWN_ERROR:
+            default:
+                // Conservative: don't retry unknown errors
+                return false;
+        }
+    }
+
+    /**
+     * Determines if an HTTP response code is retryable.
+     *
+     * @param responseCode The HTTP response code
+     * @return true if the response indicates a retryable condition
+     */
+    public boolean isRetryableResponseCode(int responseCode) {
+        // Retry on server errors (5xx)
+        if (responseCode >= 500 && responseCode < 600) {
+            return true;
+        }
+
+        // Retry on specific client errors
+        switch (responseCode) {
+            case 408: // Request Timeout
+            case 429: // Too Many Requests
+                return true;
+
+            default:
+                // Don't retry other response codes
+                return false;
+        }
+    }
+
+    /**
+     * Calculates the delay before the next retry attempt.
+     *
+     * @param attemptNumber The current attempt number (1-based)
+     * @return Delay in milliseconds
+     */
+    public long calculateBackoffMs(int attemptNumber) {
+        if (attemptNumber <= 0) {
+            return 0;
+        }
+
+        // Calculate exponential backoff
+        double baseDelay = initialBackoffMs * Math.pow(BACKOFF_MULTIPLIER, attemptNumber - 1);
+
+        // Cap at maximum backoff
+        baseDelay = Math.min(baseDelay, maxBackoffMs);
+
+        // Add jitter to avoid thundering herd
+        double jitterRange = baseDelay * JITTER_FACTOR;
+        double jitter = (random.nextDouble() - 0.5) * 2 * jitterRange;
+
+        long finalDelay = (long) Math.max(0, baseDelay + jitter);
+
+        logger.debug("Retry backoff for attempt {}: {}ms (base: {}ms, jitter: {}ms)",
+            attemptNumber, finalDelay, (long) baseDelay, (long) jitter);
+
+        return finalDelay;
+    }
+
+    /**
+     * Executes a retry with backoff.
+     *
+     * @param attemptNumber The current attempt number
+     * @param operation Description of the operation for logging
+     * @throws InterruptedException if sleep is interrupted
+     */
+    public void executeBackoff(int attemptNumber, String operation) throws InterruptedException {
+        long backoffMs = calculateBackoffMs(attemptNumber);
+
+        if (backoffMs > 0) {
+            logger.info("Retry {} of {} for {} (waiting {}ms)...",
+                attemptNumber, maxRetries, operation, backoffMs);
+
+            Thread.sleep(backoffMs);
+        }
+    }
+
+    /**
+     * Wraps a download operation with retry logic.
+     *
+     * @param operation The operation to execute
+     * @param operationName Description for logging
+     * @param <T> Result type
+     * @return The result of the operation
+     * @throws ArtifactDownloadException if all retries fail
+     */
+    public <T> T executeWithRetry(RetryableOperation<T> operation, String operationName)
+            throws ArtifactDownloadException {
+
+        ArtifactDownloadException lastException = null;
+
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                // Execute backoff if not first attempt
+                if (attempt > 1) {
+                    executeBackoff(attempt, operationName);
+                }
+
+                // Try the operation
+                logger.debug("Attempt {}/{} for {}", attempt, maxRetries, operationName);
+                return operation.execute();
+
+            } catch (ArtifactDownloadException e) {
+                lastException = e;
+
+                // Check if retryable
+                if (!isRetryable(e)) {
+                    logger.debug("Non-retryable error for {}: {}", operationName, e.getCategory());
+                    throw e;
+                }
+
+                // Check if we have more retries
+                if (attempt == maxRetries) {
+                    logger.error("All {} retry attempts exhausted for {}", maxRetries, operationName);
+                    throw e;
+                }
+
+                logger.warn("Retryable error on attempt {}/{} for {}: {}",
+                    attempt, maxRetries, operationName, e.getSanitizedMessage());
+
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new ArtifactDownloadException(
+                    ArtifactDownloadException.ErrorCategory.UNKNOWN_ERROR,
+                    operationName,
+                    "Operation interrupted",
+                    e
+                );
+            } catch (Exception e) {
+                // Wrap unexpected exceptions
+                throw new ArtifactDownloadException(
+                    ArtifactDownloadException.ErrorCategory.UNKNOWN_ERROR,
+                    operationName,
+                    "Unexpected error: " + e.getMessage(),
+                    e
+                );
+            }
+        }
+
+        // Should not reach here
+        if (lastException != null) {
+            throw lastException;
+        } else {
+            throw new ArtifactDownloadException(
+                ArtifactDownloadException.ErrorCategory.UNKNOWN_ERROR,
+                operationName,
+                "Retry logic error: no exception captured"
+            );
+        }
+    }
+
+    /**
+     * Functional interface for retryable operations.
+     */
+    @FunctionalInterface
+    public interface RetryableOperation<T> {
+        T execute() throws Exception;
+    }
+
+    // Validation methods
+
+    private int validateRetryCount(Integer retryCount) {
+        if (retryCount == null) {
+            return DEFAULT_RETRY_COUNT;
+        }
+
+        if (retryCount < 0) {
+            logger.warn("Retry count cannot be negative ({}), using 0", retryCount);
+            return 0;
+        }
+
+        if (retryCount > 10) {
+            logger.warn("Retry count {} exceeds maximum (10), using 10", retryCount);
+            return 10;
+        }
+
+        return retryCount;
+    }
+
+    private long validateInitialBackoff(Long initialBackoffMs) {
+        if (initialBackoffMs == null) {
+            return DEFAULT_INITIAL_BACKOFF_MS;
+        }
+
+        if (initialBackoffMs < 0) {
+            logger.warn("Initial backoff cannot be negative ({}), using 0", initialBackoffMs);
+            return 0;
+        }
+
+        if (initialBackoffMs > 60000) {
+            logger.warn("Initial backoff {}ms exceeds maximum (60s), using 60s", initialBackoffMs);
+            return 60000;
+        }
+
+        return initialBackoffMs;
+    }
+
+    private long validateMaxBackoff(Long maxBackoffMs, long initialBackoff) {
+        if (maxBackoffMs == null) {
+            return DEFAULT_MAX_BACKOFF_MS;
+        }
+
+        if (maxBackoffMs < initialBackoff) {
+            logger.warn("Max backoff {}ms is less than initial backoff {}ms, using initial backoff",
+                maxBackoffMs, initialBackoff);
+            return initialBackoff;
+        }
+
+        if (maxBackoffMs > 300000) {
+            logger.warn("Max backoff {}ms exceeds maximum (5min), using 5min", maxBackoffMs);
+            return 300000;
+        }
+
+        return maxBackoffMs;
+    }
+
+    // Getters for configuration
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public long getInitialBackoffMs() {
+        return initialBackoffMs;
+    }
+
+    public long getMaxBackoffMs() {
+        return maxBackoffMs;
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/exception/ArtifactDownloadException.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/exception/ArtifactDownloadException.java
@@ -1,0 +1,113 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.exception;
+
+/**
+ * Custom exception for artifact download failures with categorized error types.
+ * Provides structured error information for better diagnostics and error handling.
+ */
+public class ArtifactDownloadException extends Exception {
+
+    /**
+     * Error categories for different types of download failures.
+     */
+    public enum ErrorCategory {
+        NETWORK_ERROR("Network communication failed"),
+        REPOSITORY_ERROR("Repository access or artifact availability issue"),
+        FILE_SYSTEM_ERROR("Local file system operation failed"),
+        CONFIGURATION_ERROR("Invalid configuration detected"),
+        PARTIAL_DOWNLOAD_ERROR("Partial download or resume operation failed"),
+        RANGE_NOT_SUPPORTED_ERROR("Server does not support resume/range requests"),
+        INSUFFICIENT_DISK_SPACE_ERROR("Insufficient disk space for download"),
+        UNKNOWN_ERROR("Unexpected error occurred");
+
+        private final String description;
+
+        ErrorCategory(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    private final ErrorCategory category;
+    private final String artifactCoordinates;
+    private final String actionableMessage;
+
+    /**
+     * Constructs an ArtifactDownloadException with full details.
+     *
+     * @param category The error category
+     * @param artifactCoordinates The artifact being downloaded (can be null)
+     * @param actionableMessage User-friendly message with suggested actions
+     * @param cause The underlying exception (can be null)
+     */
+    public ArtifactDownloadException(
+            ErrorCategory category,
+            String artifactCoordinates,
+            String actionableMessage,
+            Throwable cause) {
+        super(buildMessage(category, artifactCoordinates, actionableMessage), cause);
+        this.category = category;
+        this.artifactCoordinates = artifactCoordinates;
+        this.actionableMessage = actionableMessage;
+    }
+
+    /**
+     * Constructs an ArtifactDownloadException without a cause.
+     */
+    public ArtifactDownloadException(
+            ErrorCategory category,
+            String artifactCoordinates,
+            String actionableMessage) {
+        this(category, artifactCoordinates, actionableMessage, null);
+    }
+
+    private static String buildMessage(
+            ErrorCategory category,
+            String artifactCoordinates,
+            String actionableMessage) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[").append(category.name()).append("] ");
+        sb.append(category.getDescription());
+
+        if (artifactCoordinates != null && !artifactCoordinates.isEmpty()) {
+            sb.append(" for artifact: ").append(artifactCoordinates);
+        }
+
+        if (actionableMessage != null && !actionableMessage.isEmpty()) {
+            sb.append(". ").append(actionableMessage);
+        }
+
+        return sb.toString();
+    }
+
+    public ErrorCategory getCategory() {
+        return category;
+    }
+
+    public String getArtifactCoordinates() {
+        return artifactCoordinates;
+    }
+
+    public String getActionableMessage() {
+        return actionableMessage;
+    }
+
+    /**
+     * Creates a sanitized version of this exception for logging.
+     * Removes sensitive information like full file paths.
+     */
+    public String getSanitizedMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[").append(category.name()).append("] ");
+        sb.append(category.getDescription());
+
+        if (artifactCoordinates != null && !artifactCoordinates.isEmpty()) {
+            sb.append(" for artifact: ").append(artifactCoordinates);
+        }
+
+        // Don't include actionable message in sanitized version as it might contain paths
+        return sb.toString();
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/exception/DownloadErrorFactory.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/exception/DownloadErrorFactory.java
@@ -1,0 +1,249 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.exception;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.net.ConnectException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.NoSuchFileException;
+
+/**
+ * Factory for creating categorized download exceptions.
+ * Single Responsibility: Centralize exception creation and categorization logic.
+ */
+public class DownloadErrorFactory {
+
+    /**
+     * Creates an exception for network-related failures.
+     */
+    public static ArtifactDownloadException networkError(String artifactId, String message, Throwable cause) {
+        return new ArtifactDownloadException(
+            ArtifactDownloadException.ErrorCategory.NETWORK_ERROR,
+            artifactId,
+            message,
+            cause
+        );
+    }
+
+    /**
+     * Creates an exception for repository-related failures.
+     */
+    public static ArtifactDownloadException repositoryError(String artifactId, String message, Throwable cause) {
+        return new ArtifactDownloadException(
+            ArtifactDownloadException.ErrorCategory.REPOSITORY_ERROR,
+            artifactId,
+            message,
+            cause
+        );
+    }
+
+    /**
+     * Creates an exception for file system failures.
+     */
+    public static ArtifactDownloadException fileSystemError(String artifactId, String message, Throwable cause) {
+        return new ArtifactDownloadException(
+            ArtifactDownloadException.ErrorCategory.FILE_SYSTEM_ERROR,
+            artifactId,
+            message,
+            cause
+        );
+    }
+
+    /**
+     * Creates an exception for configuration errors.
+     */
+    public static ArtifactDownloadException configurationError(String artifactId, String message) {
+        return new ArtifactDownloadException(
+            ArtifactDownloadException.ErrorCategory.CONFIGURATION_ERROR,
+            artifactId,
+            message
+        );
+    }
+
+    /**
+     * Creates an exception for partial download failures.
+     */
+    public static ArtifactDownloadException partialDownloadError(String artifactId, String message, Throwable cause) {
+        return new ArtifactDownloadException(
+            ArtifactDownloadException.ErrorCategory.PARTIAL_DOWNLOAD_ERROR,
+            artifactId,
+            message,
+            cause
+        );
+    }
+
+    /**
+     * Creates an exception when server doesn't support range requests.
+     */
+    public static ArtifactDownloadException rangeNotSupportedError(String artifactId, String message) {
+        return new ArtifactDownloadException(
+            ArtifactDownloadException.ErrorCategory.RANGE_NOT_SUPPORTED_ERROR,
+            artifactId,
+            message
+        );
+    }
+
+    /**
+     * Creates an exception for insufficient disk space.
+     */
+    public static ArtifactDownloadException insufficientDiskSpaceError(String artifactId,
+                                                                       long available,
+                                                                       long required) {
+        String message = String.format(
+            "Insufficient disk space: %.1f MB available, %.1f MB required. " +
+            "Free up disk space or configure a different download location.",
+            available / (1024.0 * 1024),
+            required / (1024.0 * 1024)
+        );
+        return new ArtifactDownloadException(
+            ArtifactDownloadException.ErrorCategory.INSUFFICIENT_DISK_SPACE_ERROR,
+            artifactId,
+            message
+        );
+    }
+
+    /**
+     * Creates an exception for unknown errors.
+     */
+    public static ArtifactDownloadException unknownError(String artifactId, String message, Throwable cause) {
+        return new ArtifactDownloadException(
+            ArtifactDownloadException.ErrorCategory.UNKNOWN_ERROR,
+            artifactId,
+            message,
+            cause
+        );
+    }
+
+    /**
+     * Categorizes an IOException and creates appropriate exception.
+     */
+    public static ArtifactDownloadException fromIOException(String artifactId, IOException e) {
+        // Socket timeout
+        if (e instanceof SocketTimeoutException) {
+            return networkError(artifactId,
+                "Connection timed out. Consider increasing timeout values or checking network latency.",
+                e);
+        }
+
+        // DNS resolution failure
+        if (e instanceof UnknownHostException) {
+            return networkError(artifactId,
+                "Cannot resolve Maven Central hostname. Check DNS configuration and internet connectivity.",
+                e);
+        }
+
+        // Connection refused
+        if (e instanceof ConnectException) {
+            String message = e.getMessage();
+            if (message != null && message.contains("refused")) {
+                return networkError(artifactId,
+                    "Connection refused by server. Check network connectivity and firewall settings.",
+                    e);
+            }
+        }
+
+        // File access denied
+        if (e instanceof AccessDeniedException) {
+            return fileSystemError(artifactId,
+                "Access denied to file or directory. Check file system permissions.",
+                e);
+        }
+
+        // File not found
+        if (e instanceof NoSuchFileException) {
+            return fileSystemError(artifactId,
+                "File or directory not found. Check path configuration.",
+                e);
+        }
+
+        // Check message for common patterns
+        String message = e.getMessage();
+        if (message != null) {
+            String lowerMessage = message.toLowerCase();
+
+            // Disk space issues
+            if (lowerMessage.contains("no space left") || lowerMessage.contains("disk full")) {
+                return fileSystemError(artifactId,
+                    "Insufficient disk space to save artifact. Free up disk space and retry.",
+                    e);
+            }
+
+            // Permission issues
+            if (lowerMessage.contains("permission denied") || lowerMessage.contains("access denied")) {
+                return fileSystemError(artifactId,
+                    "Permission denied. Check file system permissions for the download directory.",
+                    e);
+            }
+
+            // Network issues
+            if (lowerMessage.contains("connection reset") || lowerMessage.contains("broken pipe")) {
+                return networkError(artifactId,
+                    "Connection was reset. Check network stability and retry.",
+                    e);
+            }
+
+            // SSL/TLS issues
+            if (lowerMessage.contains("ssl") || lowerMessage.contains("tls") ||
+                lowerMessage.contains("certificate")) {
+                return networkError(artifactId,
+                    "SSL/TLS error. Check certificate configuration and proxy settings.",
+                    e);
+            }
+        }
+
+        // Default to network error for unclassified IOException
+        return networkError(artifactId,
+            "IO error during download. Check network stability and disk permissions.",
+            e);
+    }
+
+    /**
+     * Creates exception from HTTP response code.
+     */
+    public static ArtifactDownloadException fromHttpError(String artifactId, int responseCode) {
+        switch (responseCode) {
+            case 401:
+                return repositoryError(artifactId,
+                    "Authentication required (401). Repository requires credentials.",
+                    null);
+
+            case 403:
+                return repositoryError(artifactId,
+                    "Access forbidden (403). Check repository permissions.",
+                    null);
+
+            case 404:
+                return repositoryError(artifactId,
+                    "Artifact not found in repository (404).",
+                    null);
+
+            case 429:
+                return repositoryError(artifactId,
+                    "Too many requests (429). Rate limited by repository.",
+                    null);
+
+            case 500:
+            case 502:
+            case 503:
+            case 504:
+                return repositoryError(artifactId,
+                    String.format("Repository server error (%d). Try again later.", responseCode),
+                    null);
+
+            default:
+                if (responseCode >= 400 && responseCode < 500) {
+                    return repositoryError(artifactId,
+                        String.format("Client error (%d). Check request configuration.", responseCode),
+                        null);
+                } else if (responseCode >= 500) {
+                    return repositoryError(artifactId,
+                        String.format("Server error (%d). Repository may be temporarily unavailable.", responseCode),
+                        null);
+                } else {
+                    return unknownError(artifactId,
+                        String.format("Unexpected HTTP response code: %d", responseCode),
+                        null);
+                }
+        }
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/mavendownload/MavenDownloader.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/mavendownload/MavenDownloader.java
@@ -1,20 +1,30 @@
 package com.blackduck.integration.detectable.detectables.maven.resolver.mavendownload;
 
+import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorConfig;
+import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorResolver;
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.*;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -22,9 +32,32 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
+/**
+ * Downloads parent POMs and BOM POMs (and shaded-dependency POMs) directly via HTTP.
+ *
+ * <p>Used during the bootstrap phase, before Aether has built a session, where we still need to
+ * fetch a single POM file in order to assemble the effective project model. Aether is not
+ * available at this stage, so this class performs raw HTTP GETs.
+ *
+ * <p>This downloader is <strong>mirror-aware</strong>: every configured {@link JavaRepository}
+ * (including the implicit Maven Central and the Sonatype snapshot fallbacks) is resolved against
+ * the supplied list of {@link MavenMirrorConfig} via {@link MavenMirrorResolver} before any URL
+ * is built. When a mirror matches:
+ * <ul>
+ *     <li>the request URL is rewritten to the mirror's URL, and</li>
+ *     <li>if the mirror has credentials, an {@code Authorization: Basic} header is attached.</li>
+ * </ul>
+ *
+ * <p>Mirror substitution is intentionally applied even to the Sonatype snapshot fallbacks: a
+ * mirror with {@code mirrorOf=*} should intercept all repositories, fallbacks included; a mirror
+ * scoped to {@code central} (or any specific id) leaves the fallbacks untouched.
+ *
+ * <p>This class is not thread-safe; instances are intended to be short-lived and used per-POM.
+ */
 public class MavenDownloader {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final List<JavaRepository> remoteRepositories;
+    private final List<MavenMirrorConfig> mirrorConfigs;
     private final Path downloadDir;
 
     private static final String MAVEN_METADATA_XML = "maven-metadata.xml";
@@ -39,19 +72,51 @@ public class MavenDownloader {
         MAVEN_CENTRAL.setReleasesEnabled(true);
     }
 
-    private static final List<String> SONATYPE_FALLBACK_REPOS = Arrays.asList(
-        "https://oss.sonatype.org/content/repositories/snapshots/",
-        "https://s01.oss.sonatype.org/content/repositories/snapshots/",
-        "https://central.sonatype.com/repository/maven-snapshots/"
+    /**
+     * Sonatype snapshot fallback repositories, modelled as {@link JavaRepository} so they go
+     * through the same mirror-resolution path as configured repositories. Their id is set to
+     * {@code "sonatype-snapshots"} so a mirror with {@code mirrorOf=*} (or one explicitly
+     * targeting that id) will still intercept them.
+     */
+    private static final List<JavaRepository> SONATYPE_FALLBACK_REPOSITORIES = Arrays.asList(
+        sonatypeFallback("https://oss.sonatype.org/content/repositories/snapshots/"),
+        sonatypeFallback("https://s01.oss.sonatype.org/content/repositories/snapshots/"),
+        sonatypeFallback("https://central.sonatype.com/repository/maven-snapshots/")
     );
 
+    private static JavaRepository sonatypeFallback(String url) {
+        JavaRepository repo = new JavaRepository();
+        repo.setId("sonatype-snapshots");
+        repo.setName("Sonatype Snapshots Fallback");
+        repo.setUrl(url);
+        repo.setSnapshotsEnabled(true);
+        repo.setReleasesEnabled(false);
+        return repo;
+    }
+
+    /**
+     * Constructs a downloader without mirror support. Equivalent to passing an empty mirror list.
+     * Retained for callers that have not yet been threaded for mirror configuration.
+     */
     public MavenDownloader(List<JavaRepository> remoteRepositories, Path downloadDir) {
+        this(remoteRepositories, downloadDir, Collections.emptyList());
+    }
+
+    /**
+     * Constructs a mirror-aware downloader.
+     *
+     * @param remoteRepositories repositories declared in the POM being processed; may be null
+     * @param downloadDir        directory where downloaded POMs will be written
+     * @param mirrorConfigs      mirror configurations to apply; may be null or empty for none
+     */
+    public MavenDownloader(List<JavaRepository> remoteRepositories, Path downloadDir, @Nullable List<MavenMirrorConfig> mirrorConfigs) {
         if (remoteRepositories != null) {
             this.remoteRepositories = new ArrayList<>(remoteRepositories);
         } else {
             this.remoteRepositories = new ArrayList<>();
         }
         this.downloadDir = downloadDir;
+        this.mirrorConfigs = (mirrorConfigs != null) ? new ArrayList<>(mirrorConfigs) : Collections.emptyList();
 
         boolean centralRepoMissing = this.remoteRepositories.stream()
             .noneMatch(repo -> MAVEN_CENTRAL.getUrl().equalsIgnoreCase(repo.getUrl()));
@@ -151,42 +216,40 @@ public class MavenDownloader {
     }
 
     private File tryDownloadFromRepository(JavaRepository repository, DownloadContext ctx) {
+        EffectiveRepository effective = resolveEffectiveRepository(repository);
         try {
-            String baseUrl = normalizeBaseUrl(repository.getUrl());
-
             if (ctx.isSnapshot) {
-                File snapshotResult = trySnapshotDownload(baseUrl, ctx);
+                File snapshotResult = trySnapshotDownload(effective, ctx);
                 if (snapshotResult != null) {
                     return snapshotResult;
                 }
             }
-
-            return tryDirectDownload(repository, ctx);
+            return tryDirectDownload(effective, ctx);
         } catch (Exception e) {
-            logger.debug("Failed to mavendownload from repository {} for coordinates {}:{}:{} - exception: {}",
-                repository.getUrl(), ctx.groupId, ctx.artifactId, ctx.version, e.toString());
+            logger.debug("Failed to mavendownload from repository {} (effective {}) for coordinates {}:{}:{} - exception: {}",
+                repository.getUrl(), effective.baseUrl, ctx.groupId, ctx.artifactId, ctx.version, e.toString());
             logger.debug("Download exception stacktrace for repository {}: ", repository.getUrl(), e);
         }
         return null;
     }
 
-    private File trySnapshotDownload(String baseUrl, DownloadContext ctx) {
-        String metadataUrl = baseUrl + ctx.versionDir + MAVEN_METADATA_XML;
+    private File trySnapshotDownload(EffectiveRepository effective, DownloadContext ctx) {
+        String metadataUrl = effective.baseUrl + ctx.versionDir + MAVEN_METADATA_XML;
 
-        File result = trySnapshotVersionMetadataDownload(baseUrl, metadataUrl, ctx);
+        File result = trySnapshotVersionMetadataDownload(effective, metadataUrl, ctx);
         if (result != null) {
             return result;
         }
 
-        return tryTimestampBuildMetadataDownload(baseUrl, metadataUrl, ctx);
+        return tryTimestampBuildMetadataDownload(effective, metadataUrl, ctx);
     }
 
-    private File trySnapshotVersionMetadataDownload(String baseUrl, String metadataUrl, DownloadContext ctx) {
-        try (InputStream metaIn = new URL(metadataUrl).openStream()) {
+    private File trySnapshotVersionMetadataDownload(EffectiveRepository effective, String metadataUrl, DownloadContext ctx) {
+        try (InputStream metaIn = openStream(new URL(metadataUrl), effective)) {
             logger.debug("Found {} at {}", MAVEN_METADATA_XML, metadataUrl);
             String timestamped = parseSnapshotVersionFromMetadata(metaIn, ctx.artifactId);
             if (timestamped != null) {
-                return downloadTimestampedPom(baseUrl, ctx, timestamped, "timestamped snapshot");
+                return downloadTimestampedPom(effective, ctx, timestamped, "timestamped snapshot");
             }
             logger.debug("No snapshotVersion entry found in metadata for POM; will attempt timestamp+buildNumber method if present.");
         } catch (Exception metaEx) {
@@ -195,11 +258,11 @@ public class MavenDownloader {
         return null;
     }
 
-    private File tryTimestampBuildMetadataDownload(String baseUrl, String metadataUrl, DownloadContext ctx) {
-        try (InputStream metaIn = new URL(metadataUrl).openStream()) {
+    private File tryTimestampBuildMetadataDownload(EffectiveRepository effective, String metadataUrl, DownloadContext ctx) {
+        try (InputStream metaIn = openStream(new URL(metadataUrl), effective)) {
             String ts = parseTimestampBuildFromMetadata(metaIn);
             if (ts != null) {
-                return downloadTimestampedPom(baseUrl, ctx, ts, "constructed timestamped");
+                return downloadTimestampedPom(effective, ctx, ts, "constructed timestamped");
             }
         } catch (Exception e) {
             logger.debug("Failed to re-read metadata for timestamp+buildNumber method: {}", e.getMessage());
@@ -207,12 +270,12 @@ public class MavenDownloader {
         return null;
     }
 
-    private File downloadTimestampedPom(String baseUrl, DownloadContext ctx, String timestamped, String description) {
+    private File downloadTimestampedPom(EffectiveRepository effective, DownloadContext ctx, String timestamped, String description) {
         try {
             String timestampedPomPath = ctx.versionDir + ctx.artifactId + "-" + timestamped + ".pom";
-            URL pomUrl = new URL(baseUrl + timestampedPomPath);
+            URL pomUrl = new URL(effective.baseUrl + timestampedPomPath);
             logger.info("Attempting to mavendownload {} POM from {}", description, pomUrl);
-            if (downloadUrlToPath(pomUrl, ctx.newDestination)) {
+            if (downloadUrlToPath(pomUrl, ctx.newDestination, effective)) {
                 logger.info("Successfully downloaded {} POM to: {}", description, ctx.newDestination);
                 return ctx.newDestination.toFile();
             }
@@ -223,13 +286,14 @@ public class MavenDownloader {
         return null;
     }
 
-    private File tryDirectDownload(JavaRepository repository, DownloadContext ctx) {
+    private File tryDirectDownload(EffectiveRepository effective, DownloadContext ctx) {
         try {
-            URL url = new URL(normalizeBaseUrl(repository.getUrl()) + ctx.pomPath);
-            logger.debug("Attempting to mavendownload parent POM from: {} (repo id={}, repo name={})",
-                url, repository.getId(), repository.getName());
-            if (downloadUrlToPath(url, ctx.newDestination)) {
-                logger.debug("Successfully downloaded POM to: {} (from repo: {})", ctx.newDestination, repository.getUrl());
+            URL url = new URL(effective.baseUrl + ctx.pomPath);
+            logger.debug("Attempting to mavendownload parent POM from: {} (repo id={}, repo name={}{})",
+                url, effective.origin.getId(), effective.origin.getName(),
+                effective.isMirrored() ? ", via mirror" : "");
+            if (downloadUrlToPath(url, ctx.newDestination, effective)) {
+                logger.debug("Successfully downloaded POM to: {} (from repo: {})", ctx.newDestination, effective.describe());
                 return ctx.newDestination.toFile();
             }
         } catch (Exception e) {
@@ -239,8 +303,15 @@ public class MavenDownloader {
     }
 
     private File trySonatypeFallbacks(DownloadContext ctx) {
-        for (String base : SONATYPE_FALLBACK_REPOS) {
-            File result = trySonatypeFallback(base, ctx);
+        // Resolve and dedupe by effective base URL — a wildcard mirror would otherwise
+        // collapse all fallbacks into the same effective URL and we'd retry it pointlessly.
+        Set<String> attempted = new LinkedHashSet<>();
+        for (JavaRepository fallback : SONATYPE_FALLBACK_REPOSITORIES) {
+            EffectiveRepository effective = resolveEffectiveRepository(fallback);
+            if (!attempted.add(effective.baseUrl)) {
+                continue;
+            }
+            File result = trySonatypeFallback(effective, ctx);
             if (result != null) {
                 return result;
             }
@@ -248,32 +319,29 @@ public class MavenDownloader {
         return null;
     }
 
-    private File trySonatypeFallback(String baseUrl, DownloadContext ctx) {
+    private File trySonatypeFallback(EffectiveRepository effective, DownloadContext ctx) {
         try {
-            String normalizedBase = normalizeBaseUrl(baseUrl);
-
-            File metadataResult = tryFallbackMetadataDownload(normalizedBase, ctx);
+            File metadataResult = tryFallbackMetadataDownload(effective, ctx);
             if (metadataResult != null) {
                 return metadataResult;
             }
-
-            return tryFallbackDirectDownload(normalizedBase, ctx);
+            return tryFallbackDirectDownload(effective, ctx);
         } catch (Exception e) {
-            logger.debug("Fallback attempt failed for base {}: {}", baseUrl, e.getMessage());
+            logger.debug("Fallback attempt failed for base {}: {}", effective.baseUrl, e.getMessage());
         }
         return null;
     }
 
-    private File tryFallbackMetadataDownload(String baseUrl, DownloadContext ctx) {
-        String metadataUrl = baseUrl + ctx.versionDir + MAVEN_METADATA_XML;
-        try (InputStream metaIn = new URL(metadataUrl).openStream()) {
+    private File tryFallbackMetadataDownload(EffectiveRepository effective, DownloadContext ctx) {
+        String metadataUrl = effective.baseUrl + ctx.versionDir + MAVEN_METADATA_XML;
+        try (InputStream metaIn = openStream(new URL(metadataUrl), effective)) {
             logger.debug("Found {} at {} (fallback)", MAVEN_METADATA_XML, metadataUrl);
             String timestamped = parseSnapshotVersionFromMetadata(metaIn, ctx.artifactId);
             if (timestamped != null) {
                 String timestampedPomPath = ctx.versionDir + ctx.artifactId + "-" + timestamped + ".pom";
-                URL pomUrl = new URL(baseUrl + timestampedPomPath);
+                URL pomUrl = new URL(effective.baseUrl + timestampedPomPath);
                 logger.info("Attempting to mavendownload timestamped snapshot POM from fallback {}", pomUrl);
-                if (downloadUrlToPath(pomUrl, ctx.newDestination)) {
+                if (downloadUrlToPath(pomUrl, ctx.newDestination, effective)) {
                     logger.info("Successfully downloaded timestamped snapshot POM from fallback to: {}", ctx.newDestination);
                     return ctx.newDestination.toFile();
                 }
@@ -286,11 +354,11 @@ public class MavenDownloader {
         return null;
     }
 
-    private File tryFallbackDirectDownload(String baseUrl, DownloadContext ctx) {
+    private File tryFallbackDirectDownload(EffectiveRepository effective, DownloadContext ctx) {
         try {
-            URL url = new URL(baseUrl + ctx.pomPath);
+            URL url = new URL(effective.baseUrl + ctx.pomPath);
             logger.debug("Attempting fallback mavendownload from {}", url);
-            if (downloadUrlToPath(url, ctx.newDestination)) {
+            if (downloadUrlToPath(url, ctx.newDestination, effective)) {
                 logger.info("Successfully downloaded POM from fallback to: {}", ctx.newDestination);
                 return ctx.newDestination.toFile();
             }
@@ -304,25 +372,64 @@ public class MavenDownloader {
         return url.endsWith("/") ? url : url + "/";
     }
 
+    /**
+     * Resolves a {@link JavaRepository} into an {@link EffectiveRepository} by consulting the
+     * configured mirrors. If a mirror matches the repository's id, its URL and credentials are
+     * substituted; otherwise the repository's own URL is used.
+     */
+    private EffectiveRepository resolveEffectiveRepository(JavaRepository repository) {
+        MavenMirrorConfig mirror = MavenMirrorResolver.findMatchingMirror(mirrorConfigs, repository.getId());
+        if (mirror != null) {
+            logger.debug("Mirror '{}' redirects repository '{}' ({}) to {}",
+                mirror.getId(), repository.getId(), repository.getUrl(), mirror.getUrl());
+            return new EffectiveRepository(normalizeBaseUrl(mirror.getUrl()), mirror.getUsername(), mirror.getPassword(), mirror.getId(), repository);
+        }
+        return new EffectiveRepository(normalizeBaseUrl(repository.getUrl()), null, null, null, repository);
+    }
+
     private void logDownloadFailure(DownloadContext ctx) {
         String triedRepos = remoteRepositories.stream()
-            .map(JavaRepository::getUrl)
+            .map(repo -> resolveEffectiveRepository(repo).describe())
             .collect(Collectors.joining(", "));
 
         logger.error("Could not mavendownload POM for coordinates: {}:{}:{}; tried repositories: {}; downloadDir: {}",
             ctx.groupId, ctx.artifactId, ctx.version, triedRepos, downloadDir.toAbsolutePath());
     }
 
-    private boolean downloadUrlToPath(URL url, Path destination) {
-        try (InputStream inputStream = url.openStream();
-             ReadableByteChannel readableByteChannel = Channels.newChannel(inputStream);
-             FileOutputStream fileOutputStream = new FileOutputStream(destination.toFile())) {
-            fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
-            return true;
+    /**
+     * Opens an input stream to the given URL, attaching an {@code Authorization: Basic} header
+     * when the effective repository carries credentials. Centralizing this means every code path
+     * that performs a raw HTTP read gets authentication for free.
+     */
+    private InputStream openStream(URL url, EffectiveRepository effective) throws IOException {
+        URLConnection connection = url.openConnection();
+        applyBasicAuth(connection, effective);
+        return connection.getInputStream();
+    }
+
+    private boolean downloadUrlToPath(URL url, Path destination, EffectiveRepository effective) {
+        try {
+            URLConnection connection = url.openConnection();
+            applyBasicAuth(connection, effective);
+            try (InputStream inputStream = connection.getInputStream();
+                 ReadableByteChannel readableByteChannel = Channels.newChannel(inputStream);
+                 FileOutputStream fileOutputStream = new FileOutputStream(destination.toFile())) {
+                fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+                return true;
+            }
         } catch (Exception e) {
             logger.debug("Failed to mavendownload URL {}: {}", url, e.getMessage());
             return false;
         }
+    }
+
+    private void applyBasicAuth(URLConnection connection, EffectiveRepository effective) {
+        if (!effective.hasCredentials()) {
+            return;
+        }
+        String token = effective.username + ":" + effective.password;
+        String encoded = Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
+        connection.setRequestProperty("Authorization", "Basic " + encoded);
     }
 
     private String parseSnapshotVersionFromMetadata(InputStream metaIn, String artifactId) {
@@ -408,4 +515,43 @@ public class MavenDownloader {
             this.oldDestination = downloadDir.resolve(artifactId + "-" + version + ".pom");
         }
     }
+
+    /**
+     * The repository URL (and optional credentials) actually used for HTTP requests, after mirror
+     * substitution has been applied. Carries a back-reference to the originating
+     * {@link JavaRepository} for diagnostic logging.
+     */
+    private static final class EffectiveRepository {
+        final String baseUrl;
+        @Nullable final String username;
+        @Nullable final String password;
+        @Nullable final String mirrorId; // null when no mirror was applied
+        final JavaRepository origin;
+
+        EffectiveRepository(String baseUrl, @Nullable String username, @Nullable String password,
+                            @Nullable String mirrorId, JavaRepository origin) {
+            this.baseUrl = baseUrl;
+            this.username = username;
+            this.password = password;
+            this.mirrorId = mirrorId;
+            this.origin = origin;
+        }
+
+        boolean hasCredentials() {
+            return username != null && !username.isEmpty()
+                && password != null && !password.isEmpty();
+        }
+
+        boolean isMirrored() {
+            return mirrorId != null;
+        }
+
+        String describe() {
+            if (isMirrored()) {
+                return origin.getUrl() + " [via mirror '" + mirrorId + "' -> " + baseUrl + "]";
+            }
+            return origin.getUrl();
+        }
+    }
 }
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/mirror/MavenMirrorResolver.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/mirror/MavenMirrorResolver.java
@@ -1,0 +1,85 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.mirror;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Stateless utility for matching repositories against Maven mirror configurations.
+ *
+ * <p>Encapsulates the {@code <mirrorOf>} pattern matching syntax defined by Maven:
+ * <ul>
+ *   <li>{@code *} or {@code external:*} — matches any repository</li>
+ *   <li>{@code repoId} — matches that single repository id</li>
+ *   <li>{@code !repoId} — explicitly excludes that repository id</li>
+ *   <li>Tokens are comma-separated, e.g. {@code *,!internal-repo}</li>
+ * </ul>
+ *
+ * <p>This class exists so that every code path that needs mirror substitution
+ * (Aether-driven JAR download, raw POM download, fallback download, ...) shares a
+ * single, well-tested implementation. Callers should never re-implement matching inline.
+ *
+ * <p>Thread-safety: stateless and thread-safe.
+ */
+public final class MavenMirrorResolver {
+
+    private MavenMirrorResolver() {
+        // utility class — not instantiable
+    }
+
+    /**
+     * Returns the first mirror whose {@code mirrorOf} pattern matches the given repository id,
+     * or {@code null} when no mirror applies.
+     *
+     * @param mirrors mirror configurations to consult — may be null or empty
+     * @param repoId  id of the repository being requested — may be null (returns null)
+     * @return the matching mirror, or {@code null}
+     */
+    @Nullable
+    public static MavenMirrorConfig findMatchingMirror(@Nullable List<MavenMirrorConfig> mirrors, @Nullable String repoId) {
+        if (mirrors == null || mirrors.isEmpty() || repoId == null) {
+            return null;
+        }
+        for (MavenMirrorConfig mirror : mirrors) {
+            if (matchesMirrorOf(mirror.getMirrorOf(), repoId)) {
+                return mirror;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Tests whether the given {@code mirrorOf} pattern matches a repository id.
+     *
+     * @param mirrorOf comma-separated mirror-of expression (see class javadoc)
+     * @param repoId   repository id to test
+     * @return {@code true} if the pattern includes (and does not exclude) the repository id
+     */
+    public static boolean matchesMirrorOf(@Nullable String mirrorOf, @Nullable String repoId) {
+        if (mirrorOf == null || mirrorOf.trim().isEmpty() || repoId == null) {
+            return false;
+        }
+
+        boolean included = false;
+        boolean excluded = false;
+
+        for (String part : mirrorOf.split(",")) {
+            String token = part.trim();
+            if (token.isEmpty()) {
+                continue;
+            }
+            if (token.startsWith("!")) {
+                if (token.substring(1).equals(repoId)) {
+                    excluded = true;
+                }
+            } else if ("*".equals(token) || "external:*".equals(token)) {
+                included = true;
+            } else if (token.equals(repoId)) {
+                included = true;
+            }
+        }
+
+        return included && !excluded;
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlPlugin.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlPlugin.java
@@ -1,11 +1,15 @@
 package com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml;
 
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.util.List;
 
 /**
  * Represents a {@code <plugin>} element within the {@code <build><plugins>} section of a Maven POM.
  *
- * <p>Captures basic plugin coordinates for plugin detection and tracking.
+ * <p>Captures plugin coordinates plus the {@code <configuration>} and {@code <executions>} blocks
+ * needed to read maven-shade-plugin relocation and exclusion settings.
  */
 public class PomXmlPlugin {
     @JacksonXmlProperty(localName = "groupId")
@@ -17,28 +21,27 @@ public class PomXmlPlugin {
     @JacksonXmlProperty(localName = "version")
     private String version;
 
-    public String getGroupId() {
-        return groupId;
-    }
+    /** Plugin-level configuration (Style A — less common for shade plugin). */
+    @JacksonXmlProperty(localName = "configuration")
+    private PomXmlShadeConfig configuration;
 
-    public void setGroupId(String groupId) {
-        this.groupId = groupId;
-    }
+    /** Execution-level configuration (Style B — most common for shade plugin). */
+    @JacksonXmlElementWrapper(localName = "executions")
+    @JacksonXmlProperty(localName = "execution")
+    private List<PomXmlShadeExecution> executions;
 
-    public String getArtifactId() {
-        return artifactId;
-    }
+    public String getGroupId() { return groupId; }
+    public void setGroupId(String groupId) { this.groupId = groupId; }
 
-    public void setArtifactId(String artifactId) {
-        this.artifactId = artifactId;
-    }
+    public String getArtifactId() { return artifactId; }
+    public void setArtifactId(String artifactId) { this.artifactId = artifactId; }
 
-    public String getVersion() {
-        return version;
-    }
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
 
-    public void setVersion(String version) {
-        this.version = version;
-    }
+    public PomXmlShadeConfig getConfiguration() { return configuration; }
+    public void setConfiguration(PomXmlShadeConfig configuration) { this.configuration = configuration; }
+
+    public List<PomXmlShadeExecution> getExecutions() { return executions; }
+    public void setExecutions(List<PomXmlShadeExecution> executions) { this.executions = executions; }
 }
-

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlShadeArtifactSet.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlShadeArtifactSet.java
@@ -1,0 +1,39 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.util.List;
+
+/**
+ * Represents the {@code <artifactSet>} element inside the maven-shade-plugin's
+ * {@code <configuration>} block.
+ *
+ * <p>Example POM fragment:
+ * <pre>{@code
+ * <artifactSet>
+ *     <excludes>
+ *         <exclude>com.google.guava:guava</exclude>
+ *         <exclude>org.apache.hadoop:*</exclude>
+ *     </excludes>
+ * </artifactSet>
+ * }</pre>
+ *
+ * <p>Each {@code <exclude>} entry is a {@code groupId:artifactId} pattern where
+ * {@code *} acts as a wildcard for either coordinate.
+ */
+public class PomXmlShadeArtifactSet {
+
+    @JacksonXmlElementWrapper(localName = "excludes")
+    @JacksonXmlProperty(localName = "exclude")
+    private List<String> excludes;
+
+    public List<String> getExcludes() {
+        return excludes;
+    }
+
+    public void setExcludes(List<String> excludes) {
+        this.excludes = excludes;
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlShadeConfig.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlShadeConfig.java
@@ -1,0 +1,56 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.util.List;
+
+/**
+ * Represents the {@code <configuration>} block of the maven-shade-plugin.
+ *
+ * <p>This configuration may appear either directly on the {@code <plugin>} element
+ * or nested inside an {@code <execution>} element — both are valid Maven POM syntax.
+ *
+ * <p>Example POM fragment:
+ * <pre>{@code
+ * <configuration>
+ *     <relocations>
+ *         <relocation>
+ *             <pattern>com.google.guava</pattern>
+ *             <shadedPattern>com.mylib.shaded.guava</shadedPattern>
+ *         </relocation>
+ *     </relocations>
+ *     <artifactSet>
+ *         <excludes>
+ *             <exclude>com.google.guava:guava</exclude>
+ *         </excludes>
+ *     </artifactSet>
+ * </configuration>
+ * }</pre>
+ */
+public class PomXmlShadeConfig {
+
+    @JacksonXmlElementWrapper(localName = "relocations")
+    @JacksonXmlProperty(localName = "relocation")
+    private List<PomXmlShadeRelocation> relocations;
+
+    @JacksonXmlProperty(localName = "artifactSet")
+    private PomXmlShadeArtifactSet artifactSet;
+
+    public List<PomXmlShadeRelocation> getRelocations() {
+        return relocations;
+    }
+
+    public void setRelocations(List<PomXmlShadeRelocation> relocations) {
+        this.relocations = relocations;
+    }
+
+    public PomXmlShadeArtifactSet getArtifactSet() {
+        return artifactSet;
+    }
+
+    public void setArtifactSet(PomXmlShadeArtifactSet artifactSet) {
+        this.artifactSet = artifactSet;
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlShadeExecution.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlShadeExecution.java
@@ -1,0 +1,36 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * Represents a single {@code <execution>} element inside the maven-shade-plugin's
+ * {@code <executions>} block.
+ *
+ * <p>Shade plugin configuration is commonly placed inside an execution block:
+ * <pre>{@code
+ * <executions>
+ *     <execution>
+ *         <phase>package</phase>
+ *         <goals><goal>shade</goal></goals>
+ *         <configuration>
+ *             <relocations>...</relocations>
+ *             <artifactSet>...</artifactSet>
+ *         </configuration>
+ *     </execution>
+ * </executions>
+ * }</pre>
+ */
+public class PomXmlShadeExecution {
+
+    @JacksonXmlProperty(localName = "configuration")
+    private PomXmlShadeConfig configuration;
+
+    public PomXmlShadeConfig getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(PomXmlShadeConfig configuration) {
+        this.configuration = configuration;
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlShadeRelocation.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/model/pomxml/PomXmlShadeRelocation.java
@@ -1,0 +1,44 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * Represents a single {@code <relocation>} entry inside the maven-shade-plugin's
+ * {@code <configuration><relocations>} block.
+ *
+ * <p>Example POM fragment:
+ * <pre>{@code
+ * <relocation>
+ *     <pattern>com.google.guava</pattern>
+ *     <shadedPattern>com.mylib.shaded.guava</shadedPattern>
+ * </relocation>
+ * }</pre>
+ *
+ * <p>{@code pattern} is the original Java package prefix that was relocated.
+ * {@code shadedPattern} is where those classes were moved to inside the fat JAR.
+ */
+public class PomXmlShadeRelocation {
+
+    @JacksonXmlProperty(localName = "pattern")
+    private String pattern;
+
+    @JacksonXmlProperty(localName = "shadedPattern")
+    private String shadedPattern;
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public String getShadedPattern() {
+        return shadedPattern;
+    }
+
+    public void setShadedPattern(String shadedPattern) {
+        this.shadedPattern = shadedPattern;
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/module/MavenModuleProcessingContext.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/module/MavenModuleProcessingContext.java
@@ -1,6 +1,9 @@
 package com.blackduck.integration.detectable.detectables.maven.resolver.module;
 
+import com.blackduck.integration.bdio.graph.DependencyGraph;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
+import com.blackduck.integration.detectable.detectables.maven.resolver.MavenResolverOptions;
+import com.blackduck.integration.detectable.detectables.maven.resolver.ShadedDependencyScanner;
 import com.blackduck.integration.detectable.detectables.maven.resolver.graph.MavenGraphParser;
 import com.blackduck.integration.detectable.detectables.maven.resolver.graph.MavenGraphTransformer;
 import com.blackduck.integration.detectable.detectables.maven.resolver.output.CodeLocationFactory;
@@ -8,11 +11,14 @@ import com.blackduck.integration.detectable.detectables.maven.resolver.output.De
 import com.blackduck.integration.detectable.detectables.maven.resolver.output.MavenCoordinateFormatter;
 import com.blackduck.integration.detectable.detectables.maven.resolver.pom.ProjectBuilder;
 import com.blackduck.integration.detectable.detectables.maven.resolver.resolution.MavenDependencyResolver;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -55,6 +61,15 @@ public class MavenModuleProcessingContext {
     private final String compileScope;
     private final String testScope;
 
+    // Shaded dependency detection
+    @Nullable
+    private final ShadedDependencyScanner shadedDependencyScanner;
+    private final Map<String, DependencyGraph> shadedSubTreeCache;
+    private final boolean includeShadedDependencies;
+    @Nullable
+    private final MavenResolverOptions mavenResolverOptions;
+    private final Path downloadDir;
+
     /**
      * Private constructor - use Builder to create instances.
      */
@@ -72,7 +87,12 @@ public class MavenModuleProcessingContext {
         List<CodeLocation> codeLocations,
         Set<String> visitedModulePomPaths,
         String compileScope,
-        String testScope
+        String testScope,
+        @Nullable ShadedDependencyScanner shadedDependencyScanner,
+        Map<String, DependencyGraph> shadedSubTreeCache,
+        boolean includeShadedDependencies,
+        @Nullable MavenResolverOptions mavenResolverOptions,
+        Path downloadDir
     ) {
         this.projectBuilder = projectBuilder;
         this.dependencyResolver = dependencyResolver;
@@ -88,6 +108,11 @@ public class MavenModuleProcessingContext {
         this.visitedModulePomPaths = visitedModulePomPaths;
         this.compileScope = compileScope;
         this.testScope = testScope;
+        this.shadedDependencyScanner = shadedDependencyScanner;
+        this.shadedSubTreeCache = shadedSubTreeCache;
+        this.includeShadedDependencies = includeShadedDependencies;
+        this.mavenResolverOptions = mavenResolverOptions;
+        this.downloadDir = downloadDir;
     }
 
     // Getters
@@ -105,6 +130,13 @@ public class MavenModuleProcessingContext {
     public Set<String> getVisitedModulePomPaths() { return visitedModulePomPaths; }
     public String getCompileScope() { return compileScope; }
     public String getTestScope() { return testScope; }
+    @Nullable
+    public ShadedDependencyScanner getShadedDependencyScanner() { return shadedDependencyScanner; }
+    public Map<String, DependencyGraph> getShadedSubTreeCache() { return shadedSubTreeCache; }
+    public boolean isIncludeShadedDependencies() { return includeShadedDependencies; }
+    @Nullable
+    public MavenResolverOptions getMavenResolverOptions() { return mavenResolverOptions; }
+    public Path getDownloadDir() { return downloadDir; }
 
     /**
      * Builder for creating MavenModuleProcessingContext instances.
@@ -123,6 +155,11 @@ public class MavenModuleProcessingContext {
         private List<CodeLocation> codeLocations;
         private String compileScope = "compile";
         private String testScope = "test";
+        private ShadedDependencyScanner shadedDependencyScanner;
+        private Map<String, DependencyGraph> shadedSubTreeCache;
+        private boolean includeShadedDependencies;
+        private MavenResolverOptions mavenResolverOptions;
+        private Path downloadDir;
 
         public Builder projectBuilder(ProjectBuilder projectBuilder) {
             this.projectBuilder = projectBuilder;
@@ -189,8 +226,32 @@ public class MavenModuleProcessingContext {
             return this;
         }
 
+        public Builder shadedDependencyScanner(ShadedDependencyScanner shadedDependencyScanner) {
+            this.shadedDependencyScanner = shadedDependencyScanner;
+            return this;
+        }
+
+        public Builder shadedSubTreeCache(Map<String, DependencyGraph> shadedSubTreeCache) {
+            this.shadedSubTreeCache = shadedSubTreeCache;
+            return this;
+        }
+
+        public Builder includeShadedDependencies(boolean includeShadedDependencies) {
+            this.includeShadedDependencies = includeShadedDependencies;
+            return this;
+        }
+
+        public Builder mavenResolverOptions(MavenResolverOptions mavenResolverOptions) {
+            this.mavenResolverOptions = mavenResolverOptions;
+            return this;
+        }
+
+        public Builder downloadDir(Path downloadDir) {
+            this.downloadDir = downloadDir;
+            return this;
+        }
+
         public MavenModuleProcessingContext build() {
-            // Initialize visitedModulePomPaths if needed
             Set<String> visitedPaths = new HashSet<>();
 
             return new MavenModuleProcessingContext(
@@ -207,7 +268,12 @@ public class MavenModuleProcessingContext {
                 codeLocations,
                 visitedPaths,
                 compileScope,
-                testScope
+                testScope,
+                shadedDependencyScanner,
+                shadedSubTreeCache != null ? shadedSubTreeCache : new HashMap<>(),
+                includeShadedDependencies,
+                mavenResolverOptions,
+                downloadDir
             );
         }
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/module/MavenModuleProcessor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/module/MavenModuleProcessor.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -357,6 +358,18 @@ public class MavenModuleProcessor {
         if (testResult != null) {
             MavenParseResult testParseResult = context.getGraphParser().parse(testResult);
             testGraph = context.getGraphTransformer().transform(testParseResult);
+        }
+
+        // Shaded dependency detection for this module
+        if (context.isIncludeShadedDependencies() && context.getShadedDependencyScanner() != null) {
+            context.getShadedDependencyScanner().processShading(
+                compileResult, testResult,
+                compileGraph, testGraph,
+                context.getLocalRepoPath(), context.getDownloadDir(),
+                moduleProject.getRepositories() != null ? moduleProject.getRepositories() : Collections.emptyList(),
+                context.getShadedSubTreeCache(),
+                context.getMavenResolverOptions()
+            );
         }
 
         // Create and add CodeLocations

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/BomProcessor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/BomProcessor.java
@@ -1,16 +1,19 @@
 package com.blackduck.integration.detectable.detectables.maven.resolver.pom;
 
 import com.blackduck.integration.detectable.detectables.maven.resolver.mavendownload.MavenDownloader;
+import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorConfig;
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.*;
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.*;
 import com.blackduck.integration.detectable.detectables.maven.resolver.pom.property.PropertiesResolverProvider;
 import org.apache.commons.text.StringSubstitutor;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.HashSet;
@@ -49,11 +52,18 @@ class BomProcessor {
     private final Path downloadDir;
     private final ProjectBuilder projectBuilder;
     private final PropertiesResolverProvider propertiesResolverProvider;
+    private final List<MavenMirrorConfig> mirrorConfigs;
 
     BomProcessor(Path downloadDir, ProjectBuilder projectBuilder, PropertiesResolverProvider propertiesResolverProvider) {
+        this(downloadDir, projectBuilder, propertiesResolverProvider, Collections.emptyList());
+    }
+
+    BomProcessor(Path downloadDir, ProjectBuilder projectBuilder, PropertiesResolverProvider propertiesResolverProvider,
+                 @Nullable List<MavenMirrorConfig> mirrorConfigs) {
         this.downloadDir = downloadDir;
         this.projectBuilder = projectBuilder;
         this.propertiesResolverProvider = propertiesResolverProvider;
+        this.mirrorConfigs = (mirrorConfigs != null) ? mirrorConfigs : Collections.emptyList();
     }
 
     PartialMavenProject processBoms(String pomFilePath, PartialMavenProject partialModel, Set<String> visitedBoms) throws Exception {
@@ -157,7 +167,7 @@ class BomProcessor {
         JavaCoordinates bomCoords,
         PartialMavenProject partialModel
     ) throws Exception {
-        MavenDownloader mavenDownloader = new MavenDownloader(partialModel.getRepositories(), downloadDir);
+        MavenDownloader mavenDownloader = new MavenDownloader(partialModel.getRepositories(), downloadDir, mirrorConfigs);
         File bomPomFile = mavenDownloader.downloadPom(bomCoords);
 
         if (bomPomFile == null) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/BomProcessor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/BomProcessor.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -200,7 +201,7 @@ class BomProcessor {
      * Merges dependency management from BOM into partial model. Original entries take precedence.
      */
     private void mergeDependencyManagement(PartialMavenProject bomProject, PartialMavenProject partialModel) {
-        Map<String, PomXmlDependency> depMgmtMap = new HashMap<>();
+        Map<String, PomXmlDependency> depMgmtMap = new LinkedHashMap<>();
         if (bomProject.getDependencyManagement() != null) {
             bomProject.getDependencyManagement().forEach(dep ->
                 depMgmtMap.put(dep.getGroupId() + ":" + dep.getArtifactId(), dep));

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/BomProcessor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/BomProcessor.java
@@ -201,13 +201,15 @@ class BomProcessor {
      * Merges dependency management from BOM into partial model. Original entries take precedence.
      */
     private void mergeDependencyManagement(PartialMavenProject bomProject, PartialMavenProject partialModel) {
+        // Maven BOM semantics: project's own depMgmt takes precedence and comes first;
+        // BOM entries are appended only if not already declared in the project
         Map<String, PomXmlDependency> depMgmtMap = new LinkedHashMap<>();
-        if (bomProject.getDependencyManagement() != null) {
-            bomProject.getDependencyManagement().forEach(dep ->
-                depMgmtMap.put(dep.getGroupId() + ":" + dep.getArtifactId(), dep));
-        }
         partialModel.getDependencyManagement().forEach(dep ->
             depMgmtMap.put(dep.getGroupId() + ":" + dep.getArtifactId(), dep));
+        if (bomProject.getDependencyManagement() != null) {
+            bomProject.getDependencyManagement().forEach(dep ->
+                depMgmtMap.putIfAbsent(dep.getGroupId() + ":" + dep.getArtifactId(), dep));
+        }
         partialModel.setDependencyManagement(new ArrayList<>(depMgmtMap.values()));
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/ModelMerger.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/ModelMerger.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -65,14 +66,14 @@ class ModelMerger {
     }
 
     private void mergeDependencyManagement(PartialMavenProject child, PartialMavenProject parent) {
-        Map<String, PomXmlDependency> depMgmtMap = new HashMap<>();
+        Map<String, PomXmlDependency> depMgmtMap = new LinkedHashMap<>();
         addDependenciesToMap(depMgmtMap, parent.getDependencyManagement());
         addDependenciesToMap(depMgmtMap, child.getDependencyManagement());
         child.setDependencyManagement(new ArrayList<>(depMgmtMap.values()));
     }
 
     private void mergeDependencies(PartialMavenProject child, PartialMavenProject parent) {
-        Map<String, PomXmlDependency> dependenciesMap = new HashMap<>();
+        Map<String, PomXmlDependency> dependenciesMap = new LinkedHashMap<>();
         addDependenciesToMap(dependenciesMap, parent.getDependencies());
         addDependenciesToMap(dependenciesMap, child.getDependencies());
         child.setDependencies(new ArrayList<>(dependenciesMap.values()));

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/ModelMerger.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/ModelMerger.java
@@ -66,16 +66,18 @@ class ModelMerger {
     }
 
     private void mergeDependencyManagement(PartialMavenProject child, PartialMavenProject parent) {
+        // Maven merge semantics: child depMgmt first, parent appended only if not in child
         Map<String, PomXmlDependency> depMgmtMap = new LinkedHashMap<>();
-        addDependenciesToMap(depMgmtMap, parent.getDependencyManagement());
         addDependenciesToMap(depMgmtMap, child.getDependencyManagement());
+        addDependenciesIfAbsent(depMgmtMap, parent.getDependencyManagement());
         child.setDependencyManagement(new ArrayList<>(depMgmtMap.values()));
     }
 
     private void mergeDependencies(PartialMavenProject child, PartialMavenProject parent) {
+        // Maven merge semantics: child deps first (declaration order), parent appended only if not in child
         Map<String, PomXmlDependency> dependenciesMap = new LinkedHashMap<>();
-        addDependenciesToMap(dependenciesMap, parent.getDependencies());
         addDependenciesToMap(dependenciesMap, child.getDependencies());
+        addDependenciesIfAbsent(dependenciesMap, parent.getDependencies());
         child.setDependencies(new ArrayList<>(dependenciesMap.values()));
     }
 
@@ -88,6 +90,12 @@ class ModelMerger {
     private void addDependenciesToMap(Map<String, PomXmlDependency> map, java.util.List<PomXmlDependency> dependencies) {
         if (dependencies != null) {
             dependencies.forEach(dep -> map.put(dep.getGroupId() + ":" + dep.getArtifactId(), dep));
+        }
+    }
+
+    private void addDependenciesIfAbsent(Map<String, PomXmlDependency> map, java.util.List<PomXmlDependency> dependencies) {
+        if (dependencies != null) {
+            dependencies.forEach(dep -> map.putIfAbsent(dep.getGroupId() + ":" + dep.getArtifactId(), dep));
         }
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/ProjectBuilder.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/pom/ProjectBuilder.java
@@ -1,9 +1,11 @@
 package com.blackduck.integration.detectable.detectables.maven.resolver.pom;
 
 import com.blackduck.integration.detectable.detectables.maven.resolver.mavendownload.MavenDownloader;
+import com.blackduck.integration.detectable.detectables.maven.resolver.mirror.MavenMirrorConfig;
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.*;
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.*;
 import com.blackduck.integration.detectable.detectables.maven.resolver.pom.property.PropertiesResolverProvider;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -49,17 +52,35 @@ public class ProjectBuilder {
     private final PropertiesResolverProvider propertiesResolverProvider;
     private final Map<String, PartialMavenProject> pomCache = new HashMap<>();
     private final Path downloadDir;
+    private final List<MavenMirrorConfig> mirrorConfigs;
 
     private final BomProcessor bomProcessor;
     private final ModelMerger modelMerger;
     private final DependencyConverter dependencyConverter;
 
+    /**
+     * Constructs a ProjectBuilder without mirror support. Equivalent to passing an empty mirror list.
+     * Retained for callers that have not yet been threaded for mirror configuration.
+     */
     public ProjectBuilder(Path downloadDir) {
+        this(downloadDir, Collections.emptyList());
+    }
+
+    /**
+     * Constructs a mirror-aware ProjectBuilder. Mirror configurations are propagated to the
+     * internal {@link BomProcessor} and to every {@link MavenDownloader} created during parent
+     * POM resolution, so that all bootstrap-phase HTTP traffic honors corporate mirror settings.
+     *
+     * @param downloadDir   directory where downloaded parent/BOM POMs will be written
+     * @param mirrorConfigs mirror configurations to apply; may be null or empty for none
+     */
+    public ProjectBuilder(Path downloadDir, @Nullable List<MavenMirrorConfig> mirrorConfigs) {
         this.pomParser = new PomParser();
         this.propertiesResolverProvider = new PropertiesResolverProvider(null, System::getenv);
         this.downloadDir = downloadDir;
+        this.mirrorConfigs = (mirrorConfigs != null) ? mirrorConfigs : Collections.emptyList();
 
-        this.bomProcessor = new BomProcessor(downloadDir, this, propertiesResolverProvider);
+        this.bomProcessor = new BomProcessor(downloadDir, this, propertiesResolverProvider, this.mirrorConfigs);
         this.modelMerger = new ModelMerger();
         this.dependencyConverter = new DependencyConverter(propertiesResolverProvider);
     }
@@ -143,7 +164,7 @@ public class ProjectBuilder {
         String pomFilePath,
         Set<String> identifiedParents
     ) throws Exception {
-        MavenDownloader mavenDownloader = new MavenDownloader(pomFileInfo.getRepositories(), downloadDir);
+        MavenDownloader mavenDownloader = new MavenDownloader(pomFileInfo.getRepositories(), downloadDir, mirrorConfigs);
         File parentPomFile = mavenDownloader.downloadPom(parentCoords);
 
         if (parentPomFile == null) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/proxy/MavenProxyConfigurator.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/proxy/MavenProxyConfigurator.java
@@ -376,6 +376,32 @@ public class MavenProxyConfigurator {
     }
 
     /**
+     * Configures only Java system proxy properties without an Aether SessionBuilder.
+     *
+     * <p>Use this for HTTP operations outside Aether (e.g., JAR downloads via HttpURLConnection)
+     * that still need to respect the proxy. Pairs with {@link #restoreOriginalProxyProperties()}.
+     */
+    public void configureSystemProxyProperties() {
+        try {
+            if (isProxyAlreadyConfigured()) {
+                logger.info("System proxy already configured with matching values ({}:{}). No changes needed.",
+                    proxyConfig.getHost(), proxyConfig.getPort());
+                return;
+            }
+
+            logger.info("Configuring system proxy properties for JAR downloads: {}:{}", proxyConfig.getHost(), proxyConfig.getPort());
+            saveOriginalProxyProperties();
+            String nonProxyHostsPattern = buildNonProxyHostsPattern();
+            setJavaSystemProxyProperties(nonProxyHostsPattern);
+            logger.info("System proxy properties set for HTTP/HTTPS JAR downloads");
+        } catch (Exception e) {
+            logger.warn("Failed to configure system proxy properties ({}:{}). Continuing without proxy. Error: {}",
+                proxyConfig.getHost(), proxyConfig.getPort(), e.getMessage());
+            logger.debug("System proxy configuration exception details:", e);
+        }
+    }
+
+    /**
      * Restores the original Java system proxy properties that were saved by
      * {@link #saveOriginalProxyProperties()}.
      *

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/ShadedDependencyInspector.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/ShadedDependencyInspector.java
@@ -1,0 +1,78 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.DiscoveredDependency;
+import java.util.List;
+import java.util.jar.JarFile;
+
+/**
+ * Interface for detecting shaded dependencies within a JAR file.
+ *
+ * Each implementation represents a different detection strategy:
+ *   - Method 1: Delta analysis comparing original POM with dependency-reduced-pom.xml
+ *   - Method 2: Recursive metadata extraction from embedded pom.properties files
+ *   - Method 3: OSGi manifest analysis (Import-Package, Export-Package headers)
+ *   - Method 4: SPI descriptor analysis (META-INF/services/ files)
+ *   - Method 5: Build info forensics (.buildinfo, build-info.properties)
+ *
+ * <h2>Exception Contract</h2>
+ * <p>
+ * <strong>IMPORTANT:</strong> Implementations MUST NOT throw any exceptions.
+ * All exceptions must be caught internally and handled gracefully.
+ * If an error occurs during detection, implementations should:
+ * </p>
+ * <ul>
+ *   <li>Log the error with appropriate context (file name, entry name, etc.)</li>
+ *   <li>Return an empty list or a partial list of successfully discovered dependencies</li>
+ *   <li>Never propagate exceptions to the caller</li>
+ * </ul>
+ * <p>
+ * This contract ensures that one failing detector does not break the entire detection pipeline.
+ * The Application class runs multiple detectors sequentially, and a failure in one detector
+ * should not prevent other detectors from running.
+ * </p>
+ *
+ * <h2>Return Value Contract</h2>
+ * <ul>
+ *   <li>Never return null - always return an empty list if no dependencies are found</li>
+ *   <li>Each DiscoveredDependency should have a valid identifier and detection source</li>
+ *   <li>Duplicate entries within a single detector's results are acceptable (deduplication happens at the Application level)</li>
+ * </ul>
+ *
+ * <h2>Thread Safety</h2>
+ * <p>
+ * Implementations should be stateless and thread-safe. The same detector instance
+ * may be used to analyze multiple JAR files concurrently.
+ * </p>
+ */
+public interface ShadedDependencyInspector {
+
+    /**
+     * Detects shaded dependencies within the provided JAR file.
+     *
+     * <p>
+     * This method analyzes the JAR file using the detector's specific strategy
+     * and returns a list of discovered shaded dependencies. The implementation
+     * must handle all exceptions internally and never throw.
+     * </p>
+     *
+     * @param jarFile The JAR file to analyze for shaded dependencies.
+     *                Must not be null. The JAR file should already be opened
+     *                and valid (caller's responsibility).
+     *
+     * @return A list of discovered dependencies, each with its identifier and discovery method.
+     *         <ul>
+     *           <li>Returns an empty list if no shaded dependencies are found</li>
+     *           <li>Returns an empty list if an error occurs during detection</li>
+     *           <li>Never returns null</li>
+     *         </ul>
+     *
+     * @implNote Implementations MUST:
+     *           <ul>
+     *             <li>Catch all exceptions (IOException, parsing errors, etc.)</li>
+     *             <li>Log errors with sufficient context for debugging</li>
+     *             <li>Return an empty list on failure, not null</li>
+     *             <li>Not close the JarFile (caller manages the lifecycle)</li>
+     *           </ul>
+     */
+    List<DiscoveredDependency> detectShadedDependencies(JarFile jarFile);
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/methods/DeltaAnalysisInspector.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/methods/DeltaAnalysisInspector.java
@@ -1,0 +1,274 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.methods;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.pom.MavenProject;
+import com.blackduck.integration.detectable.detectables.maven.resolver.pom.ProjectBuilder;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.JavaCoordinates;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.JavaDependency;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.ShadedDependencyInspector;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.DiscoveredDependency;
+import org.eclipse.aether.artifact.Artifact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Detects shaded dependencies by performing a delta (set difference) between:
+ * - The Original pom.xml hidden inside the JAR (parsed and fully resolved via ProjectBuilder with BOM/Parent support)
+ * - The Eclipse Aether Dependency Graph (contains only unshaded dependencies)
+ *
+ * <p>This inspector leverages the core ProjectBuilder infrastructure to handle:
+ * <ul>
+ *   <li>Property placeholder resolution (${project.version}, custom properties, etc.)</li>
+ *   <li>Parent POM inheritance and property override chains</li>
+ *   <li>BOM imports and dependencyManagement version resolution</li>
+ *   <li>Multi-level dependency management merging</li>
+ * </ul>
+ *
+ * The difference = the shaded dependencies.
+ */
+public class DeltaAnalysisInspector implements ShadedDependencyInspector {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeltaAnalysisInspector.class);
+
+    private static final Set<String> EXCLUDED_SCOPES = Collections.unmodifiableSet(
+            new HashSet<String>(Arrays.asList("test", "provided", "system"))
+    );
+
+    // A mapping of GA -> Set of exact child GAVs extracted from the Aether tree
+    private final Map<String, Set<String>> aetherDirectChildrenByGa;
+    private final ProjectBuilder projectBuilder;
+    private final Artifact hostArtifact;
+
+    /**
+     * Initializes the inspector with the Aether graph context, ProjectBuilder, and host artifact.
+     *
+     * @param aetherDirectChildrenByGa A map of Artifact GA to a Set of its direct children GAVs from Aether resolution
+     * @param projectBuilder The ProjectBuilder instance used to parse and resolve POMs with full BOM/Parent support
+     * @param hostArtifact The host artifact whose JAR is being inspected (used to locate the correct POM)
+     */
+    public DeltaAnalysisInspector(Map<String, Set<String>> aetherDirectChildrenByGa, ProjectBuilder projectBuilder, Artifact hostArtifact) {
+        this.aetherDirectChildrenByGa = aetherDirectChildrenByGa != null ? aetherDirectChildrenByGa : new HashMap<String, Set<String>>();
+        this.projectBuilder = projectBuilder;
+        this.hostArtifact = hostArtifact;
+        logger.debug("[Method 1] DeltaAnalysisInspector initialized with {} GA entries in Aether map.", this.aetherDirectChildrenByGa.size());
+    }
+
+    @Override
+    public List<DiscoveredDependency> detectShadedDependencies(JarFile jarFile) {
+        List<DiscoveredDependency> discoveredDependencies = new ArrayList<DiscoveredDependency>();
+        logger.debug("[Method 1] Starting Delta Analysis for JAR: {}", jarFile.getName());
+
+        // Guard: host artifact is required for targeted POM lookup
+        if (hostArtifact == null) {
+            logger.warn("[Method 1] Host artifact not provided. Delta analysis skipped.");
+            return discoveredDependencies;
+        }
+
+        // Pre-scan JAR for .class file directory prefixes to filter ghost deps (POM lists them but classes weren't bundled)
+        NavigableSet<String> classPathPrefixes = new TreeSet<String>();
+        Enumeration<JarEntry> classEntries = jarFile.entries();
+        while (classEntries.hasMoreElements()) {
+            String entryName = classEntries.nextElement().getName();
+            if (entryName.endsWith(".class")) {
+                int lastSlash = entryName.lastIndexOf('/');
+                if (lastSlash > 0) {
+                    classPathPrefixes.add(entryName.substring(0, lastSlash + 1));
+                }
+            }
+        }
+        logger.debug("[Method 1] Pre-scanned {} unique class path prefixes for ghost detection.", classPathPrefixes.size());
+
+        JarEntry originalPomEntry = null;
+
+        // Step 1: Locate the Original POM inside the JAR using targeted path lookup
+        logger.debug("[Method 1] Step 1 - Scanning JAR entries for Original pom.xml...");
+        String targetPath = "META-INF/maven/" + hostArtifact.getGroupId()
+                + "/" + hostArtifact.getArtifactId() + "/pom.xml";
+        logger.debug("[Method 1] Step 1 - Looking for POM at exact path: {}", targetPath);
+
+        Enumeration<JarEntry> entries = jarFile.entries();
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            String name = entry.getName();
+
+            // Match only the exact expected path for the host artifact's POM
+            if (name.equals(targetPath)) {
+                originalPomEntry = entry;
+                logger.debug("[Method 1] Step 1 - Found original POM: {}", name);
+                break;
+            }
+        }
+
+        if (originalPomEntry == null) {
+            logger.debug("[Method 1] Step 1 - Original pom.xml not found at expected path '{}'. Delta analysis skipped.", targetPath);
+            return discoveredDependencies;
+        }
+
+        File tempPomFile = null;
+        Path tempDir = null;
+        try {
+            // Step 2: Extract the POM to a deterministic temporary directory so ProjectBuilder cache works
+            // Use GAV-based naming for cache hits and better debugging
+            logger.debug("[Method 1] Step 2 - Extracting original POM to temporary file...");
+            tempDir = Files.createTempDirectory(
+                "extracted-pom-" + hostArtifact.getGroupId()
+                + "_" + hostArtifact.getArtifactId()
+                + "_" + hostArtifact.getVersion());
+            tempPomFile = tempDir.resolve("pom.xml").toFile();
+            logger.trace("[Method 1] Step 2 - Temporary POM file: {}", tempPomFile.getAbsolutePath());
+
+            try (InputStream is = jarFile.getInputStream(originalPomEntry)) {
+                Files.copy(is, tempPomFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            logger.debug("[Method 1] Step 2 - Successfully extracted POM to temporary file.");
+
+            // Step 3: Delegate to ProjectBuilder to resolve properties, BOMs, and Parents
+            logger.debug("[Method 1] Step 3 - Passing extracted POM to ProjectBuilder for full resolution (BOMs, Parents, Properties)...");
+            MavenProject mavenProject = projectBuilder.buildProject(tempPomFile);
+            logger.debug("[Method 1] Step 3 - ProjectBuilder successfully built MavenProject model.");
+
+            JavaCoordinates hostCoords = mavenProject.getCoordinates();
+            if (hostCoords.getGroupId() == null || hostCoords.getArtifactId() == null) {
+                logger.warn("[Method 1] Step 3 - ProjectBuilder could not resolve host GA. Aborting delta math.");
+                return discoveredDependencies;
+            }
+
+            String hostGa = hostCoords.getGroupId() + ":" + hostCoords.getArtifactId();
+            logger.debug("[Method 1] Step 3 - Host artifact coordinates - GroupId: {}, ArtifactId: {}", hostCoords.getGroupId(), hostCoords.getArtifactId());
+            logger.debug("[Method 1] Step 3 - Host GA: {}", hostGa);
+
+            // Step 4: Extract and format the resolved dependencies from MavenProject using GA-based map
+            logger.debug("[Method 1] Step 4 - Extracting resolved dependencies from MavenProject (GA-based)...");
+            Map<String, String> originalDepsByGa = new HashMap<String, String>();
+            if (mavenProject.getDependencies() != null) {
+                logger.debug("[Method 1] Step 4 - MavenProject has {} total dependencies.", mavenProject.getDependencies().size());
+
+                for (JavaDependency dep : mavenProject.getDependencies()) {
+                    String scope = dep.getScope() != null ? dep.getScope().toLowerCase() : "compile";
+
+                    if (EXCLUDED_SCOPES.contains(scope)) {
+                        logger.trace("[Method 1] Step 4 - Skipping dependency with excluded scope '{}': {}", scope, dep.getCoordinates());
+                        continue;
+                    }
+
+                    JavaCoordinates coords = dep.getCoordinates();
+                    if (coords != null && coords.getGroupId() != null && coords.getArtifactId() != null && coords.getVersion() != null) {
+                        String ga = coords.getGroupId() + ":" + coords.getArtifactId();
+                        String gav = coords.getGroupId() + ":" + coords.getArtifactId() + ":" + coords.getVersion();
+                        originalDepsByGa.put(ga, gav);
+                        logger.trace("[Method 1] Step 4 - Added original dependency GA '{}' -> GAV '{}'", ga, gav);
+                    } else {
+                        logger.trace("[Method 1] Step 4 - Skipping dependency with incomplete coordinates: {}", coords);
+                    }
+                }
+            } else {
+                logger.debug("[Method 1] Step 4 - MavenProject has no dependencies.");
+            }
+
+            logger.debug("[Method 1] Step 4 - Original POM has {} dependencies (GA-keyed) after scope filtering.", originalDepsByGa.size());
+
+            // Step 5: Compare with Aether using GA-based lookup to handle version bumps
+            logger.debug("[Method 1] Step 5 - Retrieving Aether graph dependencies for host: {}", hostGa);
+            Set<String> aetherChildren = aetherDirectChildrenByGa.containsKey(hostGa)
+                    ? aetherDirectChildrenByGa.get(hostGa)
+                    : Collections.<String>emptySet();
+
+            logger.debug("[Method 1] Step 5 - Aether graph lists {} direct dependencies for host {}.", aetherChildren.size(), hostGa);
+            for (String aetherDep : aetherChildren) {
+                logger.trace("[Method 1] Step 5 - Aether dependency: {}", aetherDep);
+            }
+
+            // Build GA key set from Aether children for GA-based comparison
+            Set<String> aetherGaKeys = new HashSet<String>();
+            for (String aetherGav : aetherChildren) {
+                String[] parts = aetherGav.split(":");
+                if (parts.length >= 2) {
+                    aetherGaKeys.add(parts[0] + ":" + parts[1]);
+                }
+            }
+            logger.debug("[Method 1] Step 5 - Built {} GA keys from Aether children for comparison.", aetherGaKeys.size());
+
+            // GA-based Delta: If original GA is NOT in Aether GA keys, it's a shaded candidate.
+            // Ghost filter: verify .class files actually exist in the JAR for each candidate's groupId.
+            // Without this, deps listed in the POM but excluded by shade plugin config are false positives.
+            int originalSize = originalDepsByGa.size();
+            int shadedCount = 0;
+            int ghostCount = 0;
+
+            for (Map.Entry<String, String> depEntry : originalDepsByGa.entrySet()) {
+                String gaKey = depEntry.getKey();
+                String gavValue = depEntry.getValue();
+
+                if (!aetherGaKeys.contains(gaKey)) {
+                    // Candidate shaded dep — verify classes are actually bundled in the JAR
+                    String groupId = gaKey.split(":")[0];
+                    String expectedClassPrefix = groupId.replace('.', '/') + "/";
+                    String ceiling = classPathPrefixes.ceiling(expectedClassPrefix);
+                    boolean hasClasses = ceiling != null && ceiling.startsWith(expectedClassPrefix);
+
+                    if (!hasClasses) {
+                        logger.debug("[Method 1] Step 5 - Ghost dependency filtered (no .class files for '{}'): {}", expectedClassPrefix, gavValue);
+                        ghostCount++;
+                        continue;
+                    }
+
+                    logger.info("[Method 1] Step 5 - Shaded dependency detected: {}", gavValue);
+                    discoveredDependencies.add(new DiscoveredDependency(gavValue, "Delta Analysis (ProjectBuilder)"));
+                    shadedCount++;
+                } else {
+                    logger.trace("[Method 1] Step 5 - Dependency resolved by Aether (GA match): {}", gaKey);
+                }
+            }
+
+            logger.debug("[Method 1] Step 5 - Delta: {} original, {} aether GA keys, {} shaded, {} ghosts filtered.",
+                    originalSize, aetherGaKeys.size(), shadedCount, ghostCount);
+
+        } catch (Exception e) {
+            logger.error("[Method 1] Failed to process ProjectBuilder delta math for JAR {}: {}", jarFile.getName(), e.getMessage(), e);
+        } finally {
+            // Step 6: Graceful cleanup to prevent disk leaks (delete file and directory)
+            if (tempPomFile != null && tempPomFile.exists()) {
+                logger.trace("[Method 1] Step 6 - Cleaning up temporary POM file: {}", tempPomFile.getAbsolutePath());
+                try {
+                    Files.delete(tempPomFile.toPath());
+                    logger.trace("[Method 1] Step 6 - Successfully deleted temporary POM file.");
+                } catch (Exception e) {
+                    logger.warn("[Method 1] Step 6 - Failed to delete temporary POM file: {}", tempPomFile.getAbsolutePath());
+                    tempPomFile.deleteOnExit();
+                }
+            }
+            if (tempDir != null) {
+                try {
+                    Files.delete(tempDir);
+                    logger.trace("[Method 1] Step 6 - Successfully deleted temporary directory.");
+                } catch (Exception e) {
+                    logger.warn("[Method 1] Step 6 - Failed to delete temporary directory: {}", tempDir);
+                    tempDir.toFile().deleteOnExit();
+                }
+            }
+        }
+
+        logger.debug("[Method 1] Delta Analysis completed for JAR: {}", jarFile.getName());
+        return discoveredDependencies;
+    }
+
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/methods/DeltaAnalysisInspector.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/methods/DeltaAnalysisInspector.java
@@ -6,7 +6,9 @@ import com.blackduck.integration.detectable.detectables.maven.resolver.model.Jav
 import com.blackduck.integration.detectable.detectables.maven.resolver.model.JavaDependency;
 import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.ShadedDependencyInspector;
 import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.DiscoveredDependency;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.ShadePluginConfig;
 import org.eclipse.aether.artifact.Artifact;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +44,14 @@ import java.util.jar.JarFile;
  *   <li>Multi-level dependency management merging</li>
  * </ul>
  *
- * The difference = the shaded dependencies.
+ * <h2>Ghost Filter (relocation-aware)</h2>
+ * <p>A dependency found by delta math is a "ghost" — not actually bundled — only if it is
+ * listed in the shade plugin's {@code <artifactSet><excludes>}. This replaces the old
+ * class-path prefix heuristic, which incorrectly dropped relocated dependencies because
+ * their classes live under the {@code <shadedPattern>} path, not the original groupId path.
+ *
+ * <p>If no {@link ShadePluginConfig} is available (e.g., the embedded POM could not be parsed),
+ * the inspector falls back to the legacy class-path prefix heuristic so detection is not lost.
  */
 public class DeltaAnalysisInspector implements ShadedDependencyInspector {
 
@@ -58,17 +67,34 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
     private final Artifact hostArtifact;
 
     /**
-     * Initializes the inspector with the Aether graph context, ProjectBuilder, and host artifact.
+     * Parsed shade plugin configuration for the host artifact's JAR.
+     * Provides explicit exclude list and relocation patterns for an accurate ghost filter.
+     * May be null — in that case the legacy class-path heuristic is used as fallback.
+     */
+    @Nullable
+    private final ShadePluginConfig shadePluginConfig;
+
+    /**
+     * Initializes the inspector with the Aether graph context, ProjectBuilder, host artifact,
+     * and the parsed shade plugin configuration.
      *
      * @param aetherDirectChildrenByGa A map of Artifact GA to a Set of its direct children GAVs from Aether resolution
-     * @param projectBuilder The ProjectBuilder instance used to parse and resolve POMs with full BOM/Parent support
-     * @param hostArtifact The host artifact whose JAR is being inspected (used to locate the correct POM)
+     * @param projectBuilder           The ProjectBuilder instance used to parse and resolve POMs
+     * @param hostArtifact             The host artifact whose JAR is being inspected
+     * @param shadePluginConfig        Parsed shade config (excludes + relocations); may be null → fallback to legacy heuristic
      */
-    public DeltaAnalysisInspector(Map<String, Set<String>> aetherDirectChildrenByGa, ProjectBuilder projectBuilder, Artifact hostArtifact) {
+    public DeltaAnalysisInspector(
+            Map<String, Set<String>> aetherDirectChildrenByGa,
+            ProjectBuilder projectBuilder,
+            Artifact hostArtifact,
+            @Nullable ShadePluginConfig shadePluginConfig
+    ) {
         this.aetherDirectChildrenByGa = aetherDirectChildrenByGa != null ? aetherDirectChildrenByGa : new HashMap<String, Set<String>>();
         this.projectBuilder = projectBuilder;
         this.hostArtifact = hostArtifact;
-        logger.debug("[Method 1] DeltaAnalysisInspector initialized with {} GA entries in Aether map.", this.aetherDirectChildrenByGa.size());
+        this.shadePluginConfig = shadePluginConfig;
+        logger.debug("[Method 1] DeltaAnalysisInspector initialized with {} GA entries in Aether map. ShadeConfig available: {}",
+                this.aetherDirectChildrenByGa.size(), shadePluginConfig != null);
     }
 
     @Override
@@ -82,19 +108,26 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
             return discoveredDependencies;
         }
 
-        // Pre-scan JAR for .class file directory prefixes to filter ghost deps (POM lists them but classes weren't bundled)
-        NavigableSet<String> classPathPrefixes = new TreeSet<String>();
-        Enumeration<JarEntry> classEntries = jarFile.entries();
-        while (classEntries.hasMoreElements()) {
-            String entryName = classEntries.nextElement().getName();
-            if (entryName.endsWith(".class")) {
-                int lastSlash = entryName.lastIndexOf('/');
-                if (lastSlash > 0) {
-                    classPathPrefixes.add(entryName.substring(0, lastSlash + 1));
+        // Legacy fallback: pre-scan .class file path prefixes only if we have no shade config.
+        // When shade config IS available, we use the explicit <artifactSet><excludes> list instead,
+        // which correctly handles relocated deps (their classes live at the shadedPattern path,
+        // not the original groupId path, so class-path scanning would give wrong results).
+        NavigableSet<String> classPathPrefixes = null;
+        if (shadePluginConfig == null) {
+            logger.debug("[Method 1] No ShadePluginConfig available — falling back to legacy class-path ghost filter.");
+            classPathPrefixes = new TreeSet<String>();
+            Enumeration<JarEntry> classEntries = jarFile.entries();
+            while (classEntries.hasMoreElements()) {
+                String entryName = classEntries.nextElement().getName();
+                if (entryName.endsWith(".class")) {
+                    int lastSlash = entryName.lastIndexOf('/');
+                    if (lastSlash > 0) {
+                        classPathPrefixes.add(entryName.substring(0, lastSlash + 1));
+                    }
                 }
             }
+            logger.debug("[Method 1] Pre-scanned {} unique class path prefixes for legacy ghost detection.", classPathPrefixes.size());
         }
-        logger.debug("[Method 1] Pre-scanned {} unique class path prefixes for ghost detection.", classPathPrefixes.size());
 
         JarEntry originalPomEntry = null;
 
@@ -107,12 +140,9 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
         Enumeration<JarEntry> entries = jarFile.entries();
         while (entries.hasMoreElements()) {
             JarEntry entry = entries.nextElement();
-            String name = entry.getName();
-
-            // Match only the exact expected path for the host artifact's POM
-            if (name.equals(targetPath)) {
+            if (entry.getName().equals(targetPath)) {
                 originalPomEntry = entry;
-                logger.debug("[Method 1] Step 1 - Found original POM: {}", name);
+                logger.debug("[Method 1] Step 1 - Found original POM: {}", entry.getName());
                 break;
             }
         }
@@ -125,15 +155,13 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
         File tempPomFile = null;
         Path tempDir = null;
         try {
-            // Step 2: Extract the POM to a deterministic temporary directory so ProjectBuilder cache works
-            // Use GAV-based naming for cache hits and better debugging
+            // Step 2: Extract the POM to a temp directory so ProjectBuilder can process it
             logger.debug("[Method 1] Step 2 - Extracting original POM to temporary file...");
             tempDir = Files.createTempDirectory(
-                "extracted-pom-" + hostArtifact.getGroupId()
-                + "_" + hostArtifact.getArtifactId()
-                + "_" + hostArtifact.getVersion());
+                    "extracted-pom-" + hostArtifact.getGroupId()
+                    + "_" + hostArtifact.getArtifactId()
+                    + "_" + hostArtifact.getVersion());
             tempPomFile = tempDir.resolve("pom.xml").toFile();
-            logger.trace("[Method 1] Step 2 - Temporary POM file: {}", tempPomFile.getAbsolutePath());
 
             try (InputStream is = jarFile.getInputStream(originalPomEntry)) {
                 Files.copy(is, tempPomFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
@@ -141,7 +169,7 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
             logger.debug("[Method 1] Step 2 - Successfully extracted POM to temporary file.");
 
             // Step 3: Delegate to ProjectBuilder to resolve properties, BOMs, and Parents
-            logger.debug("[Method 1] Step 3 - Passing extracted POM to ProjectBuilder for full resolution (BOMs, Parents, Properties)...");
+            logger.debug("[Method 1] Step 3 - Passing extracted POM to ProjectBuilder for full resolution...");
             MavenProject mavenProject = projectBuilder.buildProject(tempPomFile);
             logger.debug("[Method 1] Step 3 - ProjectBuilder successfully built MavenProject model.");
 
@@ -152,51 +180,33 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
             }
 
             String hostGa = hostCoords.getGroupId() + ":" + hostCoords.getArtifactId();
-            logger.debug("[Method 1] Step 3 - Host artifact coordinates - GroupId: {}, ArtifactId: {}", hostCoords.getGroupId(), hostCoords.getArtifactId());
             logger.debug("[Method 1] Step 3 - Host GA: {}", hostGa);
 
-            // Step 4: Extract and format the resolved dependencies from MavenProject using GA-based map
-            logger.debug("[Method 1] Step 4 - Extracting resolved dependencies from MavenProject (GA-based)...");
+            // Step 4: Extract resolved dependencies from MavenProject (GA-keyed map)
+            logger.debug("[Method 1] Step 4 - Extracting resolved dependencies from MavenProject...");
             Map<String, String> originalDepsByGa = new HashMap<String, String>();
             if (mavenProject.getDependencies() != null) {
-                logger.debug("[Method 1] Step 4 - MavenProject has {} total dependencies.", mavenProject.getDependencies().size());
-
                 for (JavaDependency dep : mavenProject.getDependencies()) {
                     String scope = dep.getScope() != null ? dep.getScope().toLowerCase() : "compile";
-
                     if (EXCLUDED_SCOPES.contains(scope)) {
-                        logger.trace("[Method 1] Step 4 - Skipping dependency with excluded scope '{}': {}", scope, dep.getCoordinates());
                         continue;
                     }
-
                     JavaCoordinates coords = dep.getCoordinates();
                     if (coords != null && coords.getGroupId() != null && coords.getArtifactId() != null && coords.getVersion() != null) {
                         String ga = coords.getGroupId() + ":" + coords.getArtifactId();
                         String gav = coords.getGroupId() + ":" + coords.getArtifactId() + ":" + coords.getVersion();
                         originalDepsByGa.put(ga, gav);
-                        logger.trace("[Method 1] Step 4 - Added original dependency GA '{}' -> GAV '{}'", ga, gav);
-                    } else {
-                        logger.trace("[Method 1] Step 4 - Skipping dependency with incomplete coordinates: {}", coords);
                     }
                 }
-            } else {
-                logger.debug("[Method 1] Step 4 - MavenProject has no dependencies.");
             }
-
             logger.debug("[Method 1] Step 4 - Original POM has {} dependencies (GA-keyed) after scope filtering.", originalDepsByGa.size());
 
-            // Step 5: Compare with Aether using GA-based lookup to handle version bumps
+            // Step 5: Compare with Aether (GA-based) to find shaded candidates
             logger.debug("[Method 1] Step 5 - Retrieving Aether graph dependencies for host: {}", hostGa);
             Set<String> aetherChildren = aetherDirectChildrenByGa.containsKey(hostGa)
                     ? aetherDirectChildrenByGa.get(hostGa)
                     : Collections.<String>emptySet();
 
-            logger.debug("[Method 1] Step 5 - Aether graph lists {} direct dependencies for host {}.", aetherChildren.size(), hostGa);
-            for (String aetherDep : aetherChildren) {
-                logger.trace("[Method 1] Step 5 - Aether dependency: {}", aetherDep);
-            }
-
-            // Build GA key set from Aether children for GA-based comparison
             Set<String> aetherGaKeys = new HashSet<String>();
             for (String aetherGav : aetherChildren) {
                 String[] parts = aetherGav.split(":");
@@ -204,11 +214,10 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
                     aetherGaKeys.add(parts[0] + ":" + parts[1]);
                 }
             }
-            logger.debug("[Method 1] Step 5 - Built {} GA keys from Aether children for comparison.", aetherGaKeys.size());
 
-            // GA-based Delta: If original GA is NOT in Aether GA keys, it's a shaded candidate.
-            // Ghost filter: verify .class files actually exist in the JAR for each candidate's groupId.
-            // Without this, deps listed in the POM but excluded by shade plugin config are false positives.
+            // Step 6: Ghost filter + reporting
+            // A candidate is a genuine ghost ONLY if it is explicitly excluded via <artifactSet><excludes>.
+            // Relocated deps are NOT excluded — their classes are in the JAR under the shadedPattern path.
             int originalSize = originalDepsByGa.size();
             int shadedCount = 0;
             int ghostCount = 0;
@@ -217,52 +226,37 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
                 String gaKey = depEntry.getKey();
                 String gavValue = depEntry.getValue();
 
-                if (!aetherGaKeys.contains(gaKey)) {
-                    // Candidate shaded dep — verify classes are actually bundled in the JAR
-                    String groupId = gaKey.split(":")[0];
-                    String expectedClassPrefix = groupId.replace('.', '/') + "/";
-                    String ceiling = classPathPrefixes.ceiling(expectedClassPrefix);
-                    boolean hasClasses = ceiling != null && ceiling.startsWith(expectedClassPrefix);
-
-                    if (!hasClasses) {
-                        logger.debug("[Method 1] Step 5 - Ghost dependency filtered (no .class files for '{}'): {}", expectedClassPrefix, gavValue);
-                        ghostCount++;
-                        continue;
-                    }
-
-                    logger.info("[Method 1] Step 5 - Shaded dependency detected: {}", gavValue);
-                    discoveredDependencies.add(new DiscoveredDependency(gavValue, "Delta Analysis (ProjectBuilder)"));
-                    shadedCount++;
-                } else {
-                    logger.trace("[Method 1] Step 5 - Dependency resolved by Aether (GA match): {}", gaKey);
+                if (aetherGaKeys.contains(gaKey)) {
+                    logger.trace("[Method 1] Step 6 - Dependency resolved by Aether (GA match): {}", gaKey);
+                    continue;
                 }
+
+                // Candidate: in original POM but not in Aether → potentially shaded
+                String[] gaParts = gaKey.split(":", 2);
+                String candidateGroupId = gaParts.length > 0 ? gaParts[0] : "";
+                String candidateArtifactId = gaParts.length > 1 ? gaParts[1] : "";
+
+                if (isGhost(candidateGroupId, candidateArtifactId, gavValue, classPathPrefixes)) {
+                    ghostCount++;
+                    continue;
+                }
+
+                logger.info("[Method 1] Step 6 - Shaded dependency detected: {}", gavValue);
+                discoveredDependencies.add(new DiscoveredDependency(gavValue, "Delta Analysis (ProjectBuilder)"));
+                shadedCount++;
             }
 
-            logger.debug("[Method 1] Step 5 - Delta: {} original, {} aether GA keys, {} shaded, {} ghosts filtered.",
+            logger.debug("[Method 1] Step 6 - Delta: {} original, {} aether GA keys, {} shaded, {} ghosts filtered.",
                     originalSize, aetherGaKeys.size(), shadedCount, ghostCount);
 
         } catch (Exception e) {
             logger.error("[Method 1] Failed to process ProjectBuilder delta math for JAR {}: {}", jarFile.getName(), e.getMessage(), e);
         } finally {
-            // Step 6: Graceful cleanup to prevent disk leaks (delete file and directory)
             if (tempPomFile != null && tempPomFile.exists()) {
-                logger.trace("[Method 1] Step 6 - Cleaning up temporary POM file: {}", tempPomFile.getAbsolutePath());
-                try {
-                    Files.delete(tempPomFile.toPath());
-                    logger.trace("[Method 1] Step 6 - Successfully deleted temporary POM file.");
-                } catch (Exception e) {
-                    logger.warn("[Method 1] Step 6 - Failed to delete temporary POM file: {}", tempPomFile.getAbsolutePath());
-                    tempPomFile.deleteOnExit();
-                }
+                try { Files.delete(tempPomFile.toPath()); } catch (Exception ignored) { tempPomFile.deleteOnExit(); }
             }
             if (tempDir != null) {
-                try {
-                    Files.delete(tempDir);
-                    logger.trace("[Method 1] Step 6 - Successfully deleted temporary directory.");
-                } catch (Exception e) {
-                    logger.warn("[Method 1] Step 6 - Failed to delete temporary directory: {}", tempDir);
-                    tempDir.toFile().deleteOnExit();
-                }
+                try { Files.delete(tempDir); } catch (Exception ignored) { tempDir.toFile().deleteOnExit(); }
             }
         }
 
@@ -270,5 +264,48 @@ public class DeltaAnalysisInspector implements ShadedDependencyInspector {
         return discoveredDependencies;
     }
 
-}
+    /**
+     * Determines whether a delta candidate is a ghost (not actually bundled in the JAR).
+     *
+     * <p><strong>Primary path (ShadePluginConfig available):</strong>
+     * A dep is a ghost if and only if it is explicitly listed in {@code <artifactSet><excludes>}.
+     * This correctly handles relocated deps — their groupId is NOT in the excludes list, so they pass.
+     *
+     * <p><strong>Fallback path (ShadePluginConfig null):</strong>
+     * Falls back to the legacy class-path prefix heuristic: if no {@code .class} files exist under
+     * the dep's groupId package path, treat it as a ghost.
+     * <em>Note:</em> this fallback incorrectly drops relocated deps (known limitation when shade config
+     * is unavailable).
+     */
+    private boolean isGhost(
+            String groupId,
+            String artifactId,
+            String gavValue,
+            @Nullable NavigableSet<String> classPathPrefixesFallback
+    ) {
+        if (shadePluginConfig != null) {
+            // Primary: use explicit exclude list — relocation-aware and intent-driven
+            if (shadePluginConfig.isExcluded(groupId, artifactId)) {
+                logger.debug("[Method 1] Ghost (explicitly excluded in shade config): {}", gavValue);
+                return true;
+            }
+            if (shadePluginConfig.isRelocated(groupId)) {
+                logger.debug("[Method 1] Dep was relocated, confirming as shaded: {}", gavValue);
+            }
+            return false;
+        }
 
+        // Fallback: legacy class-path heuristic
+        if (classPathPrefixesFallback != null) {
+            String expectedClassPrefix = groupId.replace('.', '/') + "/";
+            String ceiling = classPathPrefixesFallback.ceiling(expectedClassPrefix);
+            boolean hasClasses = ceiling != null && ceiling.startsWith(expectedClassPrefix);
+            if (!hasClasses) {
+                logger.debug("[Method 1] Ghost (legacy fallback — no .class files for '{}'): {}", expectedClassPrefix, gavValue);
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/methods/RecursiveMetadataInspector.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/methods/RecursiveMetadataInspector.java
@@ -4,8 +4,10 @@ package com.blackduck.integration.detectable.detectables.maven.resolver.shadeins
 
 import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.ShadedDependencyInspector;
 import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.DiscoveredDependency;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.ShadePluginConfig;
 
 import org.eclipse.aether.artifact.Artifact;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,14 @@ import java.util.jar.JarFile;
  * <p>This is a DETERMINISTIC (HIGH confidence) detection method because pom.properties
  * files contain exact Maven coordinates.
  *
- * <p>The detector excludes the host JAR's own coordinates to avoid self-referencing.
+ * <h2>Ghost Filter (relocation-aware)</h2>
+ * <p>A dep found via pom.properties is a ghost only if it is explicitly listed in the
+ * shade plugin's {@code <artifactSet><excludes>}. This replaces the old class-path prefix
+ * heuristic which incorrectly dropped relocated deps because their classes live at the
+ * relocated path, not the original groupId path.
+ *
+ * <p>If no {@link ShadePluginConfig} is available, falls back to the legacy class-path
+ * prefix heuristic.
  */
 public class RecursiveMetadataInspector implements ShadedDependencyInspector {
 
@@ -38,12 +47,21 @@ public class RecursiveMetadataInspector implements ShadedDependencyInspector {
     private final Artifact hostArtifact;
 
     /**
-     * Initializes the inspector with the host artifact for reliable self-reference exclusion.
-     *
-     * @param hostArtifact The host artifact whose JAR is being inspected (used to exclude self-reference)
+     * Parsed shade plugin configuration for the host artifact's JAR.
+     * May be null — in that case the legacy class-path heuristic is used as fallback.
      */
-    public RecursiveMetadataInspector(Artifact hostArtifact) {
+    @Nullable
+    private final ShadePluginConfig shadePluginConfig;
+
+    /**
+     * Initializes the inspector with the host artifact and parsed shade configuration.
+     *
+     * @param hostArtifact     The host artifact whose JAR is being inspected (used to exclude self-reference)
+     * @param shadePluginConfig Parsed shade config (excludes + relocations); may be null → fallback to legacy heuristic
+     */
+    public RecursiveMetadataInspector(Artifact hostArtifact, @Nullable ShadePluginConfig shadePluginConfig) {
         this.hostArtifact = hostArtifact;
+        this.shadePluginConfig = shadePluginConfig;
     }
 
     /**
@@ -61,38 +79,35 @@ public class RecursiveMetadataInspector implements ShadedDependencyInspector {
 
         logger.debug("========================================================================");
         logger.debug("[Method 2] Starting Recursive Metadata Detection...");
-        logger.debug("[Method 2] Scanning all entries for embedded pom.properties files.");
+        logger.debug("[Method 2] ShadePluginConfig available: {}", shadePluginConfig != null);
         logger.debug("========================================================================");
-
-        // Step 1: Host JAR coordinates are provided via constructor
-        logger.debug("[Method 2] Step 1 - Using provided host artifact coordinates for self-reference exclusion...");
 
         if (hostArtifact != null) {
             logger.debug("[Method 2] Step 1 - Host JAR identified as: {}:{}:{}",
                     hostArtifact.getGroupId(), hostArtifact.getArtifactId(), hostArtifact.getVersion());
         } else {
-            logger.warn("[Method 2] Step 1 - Host artifact not provided. " +
-                    "Self-reference exclusion may not work correctly.");
+            logger.warn("[Method 2] Step 1 - Host artifact not provided. Self-reference exclusion may not work correctly.");
         }
 
-        // Step 1.5: Pre-scan all JAR entries to build a set of class file directory prefixes
-        // This is used to detect ghost dependencies (metadata without classes)
-        logger.debug("[Method 2] Step 1.5 - Pre-scanning JAR entries for .class file prefixes...");
-        // TreeSet gives O(log N) ghost lookups via ceiling() instead of O(N) linear scan
-        NavigableSet<String> classPathPrefixes = new TreeSet<String>();
-        Enumeration<JarEntry> prePassEntries = jarFile.entries();
-        while (prePassEntries.hasMoreElements()) {
-            String entryName = prePassEntries.nextElement().getName();
-            if (entryName.endsWith(".class")) {
-                int lastSlash = entryName.lastIndexOf('/');
-                if (lastSlash > 0) {
-                    classPathPrefixes.add(entryName.substring(0, lastSlash + 1));
+        // Legacy fallback: pre-scan .class file path prefixes only if we have no shade config.
+        NavigableSet<String> classPathPrefixes = null;
+        if (shadePluginConfig == null) {
+            logger.debug("[Method 2] Step 1.5 - No ShadePluginConfig — falling back to legacy class-path ghost filter.");
+            classPathPrefixes = new TreeSet<String>();
+            Enumeration<JarEntry> prePassEntries = jarFile.entries();
+            while (prePassEntries.hasMoreElements()) {
+                String entryName = prePassEntries.nextElement().getName();
+                if (entryName.endsWith(".class")) {
+                    int lastSlash = entryName.lastIndexOf('/');
+                    if (lastSlash > 0) {
+                        classPathPrefixes.add(entryName.substring(0, lastSlash + 1));
+                    }
                 }
             }
+            logger.debug("[Method 2] Step 1.5 - Found {} unique class path prefixes in JAR.", classPathPrefixes.size());
         }
-        logger.debug("[Method 2] Step 1.5 - Found {} unique class path prefixes in JAR.", classPathPrefixes.size());
 
-        // Step 2: Walk through every entry inside the JAR archive
+        // Walk through every entry inside the JAR archive looking for pom.properties files
         logger.debug("[Method 2] Step 2 - Scanning all JAR entries for pom.properties files...");
         Enumeration<JarEntry> entries = jarFile.entries();
         int scannedCount = 0;
@@ -106,27 +121,18 @@ public class RecursiveMetadataInspector implements ShadedDependencyInspector {
             String name = entry.getName();
             scannedCount++;
 
-            // When a dependency is shaded, its unique pom.properties file is usually dragged into the JAR
-            // under META-INF/maven/<groupId>/<artifactId>/pom.properties
             if (name.startsWith("META-INF/maven/") && name.endsWith("pom.properties")) {
 
                 logger.debug("[Method 2] Step 2 - Found pom.properties -> {}", name);
 
-                // Use try-with-resources to ensure we don't leak memory while reading the ZIP stream
                 try (InputStream is = jarFile.getInputStream(entry)) {
 
-                    // Load the key-value pairs from the properties file
-                    // Using InputStreamReader with UTF-8 encoding to handle international characters
-                    // Note: Standard Properties.load(InputStream) uses ISO-8859-1 which garbles UTF-8
                     Properties props = loadPropertiesWithUtf8(is);
 
-                    // Extract the standard Maven coordinates with null-safety
                     String groupId = props.getProperty("groupId");
                     String artifactId = props.getProperty("artifactId");
                     String version = props.getProperty("version");
 
-                    // Validate that required fields are present
-                    // groupId and artifactId are mandatory; version can be missing, but we will mark it
                     if (groupId == null || groupId.trim().isEmpty()) {
                         logger.warn("[Method 2] Step 2 - Skipping entry (missing groupId): {}", name);
                         skippedInvalidCount++;
@@ -139,11 +145,9 @@ public class RecursiveMetadataInspector implements ShadedDependencyInspector {
                         continue;
                     }
 
-                    // Trim whitespace from extracted values
                     groupId = groupId.trim();
                     artifactId = artifactId.trim();
 
-                    // Handle missing or empty version - mark as UNKNOWN instead of null
                     if (version == null || version.trim().isEmpty()) {
                         logger.warn("[Method 2] Step 2 - Version missing for {}:{}, marking as UNKNOWN", groupId, artifactId);
                         version = "UNKNOWN";
@@ -151,29 +155,21 @@ public class RecursiveMetadataInspector implements ShadedDependencyInspector {
                         version = version.trim();
                     }
 
-                    // Check if this is the host JAR's own pom.properties - skip if so
-                    // This prevents the JAR from reporting itself as a shaded dependency
+                    // Skip the host JAR's own pom.properties — prevents self-reporting
                     if (hostArtifact != null
                             && hostArtifact.getGroupId().equals(groupId)
                             && hostArtifact.getArtifactId().equals(artifactId)) {
-                        logger.debug("[Method 2] Step 2 - Skipping host JAR's own coordinates: {}:{}:{}",
-                                groupId, artifactId, version);
+                        logger.debug("[Method 2] Step 2 - Skipping host JAR's own coordinates: {}:{}:{}", groupId, artifactId, version);
                         skippedHostCount++;
                         continue;
                     }
 
-                    // Check for ghost dependency: metadata exists but no .class files for this groupId
-                    String expectedClassPrefix = groupId.replace('.', '/') + "/";
-                    String ceiling = classPathPrefixes.ceiling(expectedClassPrefix);
-                    boolean hasClasses = ceiling != null && ceiling.startsWith(expectedClassPrefix);
-                    if (!hasClasses) {
-                        logger.debug("[Method 2] Step 2 - Skipping ghost dependency (no .class files found "
-                                + "for prefix '{}'): {}:{}:{}", expectedClassPrefix, groupId, artifactId, version);
+                    // Ghost filter: only drop the dep if it was explicitly excluded from the bundle
+                    if (isGhost(groupId, artifactId, version, classPathPrefixes)) {
                         skippedGhostCount++;
                         continue;
                     }
 
-                    // Build the GAV (GroupId:ArtifactId:Version) string
                     String gav = groupId + ":" + artifactId + ":" + version;
                     logger.debug("[Method 2] Step 2 - Extracted shaded artifact: {}", gav);
                     discoveredDependencies.add(new DiscoveredDependency(gav, "Recursive Metadata Extraction"));
@@ -185,17 +181,58 @@ public class RecursiveMetadataInspector implements ShadedDependencyInspector {
             }
         }
 
-        // Step 3: Final summary
         logger.debug("------------------------------------------------------------------------");
         logger.debug("[Method 2] Step 3 - Scan complete.");
         logger.debug("[Method 2] Step 3 - Total entries scanned: {}", scannedCount);
         logger.debug("[Method 2] Step 3 - Host JAR entries skipped (self-reference): {}", skippedHostCount);
         logger.debug("[Method 2] Step 3 - Invalid entries skipped (missing fields): {}", skippedInvalidCount);
-        logger.debug("[Method 2] Step 3 - Ghost entries skipped (metadata without classes): {}", skippedGhostCount);
+        logger.debug("[Method 2] Step 3 - Ghost entries skipped: {}", skippedGhostCount);
         logger.debug("[Method 2] Step 3 - Shaded dependencies found: {}", discoveredDependencies.size());
         logger.debug("------------------------------------------------------------------------");
 
         return discoveredDependencies;
+    }
+
+    /**
+     * Determines whether a pom.properties candidate is a ghost (not actually bundled).
+     *
+     * <p><strong>Primary path (ShadePluginConfig available):</strong>
+     * A dep is a ghost if and only if it is explicitly listed in {@code <artifactSet><excludes>}.
+     * Relocated deps are NOT in the excludes list, so they correctly pass through.
+     *
+     * <p><strong>Fallback path (ShadePluginConfig null):</strong>
+     * Legacy class-path prefix heuristic — incorrectly drops relocated deps (known limitation).
+     */
+    private boolean isGhost(
+            String groupId,
+            String artifactId,
+            String version,
+            @Nullable NavigableSet<String> classPathPrefixesFallback
+    ) {
+        if (shadePluginConfig != null) {
+            if (shadePluginConfig.isExcluded(groupId, artifactId)) {
+                logger.debug("[Method 2] Ghost (explicitly excluded in shade config): {}:{}:{}", groupId, artifactId, version);
+                return true;
+            }
+            if (shadePluginConfig.isRelocated(groupId)) {
+                logger.debug("[Method 2] Dep was relocated, confirming as shaded: {}:{}:{}", groupId, artifactId, version);
+            }
+            return false;
+        }
+
+        // Fallback: legacy class-path heuristic
+        if (classPathPrefixesFallback != null) {
+            String expectedClassPrefix = groupId.replace('.', '/') + "/";
+            String ceiling = classPathPrefixesFallback.ceiling(expectedClassPrefix);
+            boolean hasClasses = ceiling != null && ceiling.startsWith(expectedClassPrefix);
+            if (!hasClasses) {
+                logger.debug("[Method 2] Ghost (legacy fallback — no .class files for '{}'): {}:{}:{}",
+                        expectedClassPrefix, groupId, artifactId, version);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -209,22 +246,15 @@ public class RecursiveMetadataInspector implements ShadedDependencyInspector {
      */
     private Properties loadPropertiesWithUtf8(InputStream is) throws Exception {
         Properties props = new Properties();
-        // Use InputStreamReader with explicit UTF-8 charset to handle international characters
-        // This fixes the ISO-8859-1 limitation of Properties.load(InputStream)
         BufferedReader reader = null;
         try {
             reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             props.load(reader);
         } finally {
             if (reader != null) {
-                try {
-                    reader.close();
-                } catch (Exception ignored) {
-                    // Ignore close exceptions
-                }
+                try { reader.close(); } catch (Exception ignored) {}
             }
         }
         return props;
     }
-
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/methods/RecursiveMetadataInspector.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/methods/RecursiveMetadataInspector.java
@@ -1,0 +1,230 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.methods;
+
+// Method 2: Detect shaded dependencies by scanning all embedded pom.properties files inside the JAR.
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.ShadedDependencyInspector;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.DiscoveredDependency;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Properties;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Scans a JAR file for all embedded pom.properties files under META-INF/maven/.
+ * Each pom.properties file typically belongs to a shaded (bundled) dependency.
+ *
+ * <p>This is a DETERMINISTIC (HIGH confidence) detection method because pom.properties
+ * files contain exact Maven coordinates.
+ *
+ * <p>The detector excludes the host JAR's own coordinates to avoid self-referencing.
+ */
+public class RecursiveMetadataInspector implements ShadedDependencyInspector {
+
+    private static final Logger logger = LoggerFactory.getLogger(RecursiveMetadataInspector.class);
+
+    private final Artifact hostArtifact;
+
+    /**
+     * Initializes the inspector with the host artifact for reliable self-reference exclusion.
+     *
+     * @param hostArtifact The host artifact whose JAR is being inspected (used to exclude self-reference)
+     */
+    public RecursiveMetadataInspector(Artifact hostArtifact) {
+        this.hostArtifact = hostArtifact;
+    }
+
+    /**
+     * Iterates over every entry in the JAR, looking for pom.properties files.
+     * Extracts groupId, artifactId, and version from each one found.
+     * Excludes the host JAR's own coordinates to avoid self-referencing.
+     *
+     * @param jarFile The JAR file to scan.
+     * @return List of discovered shaded dependencies.
+     */
+    @Override
+    public List<DiscoveredDependency> detectShadedDependencies(JarFile jarFile) {
+
+        List<DiscoveredDependency> discoveredDependencies = new ArrayList<DiscoveredDependency>();
+
+        logger.debug("========================================================================");
+        logger.debug("[Method 2] Starting Recursive Metadata Detection...");
+        logger.debug("[Method 2] Scanning all entries for embedded pom.properties files.");
+        logger.debug("========================================================================");
+
+        // Step 1: Host JAR coordinates are provided via constructor
+        logger.debug("[Method 2] Step 1 - Using provided host artifact coordinates for self-reference exclusion...");
+
+        if (hostArtifact != null) {
+            logger.debug("[Method 2] Step 1 - Host JAR identified as: {}:{}:{}",
+                    hostArtifact.getGroupId(), hostArtifact.getArtifactId(), hostArtifact.getVersion());
+        } else {
+            logger.warn("[Method 2] Step 1 - Host artifact not provided. " +
+                    "Self-reference exclusion may not work correctly.");
+        }
+
+        // Step 1.5: Pre-scan all JAR entries to build a set of class file directory prefixes
+        // This is used to detect ghost dependencies (metadata without classes)
+        logger.debug("[Method 2] Step 1.5 - Pre-scanning JAR entries for .class file prefixes...");
+        // TreeSet gives O(log N) ghost lookups via ceiling() instead of O(N) linear scan
+        NavigableSet<String> classPathPrefixes = new TreeSet<String>();
+        Enumeration<JarEntry> prePassEntries = jarFile.entries();
+        while (prePassEntries.hasMoreElements()) {
+            String entryName = prePassEntries.nextElement().getName();
+            if (entryName.endsWith(".class")) {
+                int lastSlash = entryName.lastIndexOf('/');
+                if (lastSlash > 0) {
+                    classPathPrefixes.add(entryName.substring(0, lastSlash + 1));
+                }
+            }
+        }
+        logger.debug("[Method 2] Step 1.5 - Found {} unique class path prefixes in JAR.", classPathPrefixes.size());
+
+        // Step 2: Walk through every entry inside the JAR archive
+        logger.debug("[Method 2] Step 2 - Scanning all JAR entries for pom.properties files...");
+        Enumeration<JarEntry> entries = jarFile.entries();
+        int scannedCount = 0;
+        int skippedHostCount = 0;
+        int skippedInvalidCount = 0;
+        int skippedGhostCount = 0;
+
+        while (entries.hasMoreElements()) {
+
+            JarEntry entry = entries.nextElement();
+            String name = entry.getName();
+            scannedCount++;
+
+            // When a dependency is shaded, its unique pom.properties file is usually dragged into the JAR
+            // under META-INF/maven/<groupId>/<artifactId>/pom.properties
+            if (name.startsWith("META-INF/maven/") && name.endsWith("pom.properties")) {
+
+                logger.debug("[Method 2] Step 2 - Found pom.properties -> {}", name);
+
+                // Use try-with-resources to ensure we don't leak memory while reading the ZIP stream
+                try (InputStream is = jarFile.getInputStream(entry)) {
+
+                    // Load the key-value pairs from the properties file
+                    // Using InputStreamReader with UTF-8 encoding to handle international characters
+                    // Note: Standard Properties.load(InputStream) uses ISO-8859-1 which garbles UTF-8
+                    Properties props = loadPropertiesWithUtf8(is);
+
+                    // Extract the standard Maven coordinates with null-safety
+                    String groupId = props.getProperty("groupId");
+                    String artifactId = props.getProperty("artifactId");
+                    String version = props.getProperty("version");
+
+                    // Validate that required fields are present
+                    // groupId and artifactId are mandatory; version can be missing, but we will mark it
+                    if (groupId == null || groupId.trim().isEmpty()) {
+                        logger.warn("[Method 2] Step 2 - Skipping entry (missing groupId): {}", name);
+                        skippedInvalidCount++;
+                        continue;
+                    }
+
+                    if (artifactId == null || artifactId.trim().isEmpty()) {
+                        logger.warn("[Method 2] Step 2 - Skipping entry (missing artifactId): {}", name);
+                        skippedInvalidCount++;
+                        continue;
+                    }
+
+                    // Trim whitespace from extracted values
+                    groupId = groupId.trim();
+                    artifactId = artifactId.trim();
+
+                    // Handle missing or empty version - mark as UNKNOWN instead of null
+                    if (version == null || version.trim().isEmpty()) {
+                        logger.warn("[Method 2] Step 2 - Version missing for {}:{}, marking as UNKNOWN", groupId, artifactId);
+                        version = "UNKNOWN";
+                    } else {
+                        version = version.trim();
+                    }
+
+                    // Check if this is the host JAR's own pom.properties - skip if so
+                    // This prevents the JAR from reporting itself as a shaded dependency
+                    if (hostArtifact != null
+                            && hostArtifact.getGroupId().equals(groupId)
+                            && hostArtifact.getArtifactId().equals(artifactId)) {
+                        logger.debug("[Method 2] Step 2 - Skipping host JAR's own coordinates: {}:{}:{}",
+                                groupId, artifactId, version);
+                        skippedHostCount++;
+                        continue;
+                    }
+
+                    // Check for ghost dependency: metadata exists but no .class files for this groupId
+                    String expectedClassPrefix = groupId.replace('.', '/') + "/";
+                    String ceiling = classPathPrefixes.ceiling(expectedClassPrefix);
+                    boolean hasClasses = ceiling != null && ceiling.startsWith(expectedClassPrefix);
+                    if (!hasClasses) {
+                        logger.debug("[Method 2] Step 2 - Skipping ghost dependency (no .class files found "
+                                + "for prefix '{}'): {}:{}:{}", expectedClassPrefix, groupId, artifactId, version);
+                        skippedGhostCount++;
+                        continue;
+                    }
+
+                    // Build the GAV (GroupId:ArtifactId:Version) string
+                    String gav = groupId + ":" + artifactId + ":" + version;
+                    logger.debug("[Method 2] Step 2 - Extracted shaded artifact: {}", gav);
+                    discoveredDependencies.add(new DiscoveredDependency(gav, "Recursive Metadata Extraction"));
+
+                } catch (Exception e) {
+                    logger.error("[Method 2] Step 2 - Could not parse metadata at {} - {}", name, e.getMessage());
+                    skippedInvalidCount++;
+                }
+            }
+        }
+
+        // Step 3: Final summary
+        logger.debug("------------------------------------------------------------------------");
+        logger.debug("[Method 2] Step 3 - Scan complete.");
+        logger.debug("[Method 2] Step 3 - Total entries scanned: {}", scannedCount);
+        logger.debug("[Method 2] Step 3 - Host JAR entries skipped (self-reference): {}", skippedHostCount);
+        logger.debug("[Method 2] Step 3 - Invalid entries skipped (missing fields): {}", skippedInvalidCount);
+        logger.debug("[Method 2] Step 3 - Ghost entries skipped (metadata without classes): {}", skippedGhostCount);
+        logger.debug("[Method 2] Step 3 - Shaded dependencies found: {}", discoveredDependencies.size());
+        logger.debug("------------------------------------------------------------------------");
+
+        return discoveredDependencies;
+    }
+
+    /**
+     * Loads properties from an InputStream using UTF-8 encoding.
+     * Standard Properties.load(InputStream) uses ISO-8859-1 which cannot handle UTF-8 characters.
+     * This method wraps the stream with a UTF-8 reader to properly handle international characters.
+     *
+     * @param is The input stream to read properties from.
+     * @return A Properties object with correctly decoded values.
+     * @throws Exception If reading the stream fails.
+     */
+    private Properties loadPropertiesWithUtf8(InputStream is) throws Exception {
+        Properties props = new Properties();
+        // Use InputStreamReader with explicit UTF-8 charset to handle international characters
+        // This fixes the ISO-8859-1 limitation of Properties.load(InputStream)
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+            props.load(reader);
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (Exception ignored) {
+                    // Ignore close exceptions
+                }
+            }
+        }
+        return props;
+    }
+
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/model/DiscoveredDependency.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/model/DiscoveredDependency.java
@@ -1,0 +1,406 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model;
+
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a discovered shaded dependency within a JAR file.
+ *
+ * This model is flexible to support different types of discovery:
+ *   - GAV coordinates (groupId:artifactId:version) from Maven metadata
+ *   - Package names from OSGi manifests
+ *   - Fully qualified class names from SPI descriptors
+ *   - Pseudo-GAV derived from package/class names
+ *
+ * Each discovery includes:
+ *   - An identifier (GAV, package name, or FQCN)
+ *   - The detection method that found it
+ *   - A confidence level (HIGH for deterministic, MEDIUM/LOW for heuristic)
+ *   - Optional additional metadata
+ *
+ * Confidence Classification:
+ *   - DETERMINISTIC (HIGH): 100% certain - found via exact metadata (pom.properties, POM delta)
+ *   - HEURISTIC (MEDIUM): ~70-90% certain - inferred from related metadata (OSGi headers)
+ *   - HEURISTIC (LOW): ~30-60% certain - weak indicators (SPI class names, patterns)
+ */
+public class DiscoveredDependency {
+
+    /**
+     * Confidence level indicating how reliable the detection is.
+     *
+     * HIGH = Deterministic (100% certain) - based on exact Maven metadata
+     * MEDIUM = Heuristic (~70-90% certain) - based on strong indirect indicators
+     * LOW = Heuristic (~30-60% certain) - based on weak indicators, needs verification
+     */
+    public enum Confidence {
+        /** Deterministic detection - 100% reliability (e.g., exact POM delta, pom.properties) */
+        HIGH,
+        /** Heuristic detection - ~70-90% reliability (e.g., OSGi packages with version info) */
+        MEDIUM,
+        /** Low confidence - ~30-60% reliability, requires manual verification */
+        LOW
+    }
+
+    /**
+     * Type of identifier stored in this dependency.
+     */
+    public enum IdentifierType {
+        /** Standard Maven GAV coordinate (groupId:artifactId:version) */
+        GAV,
+        /** Java package name (e.g., org.apache.commons.lang3) */
+        PACKAGE,
+        /** Fully qualified class name (e.g., com.mysql.cj.jdbc.Driver) */
+        FQCN,
+        /** Pseudo-GAV derived from package/class structure */
+        PSEUDO_GAV
+    }
+
+    // Primary identifier for the dependency (GAV, package name, or FQCN)
+    private final String identifier;
+
+    // The detection method that discovered this dependency
+    private final String detectionSource;
+
+    // Confidence level of the detection
+    private final Confidence confidence;
+
+    // Type of the identifier
+    private final IdentifierType identifierType;
+
+    // Optional additional metadata (e.g., original FQCN when pseudo-GAV is used)
+    // Java 8 compatible: explicit type parameter
+    private final Map<String, String> metadata;
+
+    /**
+     * Creates a new DiscoveredDependency with default confidence based on detection source.
+     * This constructor maintains backward compatibility with existing code.
+     *
+     * @param identifier      The dependency identifier (GAV, package, or FQCN).
+     * @param detectionSource The method/detector that found this dependency.
+     */
+    public DiscoveredDependency(String identifier, String detectionSource) {
+        this(identifier, detectionSource, inferConfidence(detectionSource), inferIdentifierType(detectionSource));
+    }
+
+    /**
+     * Creates a new DiscoveredDependency with explicit confidence level.
+     *
+     * @param identifier      The dependency identifier (GAV, package, or FQCN).
+     * @param detectionSource The method/detector that found this dependency.
+     * @param confidence      The confidence level of this detection.
+     * @param identifierType  The type of identifier.
+     */
+    public DiscoveredDependency(String identifier, String detectionSource, Confidence confidence, IdentifierType identifierType) {
+        this.identifier = identifier;
+        this.detectionSource = detectionSource;
+        this.confidence = confidence;
+        this.identifierType = identifierType;
+        this.metadata = new HashMap<String, String>();
+    }
+
+    /**
+     * Infers confidence level based on the detection source.
+     *
+     * Classification criteria:
+     *
+     * DETERMINISTIC (HIGH - 100% certain):
+     *   - Delta Analysis (Exact): Direct comparison of POM files - mathematically certain
+     *   - Recursive Metadata Extraction: Direct reading of pom.properties - exact match
+     *
+     * HEURISTIC (MEDIUM - ~70-90% certain):
+     *   - Original POM (Needs external Delta): Has POM but no reduced version for comparison
+     *   - OSGi Export-Package: Package is bundled, likely from a shaded dependency
+     *
+     * HEURISTIC (LOW - ~30-60% certain):
+     *   - OSGi Import-Package: Could be runtime dependency, not necessarily shaded
+     *   - SPI Descriptor: Class name pattern matching, may produce false positives
+     *
+     * @param detectionSource The detection source string.
+     * @return Inferred confidence level.
+     */
+    private static Confidence inferConfidence(String detectionSource) {
+        if (detectionSource == null) {
+            return Confidence.LOW;
+        }
+
+        String source = detectionSource.toLowerCase();
+
+        // DETERMINISTIC (HIGH - 100% certain)
+        // These methods read exact Maven metadata and are mathematically certain
+        if (source.contains("delta analysis (exact)")) {
+            // Direct POM delta - found in original POM but not in reduced POM
+            // This is the gold standard - 100% certain
+            return Confidence.HIGH;
+        }
+        if (source.contains("recursive metadata extraction") ||
+                source.contains("recursive metadata")) {
+            // Direct reading of pom.properties embedded in the JAR
+            // Each pom.properties file is definitive proof of a bundled artifact
+            return Confidence.HIGH;
+        }
+
+        // HEURISTIC (MEDIUM - ~70-90% certain)
+        // These methods provide strong indirect evidence
+        if (source.contains("original pom")) {
+            // Has POM metadata but couldn't do delta comparison
+            // Still fairly reliable as it's reading Maven coordinates
+            return Confidence.MEDIUM;
+        }
+        if (source.contains("osgi export-package")) {
+            // Exported packages are bundled in the JAR
+            // High correlation with shaded dependencies
+            return Confidence.MEDIUM;
+        }
+
+        // HEURISTIC (LOW - ~30-60% certain)
+        // These methods use pattern matching and may have false positives
+        if (source.contains("osgi import-package")) {
+            // Imported packages could be runtime dependencies, not shaded
+            // Lower confidence than exports
+            return Confidence.LOW;
+        }
+        if (source.contains("spi descriptor") || source.contains("spi")) {
+            // SPI files contain class names, converted to pseudo-GAV
+            // This is pattern-based inference, not direct metadata
+            return Confidence.LOW;
+        }
+
+        // Default to LOW for any unknown sources
+        return Confidence.LOW;
+    }
+
+    /**
+     * Infers identifier type based on the detection source.
+     *
+     * @param detectionSource The detection source string.
+     * @return Inferred identifier type.
+     */
+    private static IdentifierType inferIdentifierType(String detectionSource) {
+        if (detectionSource == null) {
+            return IdentifierType.GAV;
+        }
+
+        String source = detectionSource.toLowerCase();
+
+        // OSGi detection produces package-based pseudo-GAV
+        if (source.contains("osgi")) {
+            return IdentifierType.PSEUDO_GAV;
+        }
+
+        // SPI detection produces FQCN-based pseudo-GAV
+        if (source.contains("spi") || source.contains("fqcn")) {
+            return IdentifierType.PSEUDO_GAV;
+        }
+
+        // Default to GAV for Maven-based detection
+        return IdentifierType.GAV;
+    }
+
+    /**
+     * Gets the primary identifier (GAV, package name, or FQCN).
+     *
+     * @return The dependency identifier.
+     */
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * Gets the detection source/method that found this dependency.
+     *
+     * @return The detection source description.
+     */
+    public String getDetectionSource() {
+        return detectionSource;
+    }
+
+    /**
+     * Gets the confidence level of this detection.
+     *
+     * @return The confidence level.
+     */
+    public Confidence getConfidence() {
+        return confidence;
+    }
+
+    /**
+     * Gets the type of identifier stored.
+     *
+     * @return The identifier type.
+     */
+    public IdentifierType getIdentifierType() {
+        return identifierType;
+    }
+
+    /**
+     * Gets additional metadata associated with this dependency.
+     *
+     * @return Map of metadata key-value pairs.
+     */
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Adds metadata to this dependency.
+     *
+     * @param key   The metadata key.
+     * @param value The metadata value.
+     * @return This instance for method chaining.
+     */
+    public DiscoveredDependency addMetadata(String key, String value) {
+        this.metadata.put(key, value);
+        return this;
+    }
+
+    /**
+     * Parses the identifier as GAV components if it's in GAV format.
+     * Returns null values for components that can't be parsed.
+     *
+     * @return Array of [groupId, artifactId, version], with nulls for missing parts.
+     */
+    public String[] parseAsGav() {
+        if (identifier == null || identifier.isEmpty()) {
+            return new String[]{null, null, null};
+        }
+
+        String[] parts = identifier.split(":");
+        String groupId = parts.length > 0 ? parts[0] : null;
+        String artifactId = parts.length > 1 ? parts[1] : null;
+        String version = parts.length > 2 ? parts[2] : null;
+
+        return new String[]{groupId, artifactId, version};
+    }
+
+    /**
+     * Returns whether this detection is deterministic (100% certain).
+     *
+     * @return true if confidence is HIGH (deterministic), false if heuristic.
+     */
+    public boolean isDeterministic() {
+        return confidence == Confidence.HIGH;
+    }
+
+    /**
+     * Returns a human-readable confidence description.
+     *
+     * @return Description like "DETERMINISTIC (100%)" or "HEURISTIC (70-90%)"
+     */
+    public String getConfidenceDescription() {
+        switch (confidence) {
+            case HIGH:
+                return "DETERMINISTIC (100%)";
+            case MEDIUM:
+                return "HEURISTIC (70-90%)";
+            case LOW:
+                return "HEURISTIC (30-60%)";
+            default:
+                return "UNKNOWN";
+        }
+    }
+
+    /**
+     * Checks equality based on the identifier only.
+     * Two dependencies with the same identifier are considered equal,
+     * regardless of detection source. This enables proper deduplication.
+     *
+     * @param obj The object to compare.
+     * @return true if identifiers are equal.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        // Same reference check
+        if (this == obj) {
+            return true;
+        }
+
+        // Null and type check
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        // Compare by identifier only - this enables deduplication across detectors
+        DiscoveredDependency other = (DiscoveredDependency) obj;
+        return Objects.equals(identifier, other.identifier);
+    }
+
+    /**
+     * Generates hash code based on the identifier only.
+     * This ensures consistency with equals() for use in HashSet/HashMap.
+     *
+     * @return Hash code of the identifier.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier);
+    }
+
+    /**
+     * Returns a human-readable string representation of this dependency.
+     * Format: identifier [source] (confidence description)
+     *
+     * Example outputs:
+     *   org.apache.commons:commons-lang3:3.12.0 [Delta Analysis (Exact)] (DETERMINISTIC 100%)
+     *   org.slf4j:api:1.7.32 [OSGi Export-Package] (HEURISTIC 70-90%)
+     *
+     * @return Formatted string representation.
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        // Primary identifier
+        sb.append(identifier != null ? identifier : "UNKNOWN");
+
+        // Detection source in brackets
+        sb.append(" [");
+        sb.append(detectionSource != null ? detectionSource : "Unknown Source");
+        sb.append("]");
+
+        // Confidence level with percentage hint
+        sb.append(" (");
+        sb.append(getConfidenceDescription());
+        sb.append(")");
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns a compact string representation with just the identifier.
+     * Useful for logging or when source/confidence is not needed.
+     *
+     * @return Just the identifier string.
+     */
+    public String toCompactString() {
+        return identifier != null ? identifier : "UNKNOWN";
+    }
+
+    /**
+     * Returns a detailed string representation including all metadata.
+     * Useful for debugging or detailed reports.
+     *
+     * @return Detailed string with all fields.
+     */
+    public String toDetailedString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DiscoveredDependency {\n");
+        sb.append("  identifier: ").append(identifier).append("\n");
+        sb.append("  type: ").append(identifierType).append("\n");
+        sb.append("  source: ").append(detectionSource).append("\n");
+        sb.append("  confidence: ").append(getConfidenceDescription()).append("\n");
+        sb.append("  deterministic: ").append(isDeterministic()).append("\n");
+
+        if (!metadata.isEmpty()) {
+            sb.append("  metadata: {\n");
+            for (Map.Entry<String, String> entry : metadata.entrySet()) {
+                sb.append("    ").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+            }
+            sb.append("  }\n");
+        }
+
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/model/ShadePluginConfig.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/model/ShadePluginConfig.java
@@ -1,0 +1,131 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Parsed, ready-to-use summary of the maven-shade-plugin configuration extracted
+ * from a dependency's embedded {@code pom.xml}.
+ *
+ * <p>This is NOT a Jackson-mapped model — it is a clean, pre-processed data holder
+ * built by {@code ShadePluginConfigExtractor}
+ * from the raw {@code PomXmlPlugin} XML model.
+ *
+ * <p>Two sets are extracted:
+ * <ul>
+ *   <li>{@code excludedGavPatterns} — artifacts explicitly excluded from the fat JAR via
+ *       {@code <artifactSet><excludes>}. Patterns are in {@code groupId:artifactId} format
+ *       and may contain {@code *} wildcards.</li>
+ *   <li>{@code relocatedPackagePrefixes} — Java package prefixes that were relocated via
+ *       {@code <relocations><relocation><pattern>}. Stored as slash-separated class path
+ *       prefixes (e.g., {@code "com/google/guava/"}) for direct comparison against JAR entries.</li>
+ * </ul>
+ *
+ * <h2>How the ghost filter uses this</h2>
+ * <p>A dependency candidate (found via delta analysis or pom.properties scan) is a ghost
+ * (not actually bundled) if and only if it is listed in {@code excludedGavPatterns}.
+ * If it is NOT explicitly excluded, it WAS bundled — possibly with relocation — and should
+ * be reported as a shaded dependency.
+ */
+public class ShadePluginConfig {
+
+    /** Raw exclude patterns from {@code <artifactSet><excludes>}, e.g. {@code "com.google.guava:guava"}, {@code "org.apache.hadoop:*"} */
+    private final Set<String> excludedGavPatterns;
+
+    /** Class-path prefixes of relocated packages, e.g. {@code "com/google/guava/"} */
+    private final Set<String> relocatedPackagePrefixes;
+
+    public ShadePluginConfig(Set<String> excludedGavPatterns, Set<String> relocatedPackagePrefixes) {
+        this.excludedGavPatterns = excludedGavPatterns != null ? excludedGavPatterns : Collections.<String>emptySet();
+        this.relocatedPackagePrefixes = relocatedPackagePrefixes != null ? relocatedPackagePrefixes : Collections.<String>emptySet();
+    }
+
+    /**
+     * Returns the set of explicitly excluded GAV patterns from {@code <artifactSet><excludes>}.
+     * These are deps that are listed in the original POM but were deliberately NOT bundled.
+     */
+    public Set<String> getExcludedGavPatterns() {
+        return excludedGavPatterns;
+    }
+
+    /**
+     * Returns the set of relocated package class-path prefixes (slash-separated),
+     * e.g. {@code "com/google/guava/"} for a {@code <pattern>com.google.guava</pattern>} relocation.
+     */
+    public Set<String> getRelocatedPackagePrefixes() {
+        return relocatedPackagePrefixes;
+    }
+
+    /**
+     * Returns {@code true} if this dep (by groupId + artifactId) matches any of the
+     * explicitly excluded patterns from {@code <artifactSet><excludes>}.
+     *
+     * <p>Supported pattern formats:
+     * <ul>
+     *   <li>{@code com.google.guava:guava}   — exact match</li>
+     *   <li>{@code com.google.guava:*}        — wildcard on artifactId</li>
+     *   <li>{@code *:guava}                   — wildcard on groupId (rare)</li>
+     *   <li>{@code com.google.guava:guava:jar} — with packaging suffix, matched by prefix</li>
+     * </ul>
+     *
+     * @param groupId    the candidate dependency's groupId
+     * @param artifactId the candidate dependency's artifactId
+     * @return true if the dep is explicitly excluded from the fat JAR
+     */
+    public boolean isExcluded(String groupId, String artifactId) {
+        if (groupId == null || artifactId == null || excludedGavPatterns.isEmpty()) {
+            return false;
+        }
+        for (String pattern : excludedGavPatterns) {
+            if (matchesExcludePattern(pattern, groupId, artifactId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if the dep's groupId was relocated (i.e., its classes live at a
+     * different path in the JAR than the original package suggests).
+     *
+     * @param groupId the candidate dependency's groupId
+     */
+    public boolean isRelocated(String groupId) {
+        if (groupId == null || relocatedPackagePrefixes.isEmpty()) {
+            return false;
+        }
+        String classPrefix = groupId.replace('.', '/') + "/";
+        for (String relocated : relocatedPackagePrefixes) {
+            // A dep is relocated if its package prefix starts with any relocation pattern prefix
+            if (classPrefix.startsWith(relocated) || relocated.startsWith(classPrefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesExcludePattern(String pattern, String groupId, String artifactId) {
+        if (pattern == null || pattern.trim().isEmpty()) {
+            return false;
+        }
+        // Strip packaging suffix if present (e.g., "com.google.guava:guava:jar" → "com.google.guava:guava")
+        String normalised = pattern.trim();
+        int secondColon = normalised.indexOf(':', normalised.indexOf(':') + 1);
+        if (secondColon >= 0) {
+            normalised = normalised.substring(0, secondColon);
+        }
+
+        String[] parts = normalised.split(":", 2);
+        if (parts.length != 2) {
+            return false;
+        }
+        String patternGroup = parts[0].trim();
+        String patternArtifact = parts[1].trim();
+
+        boolean groupMatches = "*".equals(patternGroup) || patternGroup.equals(groupId);
+        boolean artifactMatches = "*".equals(patternArtifact) || patternArtifact.equals(artifactId);
+        return groupMatches && artifactMatches;
+    }
+}
+
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/util/SecureXmlDocumentBuilder.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/util/SecureXmlDocumentBuilder.java
@@ -1,0 +1,184 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.util;
+
+import org.slf4j.Logger;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.StringReader;
+
+/**
+ * Factory for creating secure DocumentBuilder instances with fail-safe XXE protection.
+ *
+ * <p>This utility centralizes XML parser configuration to ensure consistent security
+ * settings across all parsing operations. It applies security hardening on a best-effort
+ * basis - if a particular security feature or attribute is not supported by the runtime's
+ * XML parser implementation, it logs a debug message and continues without failing.
+ *
+ * <p><strong>Security hardening applied (in order):</strong>
+ * <ol>
+ *   <li>XMLConstants.FEATURE_SECURE_PROCESSING - General security hardening</li>
+ *   <li>Disable DOCTYPE declarations to prevent XXE attacks</li>
+ *   <li>Disable external general entities</li>
+ *   <li>Disable external parameter entities</li>
+ *   <li>Disable loading external DTDs</li>
+ *   <li>Block external DTD access via attribute</li>
+ *   <li>Block external schema access via attribute</li>
+ *   <li>Install EntityResolver that returns empty content for any external entity</li>
+ * </ol>
+ *
+ * <p><strong>Compatibility:</strong> This class is designed to work across different
+ * XML parser implementations (Xerces, JDK built-in, etc.) without failing. The
+ * error "Property 'http://javax.xml.XMLConstants/property/accessExternalDTD' is not recognized"
+ * will no longer cause failures - it will simply be logged at debug level and skipped.
+ *
+ * <p><strong>Thread Safety:</strong> Each call to {@link #newDocumentBuilder(Logger)}
+ * creates a new DocumentBuilder instance. DocumentBuilder itself is not thread-safe,
+ * so callers should not share instances across threads.
+ *
+ * <p><strong>Java 8 Compatibility:</strong> This class uses only Java 8 compatible APIs.
+ */
+public final class SecureXmlDocumentBuilder {
+
+    // Feature constants for XXE protection
+    private static final String FEATURE_DISALLOW_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl";
+    private static final String FEATURE_EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    private static final String FEATURE_EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+    private static final String FEATURE_LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private SecureXmlDocumentBuilder() {
+        // Utility class - no instantiation
+    }
+
+    /**
+     * Creates a new DocumentBuilder with best-effort XXE protection.
+     *
+     * <p>This method applies multiple layers of security hardening to prevent
+     * XML External Entity (XXE) attacks. Each security feature is applied
+     * independently - if one fails (e.g., not supported by the parser), the
+     * method continues applying other features and does not throw an exception.
+     *
+     * <p>As a final safety net, an EntityResolver is installed that returns
+     * empty content for any external entity reference, ensuring that even if
+     * some security features are not supported, external entities cannot be
+     * loaded.
+     *
+     * @param logger The logger to use for debug messages about unsupported features.
+     *               Must not be null.
+     * @return A configured DocumentBuilder instance, never null.
+     * @throws ParserConfigurationException If the DocumentBuilder cannot be created
+     *                                       at all (extremely rare - indicates JVM issue).
+     */
+    public static DocumentBuilder newDocumentBuilder(Logger logger) throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+        // Apply security features - each wrapped to handle unsupported features gracefully
+        applyFeatureSafely(factory, XMLConstants.FEATURE_SECURE_PROCESSING, true, logger,
+                "XMLConstants.FEATURE_SECURE_PROCESSING");
+
+        applyFeatureSafely(factory, FEATURE_DISALLOW_DOCTYPE, true, logger,
+                "disallow-doctype-decl");
+
+        applyFeatureSafely(factory, FEATURE_EXTERNAL_GENERAL_ENTITIES, false, logger,
+                "external-general-entities");
+
+        applyFeatureSafely(factory, FEATURE_EXTERNAL_PARAMETER_ENTITIES, false, logger,
+                "external-parameter-entities");
+
+        applyFeatureSafely(factory, FEATURE_LOAD_EXTERNAL_DTD, false, logger,
+                "load-external-dtd");
+
+        // Apply attributes - these are the ones that commonly fail on some parsers
+        applyAttributeSafely(factory, XMLConstants.ACCESS_EXTERNAL_DTD, "", logger,
+                "ACCESS_EXTERNAL_DTD");
+
+        applyAttributeSafely(factory, XMLConstants.ACCESS_EXTERNAL_SCHEMA, "", logger,
+                "ACCESS_EXTERNAL_SCHEMA");
+
+        // Create the builder
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        // Install EntityResolver as final safety net
+        // This ensures external entities return empty content even if parser ignores features
+        builder.setEntityResolver(new SafeEntityResolver(logger));
+
+        return builder;
+    }
+
+    /**
+     * Safely applies a feature to the DocumentBuilderFactory.
+     * If the feature is not supported, logs a debug message and continues.
+     *
+     * @param factory     The factory to configure.
+     * @param feature     The feature URI.
+     * @param value       The feature value (true/false).
+     * @param logger      The logger for debug messages.
+     * @param featureName Human-readable name for logging.
+     */
+    private static void applyFeatureSafely(DocumentBuilderFactory factory, String feature,
+                                           boolean value, Logger logger, String featureName) {
+        try {
+            factory.setFeature(feature, value);
+            logger.debug("XML security feature '{}' set to {}", featureName, value);
+        } catch (Exception e) {
+            logger.debug("XML security feature '{}' not supported by this parser: {}",
+                    featureName, e.getMessage());
+        }
+    }
+
+    /**
+     * Safely applies an attribute to the DocumentBuilderFactory.
+     * If the attribute is not supported, logs a debug message and continues.
+     *
+     * @param factory       The factory to configure.
+     * @param attribute     The attribute name.
+     * @param value         The attribute value.
+     * @param logger        The logger for debug messages.
+     * @param attributeName Human-readable name for logging.
+     */
+    private static void applyAttributeSafely(DocumentBuilderFactory factory, String attribute,
+                                             String value, Logger logger, String attributeName) {
+        try {
+            factory.setAttribute(attribute, value);
+            logger.debug("XML security attribute '{}' set to '{}'", attributeName, value);
+        } catch (Exception e) {
+            logger.debug("XML security attribute '{}' not supported by this parser: {}",
+                    attributeName, e.getMessage());
+        }
+    }
+
+    /**
+     * EntityResolver that returns empty content for any external entity.
+     * This is the final safety net against XXE attacks - even if the parser
+     * ignores security features, this resolver ensures no external content
+     * is loaded.
+     */
+    private static class SafeEntityResolver implements EntityResolver {
+
+        private final Logger logger;
+
+        SafeEntityResolver(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public InputSource resolveEntity(String publicId, String systemId) {
+            // Log the blocked entity resolution attempt
+            if (logger.isDebugEnabled()) {
+                logger.debug("Blocked external entity resolution - publicId: '{}', systemId: '{}'",
+                        publicId != null ? publicId : "null",
+                        systemId != null ? systemId : "null");
+            }
+
+            // Return empty InputSource to prevent any external content loading
+            return new InputSource(new StringReader(""));
+        }
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/util/ShadePluginConfigExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/resolver/shadeinspection/util/ShadePluginConfigExtractor.java
@@ -1,0 +1,166 @@
+package com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.util;
+
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXml;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXmlPlugin;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXmlShadeArtifactSet;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXmlShadeConfig;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXmlShadeExecution;
+import com.blackduck.integration.detectable.detectables.maven.resolver.model.pomxml.PomXmlShadeRelocation;
+import com.blackduck.integration.detectable.detectables.maven.resolver.shadeinspection.model.ShadePluginConfig;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.eclipse.aether.artifact.Artifact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Reads a dependency JAR's embedded {@code pom.xml} and extracts the
+ * maven-shade-plugin configuration into a {@link ShadePluginConfig}.
+ *
+ * <h2>Why the embedded POM?</h2>
+ * <p>The POM published to Maven Central is the <em>dependency-reduced</em> version —
+ * its {@code <dependencies>} section has already been cleaned up. But the original
+ * {@code pom.xml} baked into the JAR at
+ * {@code META-INF/maven/<groupId>/<artifactId>/pom.xml} is untouched and retains
+ * the full shade plugin {@code <configuration>}, including relocation patterns and
+ * artifact exclusions. This is the authoritative source for what was (or was not) bundled.
+ *
+ * <h2>Two places to look</h2>
+ * <p>The shade plugin config may appear in two locations (both are merged):
+ * <ol>
+ *   <li>Directly on the {@code <plugin>} element ({@code <plugin><configuration>})</li>
+ *   <li>Inside an {@code <execution>} ({@code <plugin><executions><execution><configuration>})</li>
+ * </ol>
+ */
+public class ShadePluginConfigExtractor {
+
+    private static final Logger logger = LoggerFactory.getLogger(ShadePluginConfigExtractor.class);
+    private static final String MAVEN_SHADE_PLUGIN_ARTIFACT_ID = "maven-shade-plugin";
+
+    private ShadePluginConfigExtractor() {
+        // static utility class
+    }
+
+    /**
+     * Extracts the shade plugin configuration from the given JAR's embedded {@code pom.xml}.
+     *
+     * @param jarFile      the opened JAR to inspect (caller manages lifecycle — do not close here)
+     * @param hostArtifact the Aether artifact representing this JAR (used to find the POM path)
+     * @return a {@link ShadePluginConfig} with the parsed excludes and relocation patterns,
+     *         or {@code null} if the embedded POM could not be read or contains no shade config
+     */
+    public static ShadePluginConfig extract(JarFile jarFile, Artifact hostArtifact) {
+        if (jarFile == null || hostArtifact == null) {
+            return null;
+        }
+
+        String pomPath = "META-INF/maven/"
+                + hostArtifact.getGroupId()
+                + "/" + hostArtifact.getArtifactId()
+                + "/pom.xml";
+
+        JarEntry pomEntry = jarFile.getJarEntry(pomPath);
+        if (pomEntry == null) {
+            logger.debug("[ShadeConfigExtractor] Embedded pom.xml not found at '{}' in JAR: {}",
+                    pomPath, jarFile.getName());
+            return null;
+        }
+
+        try (InputStream is = jarFile.getInputStream(pomEntry)) {
+            XmlMapper xmlMapper = new XmlMapper();
+            xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            PomXml pomXml = xmlMapper.readValue(is, PomXml.class);
+
+            return buildShadeConfig(pomXml, hostArtifact);
+
+        } catch (Exception e) {
+            logger.debug("[ShadeConfigExtractor] Failed to parse embedded pom.xml from JAR '{}': {}",
+                    jarFile.getName(), e.getMessage());
+            return null;
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Private helpers
+    // ----------------------------------------------------------------
+
+    private static ShadePluginConfig buildShadeConfig(PomXml pomXml, Artifact hostArtifact) {
+        if (pomXml == null || pomXml.getBuild() == null || pomXml.getBuild().getPlugins() == null) {
+            return null;
+        }
+
+        for (PomXmlPlugin plugin : pomXml.getBuild().getPlugins()) {
+            if (!MAVEN_SHADE_PLUGIN_ARTIFACT_ID.equals(plugin.getArtifactId())) {
+                continue;
+            }
+
+            // Merge plugin-level config + all execution-level configs
+            Set<String> excludedGavPatterns = new HashSet<>();
+            Set<String> relocatedPrefixes = new HashSet<>();
+
+            // Style A: <plugin><configuration>
+            mergeConfig(plugin.getConfiguration(), excludedGavPatterns, relocatedPrefixes);
+
+            // Style B: <plugin><executions><execution><configuration>
+            if (plugin.getExecutions() != null) {
+                for (PomXmlShadeExecution execution : plugin.getExecutions()) {
+                    mergeConfig(execution.getConfiguration(), excludedGavPatterns, relocatedPrefixes);
+                }
+            }
+
+            logger.debug("[ShadeConfigExtractor] Extracted shade config for {}:{}: {} exclusion(s), {} relocation(s)",
+                    hostArtifact.getGroupId(), hostArtifact.getArtifactId(),
+                    excludedGavPatterns.size(), relocatedPrefixes.size());
+
+            return new ShadePluginConfig(excludedGavPatterns, relocatedPrefixes);
+        }
+
+        logger.debug("[ShadeConfigExtractor] maven-shade-plugin found but no configuration block in: {}:{}",
+                hostArtifact.getGroupId(), hostArtifact.getArtifactId());
+        // Return empty config (plugin exists, no explicit excludes → nothing excluded)
+        return new ShadePluginConfig(new HashSet<String>(), new HashSet<String>());
+    }
+
+    private static void mergeConfig(
+            PomXmlShadeConfig config,
+            Set<String> excludedGavPatterns,
+            Set<String> relocatedPrefixes
+    ) {
+        if (config == null) {
+            return;
+        }
+
+        // Collect excluded GAV patterns
+        PomXmlShadeArtifactSet artifactSet = config.getArtifactSet();
+        if (artifactSet != null && artifactSet.getExcludes() != null) {
+            for (String exclude : artifactSet.getExcludes()) {
+                if (exclude != null && !exclude.trim().isEmpty()) {
+                    excludedGavPatterns.add(exclude.trim());
+                    logger.debug("[ShadeConfigExtractor]   Exclude pattern: {}", exclude.trim());
+                }
+            }
+        }
+
+        // Collect relocation patterns (convert to class-path prefixes: com.google.guava → com/google/guava/)
+        List<PomXmlShadeRelocation> relocations = config.getRelocations();
+        if (relocations != null) {
+            for (PomXmlShadeRelocation relocation : relocations) {
+                String pattern = relocation.getPattern();
+                if (pattern != null && !pattern.trim().isEmpty()) {
+                    String classPrefix = pattern.trim().replace('.', '/') + "/";
+                    relocatedPrefixes.add(classPrefix);
+                    logger.debug("[ShadeConfigExtractor]   Relocation pattern: {} → class prefix: {}",
+                            pattern.trim(), classPrefix);
+                }
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1252,16 +1252,16 @@ public class DetectProperties {
                     .setCategory(DetectCategory.Advanced)
                     .build();
 
-    public static final NullablePathProperty DETECT_MAVEN_BUILDLESS_SETTINGS_FILE_PATH =
-            NullablePathProperty.newBuilder("detect.maven.buildless.settings.file.path")
-                    .setInfo("Maven Buildless Settings File Path", DetectPropertyFromVersion.VERSION_11_1_0)
+    public static final NullablePathProperty DETECT_MAVEN_BUILDLESS_M2_PATH =
+            NullablePathProperty.newBuilder("detect.maven.buildless.m2.path")
+                    .setInfo("Maven Buildless M2 Directory Path", DetectPropertyFromVersion.VERSION_11_1_0)
                     .setHelp(
-                            "Path to a Maven settings.xml file to parse for mirror configurations.",
-                            "If not specified, defaults to ~/.m2/settings.xml. The parser extracts <mirror> and <server> elements to configure corporate repository managers. CLI mirror properties (detect.maven.buildless.mirror.*) take precedence over settings.xml configuration. If the specified file does not exist, extraction will fail."
+                            "Path to a custom Maven .m2 directory.",
+                            "Used to locate settings.xml (for mirror and proxy configuration) at {m2Path}/settings.xml and the local repository (for JAR downloads during shaded dependency detection) at {m2Path}/repository. If not specified, defaults to ~/.m2. If the specified directory does not exist, the features that depend on it will fall back to default behavior."
                     )
                     .setGroups(DetectGroup.MAVEN, DetectGroup.SOURCE_SCAN)
                     .setCategory(DetectCategory.Advanced)
-                    .setExample("/path/to/custom/settings.xml")
+                    .setExample("/custom/path/.m2")
                     .build();
 
     public static final BooleanProperty DETECT_NOTICES_REPORT =

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
@@ -232,7 +232,11 @@ public class DetectableOptionFactory {
         String cliMirrorOf       = detectConfiguration.getNullableValue(DetectProperties.DETECT_MAVEN_BUILDLESS_MIRROR_OF);
         String cliMirrorUsername = detectConfiguration.getNullableValue(DetectProperties.DETECT_MAVEN_BUILDLESS_MIRROR_USERNAME);
         String cliMirrorPassword = detectConfiguration.getNullableValue(DetectProperties.DETECT_MAVEN_BUILDLESS_MIRROR_PASSWORD);
-        Path   settingsFilePath  = detectConfiguration.getPathOrNull(DetectProperties.DETECT_MAVEN_BUILDLESS_SETTINGS_FILE_PATH);
+
+        // Unified .m2 path — derive settings.xml and local repository from it
+        Path m2Path = detectConfiguration.getPathOrNull(DetectProperties.DETECT_MAVEN_BUILDLESS_M2_PATH);
+        Path settingsFilePath = m2Path != null ? m2Path.resolve("settings.xml") : null;
+        Path jarRepositoryPath = m2Path != null ? m2Path.resolve("repository") : null;
 
         // Delegate proxy precedence logic: settings.xml → CLI → none
         // settings.xml takes priority because it represents Maven-specific proxy configuration
@@ -250,7 +254,10 @@ public class DetectableOptionFactory {
         List<String> resolverExcludedScopes = detectConfiguration.getValue(DetectProperties.DETECT_MAVEN_EXCLUDED_SCOPES);
         boolean includeTestScope = !resolverExcludedScopes.contains("test");
 
-        return new MavenResolverOptions(externalRepositories, proxyConfig, mirrorConfigurations, includeTestScope);
+        // Read shaded dependency detection flag
+        boolean includeShadedDependencies = detectConfiguration.getValue(DetectProperties.DETECT_MAVEN_INCLUDE_SHADED_DEPENDENCIES);
+
+        return new MavenResolverOptions(externalRepositories, proxyConfig, mirrorConfigurations, includeTestScope, includeShadedDependencies, jarRepositoryPath);
 
     }
 


### PR DESCRIPTION
# Description

 ## Summary

  - Parent POM and BOM downloads now respect configured Maven mirrors
  - All POM resolution (parent inheritance, BOM imports, shaded dependencies) routes through mirror settings
  - Mirror credentials are applied when authentication is configured