### PR TITLE
bump upload library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ dependencies {
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.12'
     implementation "com.blackduck.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'com.blackduck.integration:blackduck-upload-common:4.1.5'
+    implementation 'com.blackduck.integration:blackduck-upload-common:4.1.6'
     implementation 'com.blackducksoftware:method-analyzer-core:1.0.7'
     implementation "${locatorGroup}:${locatorModule}:2.4.2"
 


### PR DESCRIPTION
The main fix is in the blackduck-upload-common repo under PR: https://github.com/blackducksoftware/blackduck-upload-common/pull/20