### PR TITLE
fix(uv): Apply excluded groups filter to optional-dependencies in lockfile

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -116,8 +116,10 @@ public class UVLockParser {
         if(dependencyTable.contains(OPTIONAL_DEPENDENCIES_KEY)) {
             TomlTable optionalDependencyTable = dependencyTable.getTable(OPTIONAL_DEPENDENCIES_KEY);
             for(List<String> key: optionalDependencyTable.keyPathSet()) {
-                TomlArray optionalDependencyArray = optionalDependencyTable.getArray(key.get(0));
-                parseTransitiveDependencies(optionalDependencyArray, dependencyName);
+                if(!uvDetectorOptions.getExcludedDependencyGroups().contains(key.get(0))) {
+                    TomlArray optionalDependencyArray = optionalDependencyTable.getArray(key.get(0));
+                    parseTransitiveDependencies(optionalDependencyArray, dependencyName);
+                }
             }
         }
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -104,9 +104,10 @@ public class UVLockParser {
         //parse dev dependencies, it is a toml table with group name as the key and dependencies as list, check if that group is not included then do not parse them
         if(dependencyTable.contains(DEV_DEPENDENCIES_KEY)) {
             TomlTable devDependencyTable = dependencyTable.getTable(DEV_DEPENDENCIES_KEY);
-            for(List<String> key: devDependencyTable.keyPathSet()) {
-                if(!uvDetectorOptions.getExcludedDependencyGroups().contains(key.get(0))) {
-                    TomlArray devDependencyArray = devDependencyTable.getArray(key.get(0));
+            for(List<String> keyPath: devDependencyTable.keyPathSet()) {
+                String groupName = keyPath.get(0);
+                if(!uvDetectorOptions.getExcludedDependencyGroups().contains(groupName)) {
+                    TomlArray devDependencyArray = devDependencyTable.getArray(groupName);
                     parseTransitiveDependencies(devDependencyArray, dependencyName);
                 }
             }
@@ -115,9 +116,10 @@ public class UVLockParser {
         //parse optional dependencies which is part of uv tree command, it can be excluded by users using uv configuration
         if(dependencyTable.contains(OPTIONAL_DEPENDENCIES_KEY)) {
             TomlTable optionalDependencyTable = dependencyTable.getTable(OPTIONAL_DEPENDENCIES_KEY);
-            for(List<String> key: optionalDependencyTable.keyPathSet()) {
-                if(!uvDetectorOptions.getExcludedDependencyGroups().contains(key.get(0))) {
-                    TomlArray optionalDependencyArray = optionalDependencyTable.getArray(key.get(0));
+            for(List<String> keyPath: optionalDependencyTable.keyPathSet()) {
+                String groupName = keyPath.get(0);
+                if(!uvDetectorOptions.getExcludedDependencyGroups().contains(groupName)) {
+                    TomlArray optionalDependencyArray = optionalDependencyTable.getArray(groupName);
                     parseTransitiveDependencies(optionalDependencyArray, dependencyName);
                 }
             }
@@ -171,7 +173,7 @@ public class UVLockParser {
             addDependencyToGraph(currentDependency,parentDependency);
             loopOverDependencies(transitiveDependency, currentDependency, uvDetectorOptions);
         } else {
-            logger.warn("There seems to be a mismatch in the uv.lock. A dependency could not be found: " + transitiveDependency);
+            logger.warn("There seems to be a mismatch in the uv.lock. A dependency could not be found: {}", transitiveDependency);
         }
     }
 


### PR DESCRIPTION
# Description 

- Fixes a bug where the UV Lockfile Detector ignored the `detect.uv.dependency.groups.excluded` property for optional-dependencies
- Optional-dependencies now respect the same exclusion filter already applied to dev-dependencies

## Details

The UV Lockfile Detector parses three types of dependencies from `uv.lock`: main dependencies, dev-dependencies, and optional-dependencies. The exclusion filter was correctly applied to dev-dependencies but missing for optional-dependencies. This caused optional dependency groups to always be included in the BOM regardless of user exclusion settings.

The fix adds the same exclusion check to the optional-dependencies parsing loop, ensuring consistent behavior across all dependency types.
