### PR TITLE
Remove logic to not create project version in case of empty detector bdio

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -114,17 +114,19 @@ public class IntelligentModeStepRunner {
         Set<String> binaryTargets
     ) throws OperationException {
 
-        boolean hasAnythingToUploadOrScan = bdioResult.isNotEmpty()
-            || detectToolFilter.shouldInclude(DetectTool.SIGNATURE_SCAN)
-            || detectToolFilter.shouldInclude(DetectTool.BINARY_SCAN)
-            || detectToolFilter.shouldInclude(DetectTool.CONTAINER_SCAN)
-            || detectToolFilter.shouldInclude(DetectTool.IMPACT_ANALYSIS)
-            || detectToolFilter.shouldInclude(DetectTool.IAC_SCAN);
+//TODO: Short-circuit project/version creation when there is no data to upload and no scan tools are enabled. Planned for next major release.
 
-        if (!hasAnythingToUploadOrScan) {
-            logger.info("No scan results were produced and no other scan tools are enabled. Skipping Black Duck project and version creation.");
-            return;
-        }
+//        boolean hasAnythingToUploadOrScan = bdioResult.isNotEmpty()
+//            || detectToolFilter.shouldInclude(DetectTool.SIGNATURE_SCAN)
+//            || detectToolFilter.shouldInclude(DetectTool.BINARY_SCAN)
+//            || detectToolFilter.shouldInclude(DetectTool.CONTAINER_SCAN)
+//            || detectToolFilter.shouldInclude(DetectTool.IMPACT_ANALYSIS)
+//            || detectToolFilter.shouldInclude(DetectTool.IAC_SCAN);
+//
+//        if (!hasAnythingToUploadOrScan) {
+//            logger.info("No scan results were produced and no other scan tools are enabled. Skipping Black Duck project and version creation.");
+//            return;
+//        }
 
         ProjectVersionWrapper projectVersion = stepHelper.runAsGroup(
             "Create or Locate Project",


### PR DESCRIPTION
Hoping it's a good idea to comment out the code for this release as we anyway decide to add this in the next major release 12.0.