### PR TITLE
fix (Correlation Scanning): Scan counts payload signature count

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -162,7 +162,8 @@ public class IntelligentModeStepRunner {
             );
             codeLocationAccumulator.addNonWaitableCodeLocations(signatureScannerCodeLocationResult.getWaitableCodeLocationData().getSuccessfulCodeLocationNames());
             codeLocationAccumulator.addNonWaitableCodeLocations(signatureScannerCodeLocationResult.getNonWaitableCodeLocationData());
-            codeLocationAccumulator.incrementCodeLocationCountForTool(DetectTool.SIGNATURE_SCAN, 1);
+            int scanPathCount = signatureScannerCodeLocationResult.getWaitableCodeLocationData().getSuccessfulCodeLocationNames().size();
+            codeLocationAccumulator.incrementCodeLocationCountForTool(DetectTool.SIGNATURE_SCAN, scanPathCount);
         });
 
         stepHelper.runToolIfIncluded(DetectTool.BINARY_SCAN, "Binary Scanner", () -> {           


### PR DESCRIPTION
Increase signature scan code location count by the number of successful code location path.


Resolves regression found in IDETECT-5124
