### PR TITLE
IDETECT-5090: fixes pip inspector bug when it parses PEP 508 env markers

### DIFF
--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/setuptools/unit/SetupToolsPyParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/setuptools/unit/SetupToolsPyParserTest.java
@@ -1,8 +1,8 @@
 package com.blackduck.integration.detectable.detectables.setuptools.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.tomlj.Toml;
 import org.tomlj.TomlParseResult;
 
-import com.blackduck.integration.detectable.detectables.setuptools.parse.SetupToolsCfgParser;
 import com.blackduck.integration.detectable.detectables.setuptools.parse.SetupToolsParsedResult;
 import com.blackduck.integration.detectable.detectables.setuptools.parse.SetupToolsPyParser;
 import com.blackduck.integration.detectable.python.util.PythonDependency;
@@ -59,5 +58,46 @@ public class SetupToolsPyParserTest {
         }
 
         Files.delete(pyFile); // delete the temporary file
+    }
+
+    @Test
+    public void testParseWithEnvironmentMarkers() throws IOException {
+        String pyContent = "from setuptools import setup\n\nsetup(\ninstall_requires=[\n"
+            + "\"contextvars;python_version<'3.7'\",\n"
+            + "\"requests>=2.31.0\",\n"
+            + "\"dataclasses;python_version<'3.7'\",\n"
+            + "],\n)";
+        Path pyFile = Files.createTempFile("setup", ".py");
+        Files.write(pyFile, pyContent.getBytes());
+
+        String tomlContent = "[build-system]\nrequires = [\"setuptools\"]";
+        TomlParseResult result = Toml.parse(tomlContent);
+
+        SetupToolsPyParser pyParser = new SetupToolsPyParser(result);
+        pyParser.load(pyFile.toString());
+        SetupToolsParsedResult parsedResult = pyParser.parse();
+
+        List<PythonDependency> deps = parsedResult.getDirectDependencies();
+        assertEquals(3, deps.size());
+
+        // IDETECT-5090: PEP 508 environment markers must be stripped from the package name.
+        // Before the fix, "contextvars;python_version<'3.7'" produced "contextvars;python_version"
+        // as the package name instead of "contextvars".
+        PythonDependency contextvars = deps.get(0);
+        assertEquals("contextvars", contextvars.getName(), "Environment marker should be stripped; got: " + contextvars.getName());
+        assertFalse(contextvars.getName().contains(";"), "Package name must not contain marker separator ';'");
+        assertTrue(contextvars.isConditional(), "Dependency with environment marker should be marked conditional");
+
+        PythonDependency requests = deps.get(1);
+        assertEquals("requests", requests.getName());
+        assertEquals("2.31.0", requests.getVersion());
+        assertFalse(requests.isConditional(), "Dependency without environment marker should not be conditional");
+
+        PythonDependency dataclasses = deps.get(2);
+        assertEquals("dataclasses", dataclasses.getName(), "Environment marker should be stripped; got: " + dataclasses.getName());
+        assertFalse(dataclasses.getName().contains(";"), "Package name must not contain marker separator ';'");
+        assertTrue(dataclasses.isConditional(), "Dependency with environment marker should be marked conditional");
+
+        Files.delete(pyFile);
     }
 }

--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -93,6 +93,18 @@ def resolve_project_node(project_name):
     return project_dependency_node
 
 
+def normalize_package_name(package_name):
+    """Extract and normalize package name from a requirement string using regex.
+    Handles cases like 'package-name>=1.0', 'Package[extra]>=1.0', 'package (>=1.0)', etc.
+    Package names contain only: letters, digits, dots, hyphens, underscores per PEP 508."""
+    if package_name is None:
+        return None
+    name_match = match(r'^([a-zA-Z0-9._-]+)', package_name.strip())
+    if name_match:
+        return name_match.group(1)
+    return None
+
+
 def populate_dependency_tree(project_root_node, requirements_path):
     """Resolves the dependencies of the user-provided requirements.txt and appends them to the dependency tree"""
     try:
@@ -110,7 +122,9 @@ def populate_dependency_tree(project_root_node, requirements_path):
                 # re matches from left to right, so subsets (e.g. ===) should be before supersets (e.g. ==)
                 # See: https://docs.python.org/3/library/re.html
                 # --rotte NOV 2020
-                package_name = split('===|<=|!=|==|>=|~=|<|>', parsed_requirement.requirement)[0]
+                package_name = normalize_package_name(
+                    split('===|<=|!=|==|>=|~=|<|>', parsed_requirement.requirement)[0]
+                )
 
             dependency_node = recursively_resolve_dependencies(package_name, [])
 
@@ -181,18 +195,6 @@ else:
             print("[PIP_INSPECTOR] Using pkg_resources route")
         except ImportError:
             print("[PIP_INSPECTOR] WARNING: Neither importlib.metadata nor pkg_resources available")
-
-    def normalize_package_name(package_name):
-        """Extract and normalize package name from a requirement string using regex.
-        Handles cases like 'package-name>=1.0', 'Package[extra]>=1.0', 'package (>=1.0)', etc.
-        Package names contain only: letters, digits, dots, hyphens, underscores per PEP 508."""
-        if package_name is None:
-            return None
-        # Extract just the package name (valid chars: a-z, A-Z, 0-9, -, _, .)
-        name_match = match(r'^([a-zA-Z0-9._-]+)', package_name.strip())
-        if name_match:
-            return name_match.group(1)
-        return None
 
     if use_importlib_metadata:
         def get_package_by_name(package_name):


### PR DESCRIPTION
# Description

PEP 508 environment markers break PIP Native Inspector package name extraction

When requirements.txt contains entries with PEP 508 environment markers (e.g., `contextvars;python_version<"3.7"`), the fallback regex in `populate_dependency_tree()` splits on comparator characters (`<`, `>`, `==`, etc.). The `<` inside the marker is matched first, producing `contextvars;python_version` as the package name. This causes pip show to fail, forcing Detect to fall back to LOW accuracy and ultimately FAILURE_ACCURACY_NOT_MET.

The fix wraps the existing comparator-split result with `normalize_package_name()`, which uses an anchored regex `(r'^([a-zA-Z0-9._-]+)')` to extract only the valid package name characters, stopping at the `;`.

# Github Issues

(Optional) Please link to any applicable github issues.
