### PR TITLE
Update vulnerable libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA7-dterry.IDETECT-5080-update-vuln-libraries'
+version = '11.5.0-SIGQA8-dterry.IDETECT-5080-update-vuln-libraries-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         javaSourceCompatibility = 8
     }
     ext['logback.version'] = '1.2.13'
+    ext['json-path.version'] = '2.9.0'
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA4-dterry.update-vulnerabilities'
+version = '11.5.0-SIGQA5-dterry.update-vulnerabilities'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         javaSourceCompatibility = 8
     }
     ext['logback.version'] = '1.2.13'
-    ext['json-path.version'] = '2.9.0'
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA5-dterry.update-vulnerabilities'
+version = '11.5.0-SIGQA6-dterry.update-vulnerabilities'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA4-SNAPSHOT'
+version = '11.5.0-SIGQA4-dterry.update-vulnerabilities'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA6-dterry.update-vulnerabilities'
+version = '11.5.0-SIGQA7-dterry.update-vulnerabilities-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         javaSourceCompatibility = 8
     }
     ext['logback.version'] = '1.2.13'
+    ext['json-path.version'] = '2.10.0'
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA9-dterry.IDETECT-5080-update-vuln-libraries-SNAPSHOT'
+version = '11.5.0-SIGQA4-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -131,10 +131,10 @@ allprojects {
 
     dependencies {
         implementation "com.google.guava:guava:32.1.2-jre"
-        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'
+        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3'
         implementation 'org.yaml:snakeyaml:2.0'
         // jackson-core is a transitive dep coming from jackson-dataformat-yaml, earlier versions have vulnerability sonatype-2022-6438
-        implementation('com.fasterxml.jackson.core:jackson-core:2.15.0')
+        implementation('com.fasterxml.jackson.core:jackson-core:2.21.3')
         implementation 'org.freemarker:freemarker:2.3.31'
         implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA7-dterry.update-vulnerabilities-SNAPSHOT'
+version = '11.5.0-SIGQA7-dterry.IDETECT-5080-update-vuln-libraries'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA8-dterry.IDETECT-5080-update-vuln-libraries-SNAPSHOT'
+version = '11.5.0-SIGQA8-dterry.IDETECT-5080-update-vuln-libraries'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA8-dterry.IDETECT-5080-update-vuln-libraries'
+version = '11.5.0-SIGQA9-dterry.IDETECT-5080-update-vuln-libraries-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,2 @@
-gradle.ext.blackDuckCommonVersion='68.0.0'
+gradle.ext.blackDuckCommonVersion='68.0.1'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
This locks json-path to a version without vulnerabilities when used by other things like Spring.

It also moves to newer jackson and blackduck-common library versions that have fixes we should bring into Detect.