### PR TITLE
reduce tika dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,6 @@ dependencies {
 
     // autonomous
     implementation 'org.apache.tika:tika-core:2.9.0'
-    implementation 'org.apache.tika:tika-parsers-standard-package:2.9.0'
     implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.23.1'
 
     constraints {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/autonomous/model/ScanType.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/autonomous/model/ScanType.java
@@ -1,7 +1,5 @@
 package com.blackduck.integration.detect.lifecycle.autonomous.model;
 
-import com.drew.lang.annotations.NotNull;
-
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -32,7 +30,7 @@ public class ScanType implements Comparable<ScanType> {
     private SortedSet<String> scanTargets = new TreeSet<>();
 
     @Override
-    public int compareTo(@NotNull ScanType o) {
+    public int compareTo(ScanType o) {
         return scanTypeName.compareTo(o.scanTypeName);
     }
 


### PR DESCRIPTION
This removes an unnecessary dependency on tika as we only use code from the core library.

It should be noted that Detect doesn't invoke the parsing path that triggers CVE-2025-66516/CVE-2025-54988.

Note: the null removal is because there was a dependency on a transitive of the tika library I am removing. The annotation was cosmetic, and didn't do anything, so I removed it.