### PR TITLE
test: wire Maven shaded battery test to internal Artifactory artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,15 +173,6 @@ test {
     println "maxParallelForks has been set to ${maxParallelForks}"
 }
 
-// Make integration test output (stdout, stderr, logs) visible on the console
-tasks.matching { it.name == 'testIntegration' }.configureEach {
-    testLogging {
-        showStandardStreams = true
-        exceptionFormat = 'full'
-        events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
-    }
-}
-
 dependencies {
     implementation project(':common')
     implementation project(':configuration')

--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,15 @@ test {
     println "maxParallelForks has been set to ${maxParallelForks}"
 }
 
+// Make integration test output (stdout, stderr, logs) visible on the console
+tasks.matching { it.name == 'testIntegration' }.configureEach {
+    testLogging {
+        showStandardStreams = true
+        exceptionFormat = 'full'
+        events 'passed', 'failed', 'skipped', 'standard_out', 'standard_error'
+    }
+}
+
 dependencies {
     implementation project(':common')
     implementation project(':configuration')

--- a/src/main/java/com/blackduck/integration/detect/util/DetectZipUtil.java
+++ b/src/main/java/com/blackduck/integration/detect/util/DetectZipUtil.java
@@ -8,13 +8,16 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,10 +57,10 @@ public class DetectZipUtil { //TODO: Add method for extracting without the wrapp
 
     public static void unzip(File zip, File dest, Charset charset) throws IOException {
         Path destPath = dest.toPath();
-        try (ZipFile zipFile = new ZipFile(zip, ZipFile.OPEN_READ, charset)) {
-            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        try (ZipFile zipFile = ZipFile.builder().setFile(zip).setCharset(charset).get()) {
+            Enumeration<ZipArchiveEntry> entries = zipFile.getEntries();
             while (entries.hasMoreElements()) {
-                ZipEntry entry = entries.nextElement();
+                ZipArchiveEntry entry = entries.nextElement();
                 Path entryPath = destPath.resolve(entry.getName());
                 if (!entryPath.normalize().startsWith(dest.toPath().normalize())) {
                     throw new IOException("Zip entry contained path traversal");
@@ -67,12 +70,37 @@ public class DetectZipUtil { //TODO: Add method for extracting without the wrapp
                 } else {
                     Files.createDirectories(entryPath.getParent());
                     try (InputStream in = zipFile.getInputStream(entry)) {
-                        try (OutputStream out = new FileOutputStream(entryPath.toFile())) {
-                            IOUtils.copy(in, out);
-                        }
+                        Files.copy(in, entryPath);
                     }
+                    applyUnixPermissions(entryPath, entry.getUnixMode());
                 }
             }
+        }
+    }
+
+    private static void applyUnixPermissions(Path filePath, int unixMode) {
+        if (unixMode == 0) {
+            return; // no Unix permissions stored in this entry
+        }
+        try {
+            Set<PosixFilePermission> permissions = EnumSet.noneOf(PosixFilePermission.class);
+            if ((unixMode & 0400) != 0) permissions.add(PosixFilePermission.OWNER_READ);
+            if ((unixMode & 0200) != 0) permissions.add(PosixFilePermission.OWNER_WRITE);
+            if ((unixMode & 0100) != 0) permissions.add(PosixFilePermission.OWNER_EXECUTE);
+            if ((unixMode & 0040) != 0) permissions.add(PosixFilePermission.GROUP_READ);
+            if ((unixMode & 0020) != 0) permissions.add(PosixFilePermission.GROUP_WRITE);
+            if ((unixMode & 0010) != 0) permissions.add(PosixFilePermission.GROUP_EXECUTE);
+            if ((unixMode & 0004) != 0) permissions.add(PosixFilePermission.OTHERS_READ);
+            if ((unixMode & 0002) != 0) permissions.add(PosixFilePermission.OTHERS_WRITE);
+            if ((unixMode & 0001) != 0) permissions.add(PosixFilePermission.OTHERS_EXECUTE);
+            Files.setPosixFilePermissions(filePath, permissions);
+        } catch (UnsupportedOperationException e) {
+            // Windows filesystems do not support POSIX permissions; fall back to setExecutable
+            if ((unixMode & 0111) != 0) {
+                filePath.toFile().setExecutable(true, false);
+            }
+        } catch (IOException e) {
+            logger.warn("Could not set permissions on extracted file: {}", filePath);
         }
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/util/DetectZipUtil.java
+++ b/src/main/java/com/blackduck/integration/detect/util/DetectZipUtil.java
@@ -8,17 +8,13 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.PosixFilePermission;
-import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.Map;
-import java.util.Set;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.utils.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,10 +54,10 @@ public class DetectZipUtil { //TODO: Add method for extracting without the wrapp
 
     public static void unzip(File zip, File dest, Charset charset) throws IOException {
         Path destPath = dest.toPath();
-        try (ZipFile zipFile = ZipFile.builder().setFile(zip).setCharset(charset).get()) {
-            Enumeration<ZipArchiveEntry> entries = zipFile.getEntries();
+        try (ZipFile zipFile = new ZipFile(zip, ZipFile.OPEN_READ, charset)) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {
-                ZipArchiveEntry entry = entries.nextElement();
+                ZipEntry entry = entries.nextElement();
                 Path entryPath = destPath.resolve(entry.getName());
                 if (!entryPath.normalize().startsWith(dest.toPath().normalize())) {
                     throw new IOException("Zip entry contained path traversal");
@@ -71,37 +67,12 @@ public class DetectZipUtil { //TODO: Add method for extracting without the wrapp
                 } else {
                     Files.createDirectories(entryPath.getParent());
                     try (InputStream in = zipFile.getInputStream(entry)) {
-                        Files.copy(in, entryPath, StandardCopyOption.REPLACE_EXISTING);
+                        try (OutputStream out = new FileOutputStream(entryPath.toFile())) {
+                            IOUtils.copy(in, out);
+                        }
                     }
-                    applyUnixPermissions(entryPath, entry.getUnixMode());
                 }
             }
-        }
-    }
-
-    private static void applyUnixPermissions(Path filePath, int unixMode) {
-        if (unixMode == 0) {
-            return; // no Unix permissions stored in this entry
-        }
-        try {
-            Set<PosixFilePermission> permissions = EnumSet.noneOf(PosixFilePermission.class);
-            if ((unixMode & 0400) != 0) permissions.add(PosixFilePermission.OWNER_READ);
-            if ((unixMode & 0200) != 0) permissions.add(PosixFilePermission.OWNER_WRITE);
-            if ((unixMode & 0100) != 0) permissions.add(PosixFilePermission.OWNER_EXECUTE);
-            if ((unixMode & 0040) != 0) permissions.add(PosixFilePermission.GROUP_READ);
-            if ((unixMode & 0020) != 0) permissions.add(PosixFilePermission.GROUP_WRITE);
-            if ((unixMode & 0010) != 0) permissions.add(PosixFilePermission.GROUP_EXECUTE);
-            if ((unixMode & 0004) != 0) permissions.add(PosixFilePermission.OTHERS_READ);
-            if ((unixMode & 0002) != 0) permissions.add(PosixFilePermission.OTHERS_WRITE);
-            if ((unixMode & 0001) != 0) permissions.add(PosixFilePermission.OTHERS_EXECUTE);
-            Files.setPosixFilePermissions(filePath, permissions);
-        } catch (UnsupportedOperationException e) {
-            // Windows filesystems do not support POSIX permissions; fall back to setExecutable
-            if ((unixMode & 0111) != 0) {
-                filePath.toFile().setExecutable(true, false);
-            }
-        } catch (IOException e) {
-            logger.warn("Could not set permissions on extracted file: {}", filePath);
         }
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/util/DetectZipUtil.java
+++ b/src/main/java/com/blackduck/integration/detect/util/DetectZipUtil.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.Enumeration;
@@ -70,7 +71,7 @@ public class DetectZipUtil { //TODO: Add method for extracting without the wrapp
                 } else {
                     Files.createDirectories(entryPath.getParent());
                     try (InputStream in = zipFile.getInputStream(entry)) {
-                        Files.copy(in, entryPath);
+                        Files.copy(in, entryPath, StandardCopyOption.REPLACE_EXISTING);
                     }
                     applyUnixPermissions(entryPath, entry.getUnixMode());
                 }

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -22,7 +22,7 @@ import com.blackduck.integration.detector.base.DetectorType;
 public class MavenShadedDependenciesTest {
 
     private static final String PROJECT_NAME = "maven-shaded-dependency";
-    public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
+    public static final String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 
     @Test
     void mavenShadedDependencyTest() throws IOException, IntegrationException {

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -1,11 +1,12 @@
 package com.blackduck.integration.detect.battery.docker;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.blackduck.integration.detect.battery.docker.integration.BlackDuckAssertions;
 import com.blackduck.integration.detect.battery.docker.integration.BlackDuckTestConnection;
 import com.blackduck.integration.exception.IntegrationException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -21,11 +22,16 @@ import com.blackduck.integration.detector.base.DetectorType;
 public class MavenShadedDependenciesTest {
 
     private static final String PROJECT_NAME = "maven-shaded-dependency";
+    public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 
     @Test
     void mavenShadedDependencyTest() throws IOException,IntegrationException {
         try(DetectDockerTestRunner test = new DetectDockerTestRunner("detect-maven-shaded-dependency", "detect-maven:3.9.9")) {
-            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("MavenShadedDependencies.dockerfile"));
+             Map<String, String> artifactoryArgs = new HashMap<>();
+             artifactoryArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
+             BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("MavenShadedDependencies.dockerfile");
+             buildDockerImageProvider.setBuildArgs(artifactoryArgs);
+             test.withImageProvider(buildDockerImageProvider);
 
             String projectVersion = PROJECT_NAME + "-PI";
             BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
@@ -44,10 +50,6 @@ public class MavenShadedDependenciesTest {
 
             dockerAssertions.logContains("Maven CLI: SUCCESS");
             dockerAssertions.atLeastOneBdioFile();
-
-//            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
-//            blackduckAssertions.hasComponents("JCTTools");
-//            blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
 
             blackduckAssertions.hasComponents("Apache Commons Logging");
             blackduckAssertions.hasComponents("jackson-core");

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -16,7 +16,7 @@ import com.blackduck.integration.detect.battery.docker.util.DockerAssertions;
 import com.blackduck.integration.detect.configuration.DetectProperties;
 import com.blackduck.integration.detector.base.DetectorType;
 
-@Disabled
+
 @Tag("integration")
 public class MavenShadedDependenciesTest {
 

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -25,13 +25,14 @@ public class MavenShadedDependenciesTest {
     public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 
     @Test
-    void mavenShadedDependencyTest() throws IOException,IntegrationException {
-        try(DetectDockerTestRunner test = new DetectDockerTestRunner("detect-maven-shaded-dependency", "detect-maven:3.9.9")) {
-             Map<String, String> artifactoryArgs = new HashMap<>();
-             artifactoryArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
-             BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("MavenShadedDependencies.dockerfile");
-             buildDockerImageProvider.setBuildArgs(artifactoryArgs);
-             test.withImageProvider(buildDockerImageProvider);
+    void mavenShadedDependencyTest() throws IOException, IntegrationException {
+        org.junit.jupiter.api.Assertions.assertNotNull(ARTIFACTORY_URL, "SNPS_INTERNAL_ARTIFACTORY environment variable must be set");
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-maven-shaded-dependency", "detect-maven:3.9.9")) {
+            Map<String, String> artifactoryArgs = new HashMap<>();
+            artifactoryArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
+            BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("MavenShadedDependencies.dockerfile");
+            buildDockerImageProvider.setBuildArgs(artifactoryArgs);
+            test.withImageProvider(buildDockerImageProvider);
 
             String projectVersion = PROJECT_NAME + "-PI";
             BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -45,9 +45,13 @@ public class MavenShadedDependenciesTest {
             dockerAssertions.logContains("Maven CLI: SUCCESS");
             dockerAssertions.atLeastOneBdioFile();
 
-            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
-            blackduckAssertions.hasComponents("JCTTools");
-            blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
+//            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
+//            blackduckAssertions.hasComponents("JCTTools");
+//            blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
+
+            blackduckAssertions.hasComponents("Apache Commons Logging");
+            blackduckAssertions.hasComponents("jackson-core");
+            blackduckAssertions.hasComponents("jackson-databind");
         }
     }
 

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
@@ -108,11 +108,24 @@ public class BlackDuckAssertions {
 
     public void hasComponents(Set<String> componentNames) throws IntegrationException {
         List<ProjectVersionComponentVersionView> bomComponents = getBomComponents();
+
+        String allComponentNames = bomComponents.stream()
+            .map(ProjectVersionComponentVersionView::getComponentName)
+            .collect(Collectors.joining("', '", "['", "']"));
+
         componentNames.forEach(componentName -> {
             Optional<ProjectVersionComponentVersionView> blackDuckCommonComponent = bomComponents.stream()
                 .filter(ProjectVersionComponentView -> componentName.equals(ProjectVersionComponentView.getComponentName()))
                 .findFirst();
-            assertTrue(blackDuckCommonComponent.isPresent());
+            assertTrue(
+                blackDuckCommonComponent.isPresent(),
+                String.format(
+                    "Component '%s' NOT FOUND in BOM!%nBOM contains %d components: %s",
+                    componentName,
+                    bomComponents.size(),
+                    allComponentNames
+                )
+            );
         });
     }
 

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
@@ -109,6 +109,7 @@ public class BlackDuckAssertions {
     public void hasComponents(Set<String> componentNames) throws IntegrationException {
         List<ProjectVersionComponentVersionView> bomComponents = getBomComponents();
 
+        // Surfaces full BOM contents in assertion failure message for easier debugging
         String allComponentNames = bomComponents.stream()
             .map(ProjectVersionComponentVersionView::getComponentName)
             .collect(Collectors.joining("', '", "['", "']"));

--- a/src/test/resources/docker/MavenShadedDependencies.dockerfile
+++ b/src/test/resources/docker/MavenShadedDependencies.dockerfile
@@ -5,7 +5,7 @@ ENV SRC_DIR=/opt/project/src
 
 # Install git
 RUN apt-get update
-RUN apt-get install -y git
+RUN apt-get install -y git wget unzip
 
 # Set up the test project
 RUN mkdir -p ${SRC_DIR}

--- a/src/test/resources/docker/MavenShadedDependencies.dockerfile
+++ b/src/test/resources/docker/MavenShadedDependencies.dockerfile
@@ -10,6 +10,12 @@ RUN apt-get install -y git
 # Set up the test project
 RUN mkdir -p ${SRC_DIR}
 
-RUN git clone --depth 1 https://github.com/crate/crate.git ${SRC_DIR}
+# RUN git clone --depth 1 https://github.com/crate/crate.git ${SRC_DIR}
+
+RUN wget https://artifactory.tools.duckutil.net/artifactory/detect-generic-qa-local/shaded-test-10deps.zip \
+&& unzip shaded-test-10deps.zip -d /tmp/shaded \
+&& rm shaded-test-10deps.zip \
+&& cp -a /tmp/shaded/shaded-test-10deps/. ${SRC_DIR}/ \
+&& rm -rf /tmp/shaded
 
 RUN cd ${SRC_DIR}

--- a/src/test/resources/docker/MavenShadedDependencies.dockerfile
+++ b/src/test/resources/docker/MavenShadedDependencies.dockerfile
@@ -3,16 +3,15 @@ FROM maven:3.9.9-eclipse-temurin-17
 # Do not change SRC_DIR, value is expected by tests
 ENV SRC_DIR=/opt/project/src
 
-# Install git
+# Install git wget and unzip
 RUN apt-get update
 RUN apt-get install -y git wget unzip
 
 # Set up the test project
 RUN mkdir -p ${SRC_DIR}
 
-# RUN git clone --depth 1 https://github.com/crate/crate.git ${SRC_DIR}
-
-RUN wget https://artifactory.tools.duckutil.net/artifactory/detect-generic-qa-local/shaded-test-10deps.zip \
+ARG ARTIFACTORY_URL
+RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/shaded-test-10deps.zip \
 && unzip shaded-test-10deps.zip -d /tmp/shaded \
 && rm shaded-test-10deps.zip \
 && cp -a /tmp/shaded/shaded-test-10deps/. ${SRC_DIR}/ \


### PR DESCRIPTION
# Description

## Summary
  - Enables `MavenShadedDependenciesTest` — switches Dockerfile from cloning an
  external GitHub repo to fetching a pre-built internal artifact from Artifactory via `SNPS_INTERNAL_ARTIFACTORY` env var(consistent with other battery docker tests)
  - Improves `BlackDuckAssertions.hasComponents` failure message to surface full BOM contents, making failures easier to diagnose