### PR TITLE
fix(pip-inspector): resolve extras dependencies missing on Python 3.12+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA17-SNAPSHOT'
+version = '11.5.0-SIGQA17'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA17'
+version = '11.5.0-SIGQA18-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA18-SNAPSHOT'
+version = '11.5.0-SIGQA18'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.0.0-SIGQA2-IDETECT-5187'
+version = '12.0.0-SIGQA3-IDETECT-5187-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.0.0-SIGQA2-SNAPSHOT'
+version = '12.0.0-SIGQA2-IDETECT-5187'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '11.5.0-SIGQA18'
+version = '11.5.0-SIGQA19-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -25,8 +25,7 @@
 * The default output directory of the Quack Patch feature has been updated to use [detect_product_short] scan output directory. For more information, see [Quack Patch Documentation](runningdetect/quack-patch.md).
 * CentOS support in Detect Docker Inspector has been deprecated and will be removed in 12.0.0. For more details, please see [Docker Inspector Release Notes](packagemgrs/docker/releasenotes.md).
     * imageinspector.service.port.centos has been deprecated and will be removed in 12.0.0.
-* Clarified documentation for `--detect.uv.dependency.groups.excluded`. Since optional is not a dependency group in uv but a section defining extras, exclusions must reference the extra name directly (e.g., postgres, redis). Supplying optional has no effect.
-
+* Clarified documentation for `--detect.uv.dependency.groups.excluded`. Optional is not a dependency group in uv but a section defining extras, therefor supplying `optional` as a value has no effect and exclusions must reference the extra name directly (e.g., postgres, redis).
 ### Resolved issues
 * (IDETECT-5125) Fixed failure during Python scans when the `requirements.txt` file contains Python extras syntax using square brackets, e.g.: `kopf[dev]>=1.3`
 * (IDETECT-5090) Fixed PIP Native Inspector failure to parse `requirements.txt` lines that contain [PEP 508 environment markers](https://peps.python.org/pep-0508/).

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -23,7 +23,7 @@
 ### Changed features
 
 * The default output directory of the Quack Patch feature has been updated to use [detect_product_short] scan output directory. For more information, see [Quack Patch Documentation](runningdetect/quack-patch.md).
-* CentOS support in Detect Docker Inspector has been deprecated and will be removed in 12.0.0. For more details, please see [Docker Inspector Release Notes](releasenotes.md).
+* CentOS support in Detect Docker Inspector has been deprecated and will be removed in 12.0.0. For more details, please see [Docker Inspector Release Notes](packagemgrs/docker/releasenotes.md).
     * imageinspector.service.port.centos has been deprecated and will be removed in 12.0.0.
 * Clarified documentation for `--detect.uv.dependency.groups.excluded`. Since optional is not a dependency group in uv but a section defining extras, exclusions must reference the extra name directly (e.g., postgres, redis). Supplying optional has no effect.
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -32,6 +32,7 @@
 * The default output directory of the Quack Patch feature has been updated to use [detect_product_short] scan output directory. For more information, see [Quack Patch Documentation](runningdetect/quack-patch.md).
 * CentOS support in Detect Docker Inspector has been deprecated and will be removed in 12.0.0. For more details, please see [Docker Inspector Release Notes](releasenotes.md).
     * imageinspector.service.port.centos has been deprecated and will be removed in 12.0.0.
+* (IDETECT-5144) Clarified documentation for `--detect.uv.dependency.groups.excluded`. Since optional is not a dependency group in uv but a section defining extras, exclusions must reference the extra name directly (e.g., postgres, redis). Supplying optional has no effect.
 
 ### Resolved issues
 * (IDETECT-5069) Fixed Setuptools parsing for unsupported install_requires syntax in setup.py: Detect now fails fast and logs an error instead of silently misparsing, generating an incorrect BOM, and incorrectly reporting success.
@@ -41,6 +42,10 @@
 * (IDETECT-5064) Updated the Gradle init script to explicitly assign an empty configuration set to phantom projects (container modules lacking a `build.gradle` file). This change prevents tools injected by plugins such as Detekt and Ktlint from being included in the dependency report.
 * (IDETECT-5097) Updated the Gradle init script to enumerate configurations within `gradle.projectsEvaluated`, ensuring that all `afterEvaluate` callbacks, including those from the Android Gradle Plugin (AGP), have completed before configuration processing begins.
 * (IDETECT-5163) Updated the Bazel detector to treat exit code `3` from `query` and `cquery` commands as a partial success. When encountered, the detector now processes any available output and issues a warning indicating that dependency results may be incomplete.
-* (IDETECT-5053) Fixed pip inspector to correctly parse PEP 440 direct reference packages (`name @ url`), ensuring these packages are included in the dependency tree rather than being omitted.
+* (IDETECT-5053) / (IDETECT-4988) Fixed pip inspector to correctly parse PEP 440 direct reference packages (`name @ url`), ensuring these packages are included in the dependency tree rather than being omitted.
+* (IDETECT-5078) Rather then fail, Detect will now complete scans and generate empty BOMs when a Python Setuptools project has no dependencies.
+* (IDETECT-5079) Allow Detect scans to finish with success even if no configured binary file patterns (e.g., .jar, .war, .zip) are found.
+* (IDETECT-5118) Fixed UV Lockfile Detector to respect excluded dependency groups for optional‑dependencies. Optional extras specified in exclusion flags are now correctly excluded alongside development dependencies.
+* (IDETECT‑5126) Fixed a BitBake layer misidentification issue caused by project folder names colliding with layer names. The detector now resolves layers deterministically, preferring the deepest valid match and falling back to the first valid layer when necessary.
 
 ### Dependency Updates

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -20,23 +20,19 @@
 
 ## Version 11.5.0
 
-### New features
-
-* Support for the Conda Tree–based detector has been added. For more details, see [Conda Tree](packagemgrs/conda.md#conda-tree-detector).
-* Support for pnpm now extends to 10.32.1.
-* npm detectors now allow for aliases to be used when specifying dependencies in the package.json file.
-* Ivy CLI Detector, leveraging the `ivy:dependencytree` Ant task to extract direct and transitive dependencies for Ant + Ivy projects. For further information, see [Ivy (Ant) support](packagemgrs/ivy.md).
-
 ### Changed features
 
 * The default output directory of the Quack Patch feature has been updated to use [detect_product_short] scan output directory. For more information, see [Quack Patch Documentation](runningdetect/quack-patch.md).
 * CentOS support in Detect Docker Inspector has been deprecated and will be removed in 12.0.0. For more details, please see [Docker Inspector Release Notes](releasenotes.md).
     * imageinspector.service.port.centos has been deprecated and will be removed in 12.0.0.
-* (IDETECT-5144) Clarified documentation for `--detect.uv.dependency.groups.excluded`. Since optional is not a dependency group in uv but a section defining extras, exclusions must reference the extra name directly (e.g., postgres, redis). Supplying optional has no effect.
+* Clarified documentation for `--detect.uv.dependency.groups.excluded`. Since optional is not a dependency group in uv but a section defining extras, exclusions must reference the extra name directly (e.g., postgres, redis). Supplying optional has no effect.
 
 ### Resolved issues
+* (IDETECT-5125) Fixed failure during Python scans when the `requirements.txt` file contains Python extras syntax using square brackets, e.g.: `kopf[dev]>=1.3`
+* (IDETECT-5090) Fixed PIP Native Inspector failure to parse `requirements.txt` lines that contain [PEP 508 environment markers](https://peps.python.org/pep-0508/).
+* (IDETECT-5056) Fixed a Cargo Lock detector failure to parse the caret symbol '^' used in `Cargo.toml` dependency declarations.
+* (IDETECT-5071) Fixed an issue with Simple Build Tool (sbt) evictions being included in the BOM.
 * (IDETECT-5069) Fixed Setuptools parsing for unsupported install_requires syntax in setup.py: Detect now fails fast and logs an error instead of silently misparsing, generating an incorrect BOM, and incorrectly reporting success.
-
 * (IDETECT-5140) Changed the default output directory of the Quack Patch feature to use [detect_product_short] scan output directory instead of the current working directory.
 * (IDETECT-5121) Include Quack Patch output directory as part of diagnostic zip when the feature is enabled.
 * (IDETECT-5064) Updated the Gradle init script to explicitly assign an empty configuration set to phantom projects (container modules lacking a `build.gradle` file). This change prevents tools injected by plugins such as Detekt and Ktlint from being included in the dependency report.
@@ -49,3 +45,5 @@
 * (IDETECT‑5126) Fixed a BitBake layer misidentification issue caused by project folder names colliding with layer names. The detector now resolves layers deterministically, preferring the deepest valid match and falling back to the first valid layer when necessary.
 
 ### Dependency Updates
+
+* Updated Project Inspector to version 2026.6.0 ensuring continued security compliance.

--- a/documentation/src/main/markdown/packagemgrs/docker/releasenotes.md
+++ b/documentation/src/main/markdown/packagemgrs/docker/releasenotes.md
@@ -1,6 +1,6 @@
 # [docker_inspector_name] Release notes
 
-<note type="attention">Package manager inspection support for CentOS based images has been deprecated in Detect 11.5.0 and will be removed in 12.0.0. CentOS Linux has reached end of life upstream (CentOS Linux 8 in 2021; CentOS Linux 7 in 2024). Once an OS is EOL, it stops receiving regular security and maintenance updates, which inevitably lowers our confidence in any package manager based analysis.  As with any other unsupported image, Docker Inspector will still provide Detect with targets for signature and binary scanning. </note>
+<note type="attention">Package manager inspection support for CentOS based images has been deprecated in [detect_product_short] 11.5.0 and will be removed in 12.0.0. CentOS Linux has reached end of life upstream (CentOS Linux 8 in 2021; CentOS Linux 7 in 2024). Once an OS is EOL, it stops receiving regular security and maintenance updates, which inevitably lowers our confidence in any package manager based analysis. As with any other unsupported image, Docker Inspector will still provide [detect_product_short] with targets for signature and binary scanning. </note>
 
 ## Version 11.5.0
 

--- a/documentation/src/main/markdown/runningdetect/quack-patch.md
+++ b/documentation/src/main/markdown/runningdetect/quack-patch.md
@@ -32,7 +32,7 @@ Quack Patch assists developers in automatically generating code patches for pack
 * Set the LLM Gateway URL with the detect.llm.api.endpoint property: `--detect.llm.api.endpoint=https://your-llm-gateway.com`.
 * Set the LLM Gateway API key with the detect.llm.api.key property: `--detect.llm.api.key=your-llm-api-key`.
 * Set the LLM model with the detect.llm.name property: `--detect.llm.name=gpt-4`.
-* (Optional) Set the `detect.quack.patch.output` property to specify a custom directory for generated patches. If the directory doesn't exist, [detect_product_short] tries to create it and fails if unable to create the output directory. The default is the `quack-patch` folder located within the scan output directory.
+* (Optional) Set the `detect.quack.patch.output` property to specify a custom directory for generated patches. If the directory doesn't exist, [detect_product_short] tries to create it and fails if unable to create the output directory. The default is the `quack-patch` folder located within the scan output directory. If the same custom path is specified across multiple runs, patch files from previous runs may remain in the directory. Review `summary.json` to identify the patch files from the latest run.
 
 ## Example Usage
 

--- a/src/main/resources/pip-inspector.py
+++ b/src/main/resources/pip-inspector.py
@@ -26,9 +26,25 @@
 # pydevd_pycharm.settrace('<Host IP Address>', port=5002, stdoutToServer=True, stderrToServer=True)
 
 """
-A script that inspects the pip cache to determine the hierarchy of dependencies
+A script that inspects the pip cache to determine the hierarchy of dependencies.
+
+This script is invoked by Black Duck Detect as a subprocess inside the target Python
+environment. It reads what is already installed and prints a dependency tree to stdout.
+Detect parses that tree for SCA analysis.
+
+IMPORTANT: This script does NOT install packages. It only reads what is already
+installed. Run 'pip install' before invoking this script.
 
 Usage: pip-inspector.py --projectname=<project_name> --requirements=<requirements_path>
+
+Output format:
+  - Dependency tree: indented plain text, 4 spaces per level
+  - Sentinel prefixes parsed by Detect's Java side:
+      n?==v?       root project package not found in environment
+      --<name>     package not found in environment
+      r?<path>     requirements file does not exist
+      p?<path>     requirements file could not be parsed
+      [PIP_INSPECTOR] ...  informational log, ignored by Detect
 """
 
 from getopt import getopt, GetoptError
@@ -36,6 +52,17 @@ from os import path
 import sys
 from re import split, match
 
+# ---------------------------------------------------------------------------
+# pip version-aware imports
+#
+# pip reorganized its internal package structure across major versions.
+# We import parse_requirements and PipSession from the correct location
+# depending on which pip version is installed.
+#
+#   pip >= 20  ->  network.session replaced download
+#   pip 10-19  ->  pip._internal restructure, download still present
+#   pip < 10   ->  flat structure under pip (not pip._internal)
+# ---------------------------------------------------------------------------
 import pip
 pip_major_version = int(pip.__version__.split(".")[0])
 if pip_major_version >= 20:
@@ -94,9 +121,26 @@ def resolve_project_node(project_name):
 
 
 def normalize_package_name(package_name):
-    """Extract and normalize package name from a requirement string using regex.
-    Handles cases like 'package-name>=1.0', 'Package[extra]>=1.0', 'package (>=1.0)', etc.
-    Package names contain only: letters, digits, dots, hyphens, underscores per PEP 508."""
+    """Extract just the package name from a raw requirement string.
+
+    A raw requirement string from pip can look like any of these:
+      'requests>=2.0'                         version specifier
+      'kopf[dev]>=1.37.3'                     extras with version
+      'requests @ git+https://...'            PEP 508 direct URL reference
+      'boto3 ; extra == "aws"'                conditional extras marker
+      'colorama ; platform_system == "Windows"'  environment marker
+
+    In all cases we only want the package name at the start. Valid package name
+    characters are letters, digits, dots, hyphens, underscores (PEP 508).
+    The regex stops at the first character outside that set (space, [, @, ;, >, < etc.)
+    leaving us with just the clean name.
+
+    Examples:
+      'requests>=2.0'                      -> 'requests'
+      'kopf[dev]>=1.37.3'                  -> 'kopf'
+      'requests @ git+https://...'         -> 'requests'
+      'boto3 ; extra == "aws"'             -> 'boto3'
+    """
     if package_name is None:
         return None
     name_match = match(r'^([a-zA-Z0-9._-]+)', package_name.strip())
@@ -106,22 +150,40 @@ def normalize_package_name(package_name):
 
 
 def populate_dependency_tree(project_root_node, requirements_path):
-    """Resolves the dependencies of the user-provided requirements.txt and appends them to the dependency tree"""
+    """Reads requirements.txt and adds each package as a child of the root node.
+
+    Extracting the package name from a requirements.txt entry:
+
+    Modern pip (>= 20.1) returns a ParsedRequirement object from parse_requirements().
+    This object has a .requirement attribute (the raw string from the file) but does
+    NOT have a .req attribute. So hasattr(..., 'req') is always False on modern pip
+    and we always fall through to the split fallback.
+
+    Older pip (< 20.1) returned an InstallRequirement which had a .req attribute
+    with a .name property. That path is kept for backwards compatibility.
+
+    The split fallback splits the raw string on version comparators to isolate the
+    package name, then normalize_package_name() cleans it further. This handles:
+      - Standard pins:        'flask==3.0.0'           -> split on == -> 'flask'
+      - Version ranges:       'requests>=2.0'          -> split on >= -> 'requests'
+      - Extras with version:  'kopf[dev]>=1.37.3'      -> split on >= -> 'kopf[dev]'
+                                                           normalize  -> 'kopf'
+      - PEP 508 URL refs:     'requests @ git+https://'-> no comparator match
+                                                           normalize  -> 'requests'
+    """
     try:
         parsed_requirements = parse_requirements(requirements_path, session=PipSession())
         for parsed_requirement in parsed_requirements:
             package_name = None
 
-            # In 20.1 of pip, the requirements object changed
+            # Path 1: old pip (< 20.1) — InstallRequirement has .req.name directly
             if hasattr(parsed_requirement, 'req'):
                 package_name = parsed_requirement.req.name
+
+            # Path 2: modern pip fallback — split on version comparators then normalize.
+            # Comparators ordered longest-first to avoid partial matches (e.g. === before ==).
+            # See: https://www.python.org/dev/peps/pep-0508/#grammar
             if package_name is None:
-                # Comparators from: https://www.python.org/dev/peps/pep-0508/#grammar
-                # (Last updated November 2020)
-                #
-                # re matches from left to right, so subsets (e.g. ===) should be before supersets (e.g. ==)
-                # See: https://docs.python.org/3/library/re.html
-                # --rotte NOV 2020
                 package_name = normalize_package_name(
                     split('===|<=|!=|==|>=|~=|<|>', parsed_requirement.requirement)[0]
                 )
@@ -138,7 +200,18 @@ def populate_dependency_tree(project_root_node, requirements_path):
 
 
 def recursively_resolve_dependencies(package_name, history):
-    """Forms a DependencyNode by recursively resolving its dependencies. Tracks history for cyclic dependencies."""
+    """Builds a DependencyNode tree by recursively resolving transitive dependencies.
+
+    For each package:
+      1. Look it up in the installed environment via get_package_by_name()
+      2. get_package_by_name() returns the node (name + version) and a list of
+         its direct dependency names (already normalized, ready for lookup)
+      3. Recurse into each dependency to build their subtrees
+
+    The history list tracks packages already visited in the current traversal.
+    If a package appears again (cycle or diamond dependency), it is added as a
+    leaf node without re-expanding its children. This prevents infinite loops.
+    """
     dependency_node, child_names = get_package_by_name(package_name)
 
     if dependency_node is None:
@@ -153,119 +226,155 @@ def recursively_resolve_dependencies(package_name, history):
 
     return dependency_node
 
-use_pip_internal_to_search_packages = False
-if sys.version_info.major > 3 or sys.version_info.major == 3 and sys.version_info.minor >= 12:
-    # Python version 3.12 is used as a cutoff for the following reasons:
-    #  * it is the version in which pkg_resources is no longer included by default
-    #  * a test confirmed that this version of python is incompatible with PIP versions below 21.2,
-    #    which was the most recent version in which PIP search_packages_info interface changed
-    use_pip_internal_to_search_packages = True
-    print("[PIP_INSPECTOR] Using pip internal API (Python 3.12+)")
 
-if use_pip_internal_to_search_packages:
-    from pip._internal.commands.show import search_packages_info
+# ---------------------------------------------------------------------------
+# get_package_by_name — two implementations, one chosen at startup
+#
+# The right implementation is selected once at module load time based on
+# which libraries are available. Only one definition ends up active.
+#
+# WHY TWO IMPLEMENTATIONS:
+#
+#   Python 3.8+  ->  Flow 1: importlib.metadata (standard library)
+#                    Available since Python 3.8, present on all modern Python
+#                    versions including 3.12+. Reads package metadata directly
+#                    from .dist-info directories on disk.
+#                    dist.requires returns ALL Requires-Dist entries including
+#                    extras markers ('; extra == "dev"'), giving us the full
+#                    transitive dependency picture.
+#
+#   Python < 3.8  ->  Flow 2: pkg_resources (legacy fallback)
+#                    importlib.metadata not available. Uses setuptools'
+#                    pkg_resources.working_set. Only returns unconditional
+#                    dependencies (environment markers evaluated at call time,
+#                    extras-only dependencies not included unless activated).
+#
+# BOTH FLOWS follow the same contract:
+#   Input:  package_name (str) — may be a raw string with version/extras/markers,
+#           normalize_package_name() is applied internally before any lookup.
+#   Output: (DependencyNode, list_of_child_names)
+#           child names are already normalized clean package names, ready for
+#           the next recursion. None is returned if the package is not found.
+# ---------------------------------------------------------------------------
 
+use_importlib_metadata = False
+use_pkg_resources = False
+
+# Priority 1: importlib.metadata — standard library since Python 3.8, covers all modern versions
+try:
+    import importlib.metadata as metadata
+    use_importlib_metadata = True
+    print("[PIP_INSPECTOR] Using importlib.metadata route")
+except ImportError:
+    # Priority 2: pkg_resources — legacy fallback for Python < 3.8
+    try:
+        from pkg_resources import working_set, Requirement
+        use_pkg_resources = True
+        print("[PIP_INSPECTOR] Using pkg_resources route")
+    except ImportError:
+        print("[PIP_INSPECTOR] WARNING: Neither importlib.metadata nor pkg_resources available")
+
+if use_importlib_metadata:
+    # ---------------------------------------------------------------------------
+    # Flow 1: importlib.metadata (Python 3.8+, including 3.12+)
+    #
+    # Reads installed package metadata directly from .dist-info directories.
+    # dist.requires returns ALL Requires-Dist entries including extras markers
+    # such as '; extra == "dev"'. normalize_package_name() strips the markers
+    # so only the package name is passed to the next lookup.
+    #
+    # Name variants are tried (lowercase, hyphens vs underscores) because
+    # package names are stored inconsistently across environments.
+    # ---------------------------------------------------------------------------
     def get_package_by_name(package_name):
-        """Looks up a package from the pip cache using internal pip API.
-        This should not be used when PIP is older than 21.2 since the internal API was slightly different then.
-        """
         if package_name is None:
             return None, None
 
-        package_info = next(search_packages_info([package_name.strip()]), None)
+        # Normalize incoming name — may contain version specifiers, extras, or
+        # URL syntax (e.g. 'requests @ git+https://...') from the requirements
+        # file or from a parent package's Requires-Dist list.
+        normalized_name = normalize_package_name(package_name)
+
+        package_info = None
+        try:
+            package_info = metadata.distribution(normalized_name)
+        except:
+            # Try common name variants — pip normalizes hyphens/underscores/dots
+            # inconsistently, so the stored name may differ from what was requested
+            name_variants = (normalized_name, normalized_name.lower(), normalized_name.replace('-', '_'), normalized_name.replace('_', '-'), normalized_name.replace('.', '-'))
+            for name_variant in name_variants:
+                try:
+                    package_info = metadata.distribution(name_variant)
+                    break
+                except metadata.PackageNotFoundError:
+                    continue
 
         if package_info is None:
             return None, None
 
-        return DependencyNode(package_info.name, package_info.version), package_info.requires
-else:
-    use_importlib_metadata = False
-    use_pkg_resources = False
+        # Normalize each child requirement string to a plain package name.
+        # Entries that are not installed will return None from the next lookup
+        # and are silently skipped by recursively_resolve_dependencies.
+        requires = []
+        if package_info.requires:
+            for requirement in package_info.requires:
+                req_name = normalize_package_name(requirement)
+                requires.append(req_name)
 
-    # Priority 1: Try importlib.metadata (modern standard, Python 3.8+)
-    try:
-        import importlib.metadata as metadata
-        use_importlib_metadata = True
-        print("[PIP_INSPECTOR] Using importlib.metadata route")
-    except ImportError:
-        # Priority 2: Fall back to pkg_resources
+        # Remove duplicates while preserving order
+        requires = list(dict.fromkeys(requires))
+
+        return DependencyNode(package_info.metadata['Name'], package_info.metadata['Version']), requires
+
+elif use_pkg_resources:
+    # ---------------------------------------------------------------------------
+    # Flow 2: pkg_resources (Python < 3.8, legacy fallback)
+    #
+    # Uses setuptools' WorkingSet which is built at import time by scanning
+    # all installed .dist-info and .egg-info directories.
+    #
+    # NOTE: package.requires() evaluates environment markers at call time,
+    # meaning only dependencies applicable to the current platform/Python
+    # version are returned. Extras-only dependencies are NOT included unless
+    # the extras were explicitly activated. This differs from Flow 1 which
+    # returns all Requires-Dist entries unconditionally.
+    # ---------------------------------------------------------------------------
+    def get_package_by_name(package_name):
+        if package_name is None:
+            return None, None
+
+        package = None
+
+        package_dict = working_set.by_key
         try:
-            from pkg_resources import working_set, Requirement
-            use_pkg_resources = True
-            print("[PIP_INSPECTOR] Using pkg_resources route")
-        except ImportError:
-            print("[PIP_INSPECTOR] WARNING: Neither importlib.metadata nor pkg_resources available")
+            # Requirement.parse normalizes the name to a lookup key
+            package = package_dict[Requirement.parse(package_name).key]
+        except:
+            # Try common name variants if the normalized key lookup fails
+            name_variants = (package_name, package_name.lower(), package_name.replace('-', '_'), package_name.replace('_', '-'), package_name.replace('.', '-'))
+            for name_variant in name_variants:
+                if name_variant in package_dict:
+                    package = package_dict[name_variant]
+                    break
 
-    if use_importlib_metadata:
-        def get_package_by_name(package_name):
-            """Looks up a package from the pip cache using importlib.metadata"""
-            if package_name is None:
-                return None, None
+        if package is None:
+            return None, None
 
-            # Normalize the package name to handle different representations
-            normalized_name = normalize_package_name(package_name)
-
-            package_info = None
-            try:
-                package_info = metadata.distribution(normalized_name)
-            except:
-                # Try name variants if the initial lookup fails
-                name_variants = (normalized_name, normalized_name.lower(), normalized_name.replace('-', '_'), normalized_name.replace('_', '-'), normalized_name.replace('.', '-'))
-                for name_variant in name_variants:
-                    try:
-                        package_info = metadata.distribution(name_variant)
-                        break
-                    except metadata.PackageNotFoundError:
-                        continue
-
-            if package_info is None:
-                return None, None
-
-            # Parse requires list: entries are strings like "package-name>=1.0"
-            requires = []
-            if package_info.requires:
-                for requirement in package_info.requires:
-                    # Extract and normalize the package name from the requirement string
-                    req_name = normalize_package_name(requirement)
-                    requires.append(req_name)
-
-            # Remove duplicates while preserving order
-            requires = list(dict.fromkeys(requires))
-
-            return DependencyNode(package_info.metadata['Name'], package_info.metadata['Version']), requires
-
-    elif use_pkg_resources:
-        def get_package_by_name(package_name):
-            """Looks up a package from the pip cache using pkg_resources"""
-            if package_name is None:
-                return None, None
-
-            package = None
-
-            package_dict = working_set.by_key
-            try:
-                package = package_dict[Requirement.parse(package_name).key]
-            except:
-                name_variants = (package_name, package_name.lower(), package_name.replace('-', '_'), package_name.replace('_', '-'), package_name.replace('.', '-'))
-                for name_variant in name_variants:
-                    if name_variant in package_dict:
-                        package = package_dict[name_variant]
-                        break
-
-            if package is None:
-                return None, None
-            return DependencyNode(package.project_name, package.version), [requirement.key for requirement in package.requires()]
+        # package.requires() returns Requirement objects with environment
+        # markers already evaluated — .key gives the normalized package name
+        return DependencyNode(package.project_name, package.version), [requirement.key for requirement in package.requires()]
 
 
 class DependencyNode(object):
-    """Represents a python dependency in a tree graph with a name, version, and array of children DependencyNodes"""
+    """A node in the dependency tree, holding a package name, version, and its children."""
     def __init__(self, name, version):
         self.name = name
         self.version = version
         self.children = []
 
     def render(self, layer=1):
-        """Recursively builds a dependency tree string to be printed to the commandline"""
+        """Recursively builds the indented dependency tree string printed to stdout.
+        Each child level is indented by 4 spaces. Detect parses this output."""
         result = self.name + "==" + self.version
         for child in self.children:
             result += "\n" + (" " * 4 * layer)


### PR DESCRIPTION
**Problem**                                                                                                                                                                                                        
                                                                                                                                                                                                                 When a requirements.txt contains extras syntax (e.g. `uvicorn[standard]>=0.20.0`), transitive dependencies introduced by those extras were missing from the dependency tree on Python 3.12+.                     
                                                                                                                                                                                                                 
**Root Cause**                                                                                                                                                                                                     
                                                                                                                                                                                                                 `pip-inspector.py` had a dedicated code path for Python 3.12+ that used pip's internal `search_packages_info` API. This API strips extras-conditional Requires-Dist entries, so any dependency gated behind ` ; extra == "..."` was silently dropped.                                                                                                                                                                                 
                                                                                                                                                                                                                 
**Changes**  
- Replaced `search_packages_info` with` importlib.metadata` in the Python 3.12+ path, which returns the full Requires-Dist list including extras markers
- Removed the now-unnecessary Python 3.12+ specific code path entirely - `importlib.metadata` has been available since Python 3.8 and handles all modern Python versions uniformly 
- Script simplified from three lookup flows to two: **`importlib.metadata`** (Python 3.8+) and `pkg_resources` (Python < 3.8 legacy fallback)
- Added inline comments throughout the script explaining the pip version compatibility layer, the two flows, and the `normalize_package_name` role 