### PR TITLE
Update documentation URL in error message to docs.blackduck.com

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/shutdown/ExceptionUtility.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/shutdown/ExceptionUtility.java
@@ -16,7 +16,7 @@ import com.blackduck.integration.rest.exception.IntegrationRestException;
 
 public class ExceptionUtility {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    private static final String BLACKDUCK_ERROR_MESSAGE = "An unrecoverable error occurred which may be due to your environment and/or configuration. Please double check the Detect documentation: https://documentation.blackduck.com/bundle/integrations-detect/page/introduction.html";
+    private static final String BLACKDUCK_ERROR_MESSAGE = "An unrecoverable error occurred which may be due to your environment and/or configuration. Please double check the Detect documentation: https://docs.blackduck.com/r/detect/latest/black-duck-detect/introduction-to-black-duck-detect.html";
     private static final String BLACKDUCK_TIMEOUT_ERROR_MESSAGE = "The Black Duck SCA server did not respond within the timeout period.";
 
     public void logException(Exception e) {


### PR DESCRIPTION
# Description

Update the documentation URL in the error message from the deprecated `documentation.blackduck.com` domain to the new `docs.blackduck.com` domain.

  - Old: `https://documentation.blackduck.com/bundle/integrations-detect/page/introduction.html`
  - New: `https://docs.blackduck.com/r/detect/latest/black-duck-detect/introduction-to-black-duck-detect.html`

  The old URL currently redirects to `https://docs.blackduck.com/home` instead of the intended Detect introduction page, making it unhelpful for users troubleshooting errors.

# Github Issues

N/A
