### PR TITLE
Fix jackson vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,10 @@ allprojects {
         implementation 'org.yaml:snakeyaml:2.0'
         // jackson-core is a transitive dep coming from jackson-dataformat-yaml, earlier versions have vulnerability sonatype-2022-6438
         implementation('com.fasterxml.jackson.core:jackson-core:2.21.3')
+        // jackson-databind and jackson-annotations are pinned by Spring Boot 2.7 BOM to 2.13.5;
+        // override to fix vulnerabilities and keep all jackson artifacts in sync
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.21.3')
+        implementation('com.fasterxml.jackson.core:jackson-annotations:2.21')
         implementation 'org.freemarker:freemarker:2.3.31'
         implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,6 @@ buildscript {
     }
     ext['logback.version'] = '1.2.13'
     ext['json-path.version'] = '2.10.0'
-    // Spring Boot 2.7 BOM manages kotlin at 1.6.21; override to fix CVE-2026-53914
-    ext['kotlin.version'] = '1.9.25'
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ buildscript {
     }
     ext['logback.version'] = '1.2.13'
     ext['json-path.version'] = '2.10.0'
+    // Spring Boot 2.7 BOM manages kotlin at 1.6.21; override to fix CVE-2026-53914
+    ext['kotlin.version'] = '1.9.25'
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript
 
     dependencies {
@@ -132,14 +134,14 @@ allprojects {
 
     dependencies {
         implementation "com.google.guava:guava:32.1.2-jre"
-        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3'
+        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.0'
         implementation 'org.yaml:snakeyaml:2.0'
         // jackson-core is a transitive dep coming from jackson-dataformat-yaml, earlier versions have vulnerability sonatype-2022-6438
-        implementation('com.fasterxml.jackson.core:jackson-core:2.21.3')
+        implementation('com.fasterxml.jackson.core:jackson-core:2.22.0')
         // jackson-databind and jackson-annotations are pinned by Spring Boot 2.7 BOM to 2.13.5;
-        // override to fix vulnerabilities and keep all jackson artifacts in sync
-        implementation('com.fasterxml.jackson.core:jackson-databind:2.21.3')
-        implementation('com.fasterxml.jackson.core:jackson-annotations:2.21')
+        // override to fix CVE-2026-54512, CVE-2026-54513 and keep all jackson artifacts in sync
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.22.0')
+        implementation('com.fasterxml.jackson.core:jackson-annotations:2.22')
         implementation 'org.freemarker:freemarker:2.3.31'
         implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
 


### PR DESCRIPTION
CVEs are appearing in older versions of Jackson-*. Updating those libraries.