### PR TITLE
Support for writing diagnostic archive file to a custom path

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -23,3 +23,4 @@
 ### New features
 
 * Support for npm has been extended to 11.13.0 and Node.js 24.17.0.
+* Introduced a property named `detect.diagnostic.archive.path` to specify a custom path for the diagnostic archive.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -23,4 +23,4 @@
 ### New features
 
 * Support for npm has been extended to 11.13.0 and Node.js 24.17.0.
-* Introduced a property named `detect.diagnostic.archive.path` to specify a custom path for the diagnostic archive.
+* Introduced a property named `detect.diagnostic.archive.path`, which enables the specification of a custom path for the diagnostic archive.

--- a/documentation/src/main/markdown/troubleshooting/diagnosticmode.md
+++ b/documentation/src/main/markdown/troubleshooting/diagnosticmode.md
@@ -29,4 +29,7 @@ After running [detect_product_short] in diagnostic mode, log messages similar to
 2019-03-29 09:32:03 INFO  [main] --- Diagnostic mode has completed.
 ```
 
+By default, the diagnostic zip is created in the runs output directory. You can specify a custom path for the diagnostic archive using the `detect.diagnostic.archive.path` property.
+
+
 To conserve disk space, be sure to disable diagnostic mode once it is no longer needed.

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -770,10 +770,10 @@ public class DetectProperties {
             .build();
 
     public static final StringProperty DETECT_DIAGNOSTIC_ARCHIVE_PATH =
-        StringProperty.newBuilder("detect.diagnostic.archive.path", null)
+        StringProperty.newBuilder("detect.diagnostic.archive.path", "")
             .setInfo("Diagnostic Archive Output Path", DetectPropertyFromVersion.VERSION_12_0_0)
             .setHelp(
-                "The path to the zip file that will be created when diagnostic mode is enabled.",
+                "Custom output path for diagnostic archive. A file named detect-run-<runId>.zip will be created under the specified path.",
                 "See the following for more <xref href=\"https://documentation%2Eblackduck%2Ecom/bundle/detect/page/troubleshooting/diagnosticmode%2Ehtml\" scope=\"external\" format=\"html\" target=\"_blank\">Diagnostic Mode information.</xref>")
             .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
             .build();

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -767,7 +767,16 @@ public class DetectProperties {
                 "When enabled, diagnostic mode collects files valuable for troubleshooting (logs, BDIO file, extraction files, reports, etc.), writes them to a zip file, and logs the path to the zip file.",
                 "See the following for more <xref href=\"https://documentation%2Eblackduck%2Ecom/bundle/detect/page/troubleshooting/diagnosticmode%2Ehtml\" scope=\"external\" format=\"html\" target=\"_blank\">Diagnostic Mode information.</xref>")
             .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
-            .build(); 
+            .build();
+
+    public static final StringProperty DETECT_DIAGNOSTIC_ARCHIVE_PATH =
+        StringProperty.newBuilder("detect.diagnostic.archive.path", null)
+            .setInfo("Diagnostic Archive Output Path", DetectPropertyFromVersion.VERSION_12_0_0)
+            .setHelp(
+                "The path to the zip file that will be created when diagnostic mode is enabled.",
+                "See the following for more <xref href=\"https://documentation%2Eblackduck%2Ecom/bundle/detect/page/troubleshooting/diagnosticmode%2Ehtml\" scope=\"external\" format=\"html\" target=\"_blank\">Diagnostic Mode information.</xref>")
+            .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
+            .build();
 
     public static final BooleanProperty DETECT_IGNORE_CONNECTION_FAILURES =
         BooleanProperty.newBuilder("detect.ignore.connection.failures", false)

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -774,7 +774,7 @@ public class DetectProperties {
             .setInfo("Diagnostic Archive Output Path", DetectPropertyFromVersion.VERSION_12_0_0)
             .setHelp(
                 "Custom output path for diagnostic archive. A file named detect-run-<runId>.zip will be created under the specified path.",
-                "See the following for more <xref href=\"https://documentation%2Eblackduck%2Ecom/bundle/detect/page/troubleshooting/diagnosticmode%2Ehtml\" scope=\"external\" format=\"html\" target=\"_blank\">Diagnostic Mode information.</xref>")
+                "See the following for more <xref href=\"https://docs.blackduck.com/r/detect/latest/black%2Dduck%2Ddetect/detect%2Ddiagnostic%2Dmode%2Ehtml%5C\" scope=\"external\" format=\"html\" target=\"_blank\">Diagnostic Mode information.</xref>")
             .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
             .build();
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectPropertyFromVersion.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectPropertyFromVersion.java
@@ -60,7 +60,8 @@ public enum DetectPropertyFromVersion implements PropertyVersion {
     VERSION_11_0_0("11.0.0"),
     VERSION_11_2_0("11.2.0"),
     VERSION_11_3_0("11.3.0"),
-    VERSION_11_4_0("11.4.0");
+    VERSION_11_4_0("11.4.0"),
+    VERSION_12_0_0("12.0.0");
 
     private final String version;
 

--- a/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
@@ -124,22 +124,13 @@ public class DiagnosticSystem {
             logger.error("Failed to create diagnostic zip. Cleanup will not occur.", e);
         }
 
-        if (!zipCreated) {
+        String detectDiagnosticOutputPath = propertyConfiguration.getValueOrDefault(DetectProperties.DETECT_DIAGNOSTIC_ARCHIVE_PATH).trim();
+        // If detect.diagnostic.archive.path is specified and is not empty, then copy diagnostic zip to that path.
+        if (zipCreated && !detectDiagnosticOutputPath.isEmpty()) {
+            copyDiagnosticArchiveToCustomPath("detect-run-" + detectRunId.getRunId() + ".zip", detectDiagnosticOutputPath);
+        } else {
             logger.error("Diagnostic mode failed to create zip. Cleanup will not occur.");
         }
-        // If detect.diagnostic.archive.path is specified and is not empty, then copy diagnostic zip to that path.
-        String detectDiagnosticOutputPath = propertyConfiguration.getValueOrDefault(DetectProperties.DETECT_DIAGNOSTIC_ARCHIVE_PATH);
-        if (!detectDiagnosticOutputPath.isEmpty()) {
-            File diagnosticZipFile = new File(directoryManager.getRunsOutputDirectory(), detectRunId.getRunId() + ".zip");
-            File destinationFile = new File(detectDiagnosticOutputPath + "detect-run-" + detectRunId.getRunId() + ".zip");
-            try {
-                FileUtils.copyFile(diagnosticZipFile, destinationFile);
-                logger.info("Diagnostic zip file copied to {}.", destinationFile.getAbsolutePath());
-            } catch (IOException e) {
-                logger.error("Failed to copy diagnostic zip file to {}. Error: {}", destinationFile.getAbsolutePath(), e.getMessage());
-            }
-        }
-
         logger.info("Diagnostic mode has completed.");
     }
 
@@ -169,5 +160,17 @@ public class DiagnosticSystem {
         directoriesToCompress.add(directoryManager.getRunHomeDirectory());
         DiagnosticZipCreator zipper = new DiagnosticZipCreator();
         return zipper.createDiagnosticZip(detectRunId.getRunId(), directoryManager.getRunsOutputDirectory(), directoriesToCompress);
+    }
+
+    public void copyDiagnosticArchiveToCustomPath(String diagnosticArchiveName, String detectDiagnosticOutputPath) {
+        try {
+            File diagnosticZipFile = new File(directoryManager.getRunsOutputDirectory(), diagnosticArchiveName);
+            FileUtils.forceMkdir(new File(detectDiagnosticOutputPath));
+            File destinationFile = new File(detectDiagnosticOutputPath + File.separator + diagnosticArchiveName);
+            FileUtils.copyFile(diagnosticZipFile, destinationFile);
+            logger.info("Diagnostic zip file copied to {}.", destinationFile.getAbsolutePath());
+        } catch (IOException e) {
+            logger.error("Failed to copy diagnostic zip file to a custom path at {}. Error: {}", detectDiagnosticOutputPath, e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
@@ -127,6 +127,18 @@ public class DiagnosticSystem {
         if (!zipCreated) {
             logger.error("Diagnostic mode failed to create zip. Cleanup will not occur.");
         }
+        // If detect.diagnostic.archive.path is specified and is not empty, then copy diagnostic zip to that path.
+        String detectDiagnosticOutputPath = propertyConfiguration.getValueOrDefault(DetectProperties.DETECT_DIAGNOSTIC_ARCHIVE_PATH);
+        if (!detectDiagnosticOutputPath.isEmpty()) {
+            File diagnosticZipFile = new File(directoryManager.getRunsOutputDirectory(), detectRunId.getRunId() + ".zip");
+            File destinationFile = new File(detectDiagnosticOutputPath + "detect-run-" + detectRunId.getRunId() + ".zip");
+            try {
+                FileUtils.copyFile(diagnosticZipFile, destinationFile);
+                logger.info("Diagnostic zip file copied to {}.", destinationFile.getAbsolutePath());
+            } catch (IOException e) {
+                logger.error("Failed to copy diagnostic zip file to {}. Error: {}", destinationFile.getAbsolutePath(), e.getMessage());
+            }
+        }
 
         logger.info("Diagnostic mode has completed.");
     }

--- a/src/test/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystemTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystemTest.java
@@ -1,0 +1,134 @@
+package com.blackduck.integration.detect.workflow.diagnostic;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.TreeMap;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.blackduck.integration.configuration.config.PropertyConfiguration;
+import com.blackduck.integration.configuration.source.MapPropertySource;
+import com.blackduck.integration.detect.configuration.DetectInfo;
+import com.blackduck.integration.detect.configuration.DetectProperties;
+import com.blackduck.integration.detect.workflow.DetectRunId;
+import com.blackduck.integration.detect.workflow.event.EventSystem;
+import com.blackduck.integration.detect.workflow.file.DirectoryManager;
+import com.blackduck.integration.detect.workflow.file.DirectoryOptions;
+import com.blackduck.integration.util.OperatingSystemType;
+
+class DiagnosticSystemTest {
+
+    private static final String TEST_PROPERTY_SOURCE_NAME = "TEST_PROPERTIES";
+    private static final String TEST_RUN_ID = "test-run-id";
+
+    @TempDir
+    File tempDir;
+
+    /**
+     * Verifies that when detect.diagnostic.archive.path is set, the diagnostic zip file
+     * is copied to the specified custom path after finish() is called.
+     */
+    @Test
+    void diagnosticZipCopiedToCustomArchivePath() throws IOException {
+        // Arrange
+        File outputDir = new File(tempDir, "detect-output");
+        outputDir.mkdirs();
+        File customArchiveDir = new File(tempDir, "custom-archive");
+        customArchiveDir.mkdirs();
+
+        DetectRunId detectRunId = new DetectRunId(TEST_RUN_ID, "test-correlation-id");
+        DirectoryOptions directoryOptions = new DirectoryOptions(
+            null, outputDir.toPath(), null, null, null, null, null
+        );
+        DirectoryManager directoryManager = new DirectoryManager(directoryOptions, detectRunId);
+
+        // Pre-create the source zip file that finish() will attempt to copy.
+        // The copy logic in DiagnosticSystem.finish() looks for {runId}.zip in the runs output directory.
+        File runsOutputDir = directoryManager.getRunsOutputDirectory();
+        File sourceZipFile = new File(runsOutputDir, TEST_RUN_ID + ".zip");
+        FileUtils.writeStringToFile(sourceZipFile, "dummy zip content", StandardCharsets.UTF_8);
+
+        // Use trailing separator so the concatenation in finish() produces a valid path:
+        // detectDiagnosticOutputPath + "detect-run-" + runId + ".zip"
+        String customArchivePath = customArchiveDir.getAbsolutePath() + File.separator;
+        PropertyConfiguration propertyConfiguration = buildPropertyConfiguration(customArchivePath);
+
+        DetectInfo detectInfo = new DetectInfo("test-version", OperatingSystemType.LINUX, "2024-01-01");
+        EventSystem eventSystem = new EventSystem();
+
+        DiagnosticSystem diagnosticSystem = new DiagnosticSystem(
+            propertyConfiguration,
+            detectRunId,
+            detectInfo,
+            directoryManager,
+            eventSystem,
+            new TreeMap<>()
+        );
+
+        // Act
+        diagnosticSystem.finish();
+
+        // Assert
+        File expectedDestinationFile = new File(customArchiveDir, "detect-run-" + TEST_RUN_ID + ".zip");
+        Assertions.assertTrue(
+            expectedDestinationFile.exists(),
+            "Diagnostic zip should be copied to the custom archive path when detect.diagnostic.archive.path is set"
+        );
+    }
+
+    /**
+     * Verifies that when detect.diagnostic.archive.path is empty, no copy of the
+     * diagnostic zip is performed to an alternate location.
+     */
+    @Test
+    void diagnosticZipNotCopiedWhenArchivePathIsEmpty() throws IOException {
+        // Arrange
+        File outputDir = new File(tempDir, "detect-output");
+        outputDir.mkdirs();
+        File unexpectedCopyDir = new File(tempDir, "should-not-receive-copy");
+
+        DetectRunId detectRunId = new DetectRunId(TEST_RUN_ID, "test-correlation-id");
+        DirectoryOptions directoryOptions = new DirectoryOptions(
+            null, outputDir.toPath(), null, null, null, null, null
+        );
+        DirectoryManager directoryManager = new DirectoryManager(directoryOptions, detectRunId);
+
+        // Configure detect.diagnostic.archive.path as empty — copy should be skipped
+        PropertyConfiguration propertyConfiguration = buildPropertyConfiguration("");
+
+        DetectInfo detectInfo = new DetectInfo("test-version", OperatingSystemType.LINUX, "2024-01-01");
+        EventSystem eventSystem = new EventSystem();
+
+        DiagnosticSystem diagnosticSystem = new DiagnosticSystem(
+            propertyConfiguration,
+            detectRunId,
+            detectInfo,
+            directoryManager,
+            eventSystem,
+            new TreeMap<>()
+        );
+
+        // Act
+        diagnosticSystem.finish();
+
+        // Assert — no file should have been placed in an unrelated directory
+        Assertions.assertFalse(
+            unexpectedCopyDir.exists(),
+            "No diagnostic zip should be copied when detect.diagnostic.archive.path is empty"
+        );
+    }
+
+    private PropertyConfiguration buildPropertyConfiguration(String archivePath) {
+        HashMap<String, String> propertySourceMap = new HashMap<>();
+        propertySourceMap.put(DetectProperties.DETECT_DIAGNOSTIC_ARCHIVE_PATH.getKey(), archivePath);
+        MapPropertySource mapPropertySource = new MapPropertySource(TEST_PROPERTY_SOURCE_NAME, propertySourceMap);
+        return new PropertyConfiguration(Collections.singletonList(mapPropertySource), Collections.emptySortedMap());
+    }
+}
+


### PR DESCRIPTION
# Description

Support for writing diagnostic archive file to a custom path via `detect.diagnostic.archive.path` property.

## Changes

- Add a new property named `detect.diagnostic.archive.path` to accept a custom ouput path for diagnostic zip.
- Copying the archive file to the custom path (if specified) post the diagnostic zip creation.

IDETECT-5023

