### PR TITLE
fix antlr vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,8 @@ allprojects {
         // override to fix CVE-2026-54512, CVE-2026-54513 and keep all jackson artifacts in sync
         implementation('com.fasterxml.jackson.core:jackson-databind:2.22.0')
         implementation('com.fasterxml.jackson.core:jackson-annotations:2.22')
+        // antlr4-runtime is a transitive dep via org.tomlj:tomlj; 4.11.1 has CVE-2026-13500
+        implementation('org.antlr:antlr4-runtime:4.13.2')
         implementation 'org.freemarker:freemarker:2.3.31'
         implementation 'org.apache.httpcomponents:httpclient-osgi:4.5.14'
 


### PR DESCRIPTION
antlr is being brought in by tomlj and is vulnerable. We need to pin the version as we have the latest tomlj already.