### PR TITLE
Updated the release notes about the maven 3.9.16 support

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -24,10 +24,10 @@
 
 * Support for npm has been extended to 11.13.0 and Node.js 24.17.0.
 * Introduced a property named `detect.diagnostic.archive.path`, which enables the specification of a custom path for the diagnostic archive.
-* (IDETECT-5201) Support for maven now extends to 3.9.16.
 * Support for the following package managers have been extended:
   * RubyGems: 4.0.15
   * Gradle: 9.6.1
+  * Maven: 3.9.16
 
 ### Dependency Updates
 * Update ANTLR library to version 4.13.2.

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -24,6 +24,7 @@
 
 * Support for npm has been extended to 11.13.0 and Node.js 24.17.0.
 * Introduced a property named `detect.diagnostic.archive.path`, which enables the specification of a custom path for the diagnostic archive.
+* (IDETECT-5201) Support for maven now extends to 3.9.16.
 * Support for the following package managers have been extended:
   * RubyGems: 4.0.15
   * Gradle: 9.6.1


### PR DESCRIPTION
# Description

Detect has been verified to work correctly with Maven 3.9.16, the latest stable Maven release.

## Details

- Compatibility testing was performed against Maven 3.9.16.

- All Detect scans completed successfully.

- No code changes were required to support this version.

## Conclusion  
Detect is fully compatible with Maven 3.9.16. Documentation updated to reflect support for this version.