### PR TITLE
add package managers support section in release notes

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -24,6 +24,9 @@
 
 * Support for npm has been extended to 11.13.0 and Node.js 24.17.0.
 * Introduced a property named `detect.diagnostic.archive.path`, which enables the specification of a custom path for the diagnostic archive.
+* Support for the following package managers have been extended:
+  * RubyGems: 4.0.15
+  * Gradle: 9.6.1
 
 ### Dependency Updates
 * Update ANTLR library to version 4.13.2.


### PR DESCRIPTION
Following the pattern from 11.0 relesae - 

1. Support for Rubygems extended to 4.0.15
2. Support for Gradle extended to 9.6.1
