### PR TITLE
move to tika 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation 'org.apache.pdfbox:pdfbox:2.0.27'
 
     // autonomous
-    implementation 'org.apache.tika:tika-core:2.9.0'
+    implementation 'org.apache.tika:tika-core:3.2.2'
     implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.23.1'
 
     constraints {

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -29,3 +29,4 @@
 * Update ANTLR library to version 4.13.2.
 * Update Jackson libraries to version 2.22.0.
 * Update Java minimum version to 11.
+* Update Tika library to version 3.2.2.


### PR DESCRIPTION
With Java 11 in place we now can update to Tika's 3.x line and remove vulnerabilities.