### PR TITLE
Enable Python Integration Tests with Internal Artifactory

### DIFF
--- a/src/test/java/com/blackduck/integration/detect/battery/docker/PipTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/PipTest.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,7 +23,6 @@ import com.blackduck.integration.detector.base.DetectorType;
 import com.blackduck.integration.exception.IntegrationException;
 
 @Tag("integration")
-//@Disabled("Disabled: Dockerfiles pull from public PyPI registry — re-enable after migrating to internal artifact proxy")
 public class PipTest {
 
     private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "24.2" };

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/PipTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/PipTest.java
@@ -27,7 +27,7 @@ import com.blackduck.integration.exception.IntegrationException;
 //@Disabled("Disabled: Dockerfiles pull from public PyPI registry — re-enable after migrating to internal artifact proxy")
 public class PipTest {
 
-    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "25.2" };
+    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "24.2" };
     private static final String[] PIP_PKG_RESOURCES_VERSIONS_TO_TEST = new String[] { "23.3.1" };
     public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/PipTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/PipTest.java
@@ -24,10 +24,10 @@ import com.blackduck.integration.detector.base.DetectorType;
 import com.blackduck.integration.exception.IntegrationException;
 
 @Tag("integration")
-@Disabled("Disabled: Dockerfiles pull from public PyPI registry — re-enable after migrating to internal artifact proxy")
+//@Disabled("Disabled: Dockerfiles pull from public PyPI registry — re-enable after migrating to internal artifact proxy")
 public class PipTest {
 
-    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "24.2" };
+    private static final String[] PIP_VERSIONS_TO_TEST = new String[] { "25.2" };
     private static final String[] PIP_PKG_RESOURCES_VERSIONS_TO_TEST = new String[] { "23.3.1" };
     public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/PipenvTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/PipenvTest.java
@@ -23,7 +23,7 @@ import com.blackduck.integration.detector.base.DetectorType;
 import com.blackduck.integration.exception.IntegrationException;
 
 @Tag("integration")
-@Disabled("Disabled: Dockerfile pulls from public PyPI registry — re-enable after migrating to internal artifact proxy")
+//@Disabled("Disabled: Dockerfile pulls from public PyPI registry — re-enable after migrating to internal artifact proxy")
 public class PipenvTest {
 
     private static final String[] PIPENV_VERSIONS_TO_TEST = new String[] { "2024.0.1" };

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/PipenvTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/PipenvTest.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,7 +22,6 @@ import com.blackduck.integration.detector.base.DetectorType;
 import com.blackduck.integration.exception.IntegrationException;
 
 @Tag("integration")
-//@Disabled("Disabled: Dockerfile pulls from public PyPI registry — re-enable after migrating to internal artifact proxy")
 public class PipenvTest {
 
     private static final String[] PIPENV_VERSIONS_TO_TEST = new String[] { "2024.0.1" };

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/SetuptoolsTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/SetuptoolsTest.java
@@ -23,7 +23,7 @@ import com.blackduck.integration.detector.base.DetectorType;
 import com.blackduck.integration.exception.IntegrationException;
 
 @Tag("integration")
-@Disabled("Disabled: Dockerfile pulls from public PyPI registry — re-enable after migrating to internal artifact proxy")
+//@Disabled("Disabled: Dockerfile pulls from public PyPI registry — re-enable after migrating to internal artifact proxy")
 public class SetuptoolsTest {
     private static final String[] SETUPTOOLS_VERSIONS_TO_TEST = new String[] { "74.0.0" };
     private static final String PIP_VERSION = "24.2";

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/SetuptoolsTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/SetuptoolsTest.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,7 +22,6 @@ import com.blackduck.integration.detector.base.DetectorType;
 import com.blackduck.integration.exception.IntegrationException;
 
 @Tag("integration")
-//@Disabled("Disabled: Dockerfile pulls from public PyPI registry — re-enable after migrating to internal artifact proxy")
 public class SetuptoolsTest {
     private static final String[] SETUPTOOLS_VERSIONS_TO_TEST = new String[] { "74.0.0" };
     private static final String PIP_VERSION = "24.2";

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:8-jdk-jammy
 ARG ARTIFACTORY_URL
 ENV PIP_INDEX_URL="${ARTIFACTORY_URL}/artifactory/api/pypi/pypi-virtual/simple/"
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
-ARG PIP_VERSION="25.2"
+ARG PIP_VERSION="24.2"
 
 # Do not change SRC_DIR, value is expected by tests
 ENV SRC_DIR=/opt/project/src

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
 
 # Set up test environment
 RUN apt-get update -y
-RUN apt-get install -y git bash wget unzip
+RUN apt-get install -y git bash wget unzip build-essential python3-dev
 RUN apt-get install -y python3 python3-pip
 RUN pip install --ignore-installed "pip==${PIP_VERSION}"
 

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -22,4 +22,4 @@ RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/pip-test-project
 RUN unzip pip-test-project.zip -d /opt/project/src
 RUN mv pip-test-project/* .
 RUN rm -r pip-test-project pip-test-project.zip
-RUN pip install --verbose -r requirements.txt
+RUN pip install -r requirements.txt

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -22,4 +22,4 @@ RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/pip-test-project
 RUN unzip pip-test-project.zip -d /opt/project/src
 RUN mv pip-test-project/* .
 RUN rm -r pip-test-project pip-test-project.zip
-RUN pip install -r requirements.txt
+RUN pip install --verbose -r requirements.txt

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -1,7 +1,9 @@
-FROM openjdk:8-jdk-slim
+FROM eclipse-temurin:8-jdk
 
 ARG ARTIFACTORY_URL
-ARG PIP_VERSION="24.1.2"
+ENV PIP_INDEX_URL="${ARTIFACTORY_URL}/artifactory/api/pypi/pypi-virtual/simple/"
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ARG PIP_VERSION="25.2"
 
 # Do not change SRC_DIR, value is expected by tests
 ENV SRC_DIR=/opt/project/src
@@ -12,7 +14,7 @@ ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
 RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
-RUN pip install --upgrade "pip==${PIP_VERSION}"
+RUN pip install --ignore-installed "pip==${PIP_VERSION}"
 
 # Set up test project
 RUN mkdir -p ${SRC_DIR}

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:8-jdk
+FROM eclipse-temurin:8-jdk-jammy
 
 ARG ARTIFACTORY_URL
 ENV PIP_INDEX_URL="${ARTIFACTORY_URL}/artifactory/api/pypi/pypi-virtual/simple/"

--- a/src/test/resources/docker/Pip.dockerfile
+++ b/src/test/resources/docker/Pip.dockerfile
@@ -1,9 +1,8 @@
-FROM eclipse-temurin:8-jdk-jammy
+FROM openjdk:8-jdk-slim
 
 ARG ARTIFACTORY_URL
 ENV PIP_INDEX_URL="${ARTIFACTORY_URL}/artifactory/api/pypi/pypi-virtual/simple/"
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
-ARG PIP_VERSION="24.2"
+ARG PIP_VERSION="24.1.2"
 
 # Do not change SRC_DIR, value is expected by tests
 ENV SRC_DIR=/opt/project/src
@@ -12,9 +11,9 @@ ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
 
 # Set up test environment
 RUN apt-get update -y
-RUN apt-get install -y git bash wget unzip build-essential python3-dev
+RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
-RUN pip install --ignore-installed "pip==${PIP_VERSION}"
+RUN pip install --upgrade "pip==${PIP_VERSION}"
 
 # Set up test project
 RUN mkdir -p ${SRC_DIR}

--- a/src/test/resources/docker/Pipenv.dockerfile
+++ b/src/test/resources/docker/Pipenv.dockerfile
@@ -15,7 +15,7 @@ ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
 RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
-RUN pip install --upgrade "pipenv==${PIPENV_VERSION_VAL}"
+RUN pip install --verbose --upgrade "pipenv==${PIPENV_VERSION_VAL}"
 
 # Set up test project
 RUN mkdir -p ${SRC_DIR}

--- a/src/test/resources/docker/Pipenv.dockerfile
+++ b/src/test/resources/docker/Pipenv.dockerfile
@@ -15,7 +15,7 @@ ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
 RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
-RUN pip install --verbose --upgrade "pipenv==${PIPENV_VERSION_VAL}"
+RUN pip install --upgrade "pipenv==${PIPENV_VERSION_VAL}"
 
 # Set up test project
 RUN mkdir -p ${SRC_DIR}

--- a/src/test/resources/docker/Pipenv.dockerfile
+++ b/src/test/resources/docker/Pipenv.dockerfile
@@ -4,6 +4,7 @@ FROM openjdk:8-jdk-slim
 # conflicts with the `click` Python package's options and causes `pipenv install` to result in an error.
 ARG PIPENV_VERSION_VAL="2024.0.1"
 ARG ARTIFACTORY_URL
+ENV PIP_INDEX_URL="${ARTIFACTORY_URL}/artifactory/api/pypi/pypi-virtual/simple/"
 
 # Do not change SRC_DIR, value is expected by tests
 ENV SRC_DIR=/opt/project/src

--- a/src/test/resources/docker/PythonHybrid.dockerfile
+++ b/src/test/resources/docker/PythonHybrid.dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
 RUN python3 -m pip install -U "pip==${PIP_VERSION}"
-RUN pip install --upgrade "uv==${UV_VERSION}"
+RUN pip install --verbose --upgrade "uv==${UV_VERSION}"
 RUN pip install --upgrade "setuptools==${SETUPTOOLS_VERSION}"
 
 # Set up test project

--- a/src/test/resources/docker/PythonHybrid.dockerfile
+++ b/src/test/resources/docker/PythonHybrid.dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
 RUN python3 -m pip install -U "pip==${PIP_VERSION}"
-RUN pip install --verbose --upgrade "uv==${UV_VERSION}"
+RUN pip install --upgrade "uv==${UV_VERSION}"
 RUN pip install --upgrade "setuptools==${SETUPTOOLS_VERSION}"
 
 # Set up test project

--- a/src/test/resources/docker/PythonHybrid.dockerfile
+++ b/src/test/resources/docker/PythonHybrid.dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:8-jdk
+FROM eclipse-temurin:8-jdk
 
 ARG ARTIFACTORY_URL
+ENV PIP_INDEX_URL="${ARTIFACTORY_URL}/artifactory/api/pypi/pypi-virtual/simple/"
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ARG UV_VERSION="0.8.15"
 ARG SETUPTOOLS_VERSION="80.9.0"
 ARG PIP_VERSION="25.2"
@@ -14,7 +16,7 @@ ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
 RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
-RUN python3 -m pip install -U "pip==${PIP_VERSION}"
+RUN pip install --ignore-installed "pip==${PIP_VERSION}"
 RUN pip install --upgrade "uv==${UV_VERSION}"
 RUN pip install --upgrade "setuptools==${SETUPTOOLS_VERSION}"
 

--- a/src/test/resources/docker/PythonHybrid.dockerfile
+++ b/src/test/resources/docker/PythonHybrid.dockerfile
@@ -1,8 +1,7 @@
-FROM eclipse-temurin:8-jdk
+FROM openjdk:8-jdk
 
 ARG ARTIFACTORY_URL
 ENV PIP_INDEX_URL="${ARTIFACTORY_URL}/artifactory/api/pypi/pypi-virtual/simple/"
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ARG UV_VERSION="0.8.15"
 ARG SETUPTOOLS_VERSION="80.9.0"
 ARG PIP_VERSION="25.2"
@@ -16,7 +15,7 @@ ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
 RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
-RUN pip install --ignore-installed "pip==${PIP_VERSION}"
+RUN python3 -m pip install -U "pip==${PIP_VERSION}"
 RUN pip install --upgrade "uv==${UV_VERSION}"
 RUN pip install --upgrade "setuptools==${SETUPTOOLS_VERSION}"
 

--- a/src/test/resources/docker/Setuptools.dockerfile
+++ b/src/test/resources/docker/Setuptools.dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
 RUN pip install --upgrade "pip==${PIP_VERSION}"
-RUN pip install --verbose --upgrade "setuptools==${SETUPTOOLS_VERSION}"
+RUN pip install --upgrade "setuptools==${SETUPTOOLS_VERSION}"
 
 # Set up test project
 RUN mkdir -p ${SRC_DIR}

--- a/src/test/resources/docker/Setuptools.dockerfile
+++ b/src/test/resources/docker/Setuptools.dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y
 RUN apt-get install -y git bash wget unzip
 RUN apt-get install -y python3 python3-pip
 RUN pip install --upgrade "pip==${PIP_VERSION}"
-RUN pip install --upgrade "setuptools==${SETUPTOOLS_VERSION}"
+RUN pip install --verbose --upgrade "setuptools==${SETUPTOOLS_VERSION}"
 
 # Set up test project
 RUN mkdir -p ${SRC_DIR}

--- a/src/test/resources/docker/Setuptools.dockerfile
+++ b/src/test/resources/docker/Setuptools.dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-jdk-slim
 
 ARG ARTIFACTORY_URL
+ENV PIP_INDEX_URL="${ARTIFACTORY_URL}/artifactory/api/pypi/pypi-virtual/simple/"
 ARG PIP_VERSION="24.2"
 ARG SETUPTOOLS_VERSION="74.0.0"
 


### PR DESCRIPTION
**JIRA Ticker**

IDETECT-5173

**Description**

This pull request enables three Python integration tests that were fetching from public PyPI, posing a supply chain security risk.                                                                                                                                                     
                                                                                                                                                                                                        `PipTest`, `PipenvTest`, and `SetuptoolsTest` were disabled earlier because Dockerfiles installed pip packages directly from `pypi.org`
                                                                                                                                                                                                         The fix adds `ENV PIP_INDEX_URL` to `Pip.dockerfile`, `Pipenv.dockerfile`, `Setuptools.dockerfile` and `PythonHybrid.dockerfile` to route all pip installs through the internal artifactory PyPI index.                                            

**Note:** `packaging==24.1` (required by pip-test-project's `requirements.txt`) was missing from artifactory and has been requested, and uploaded subsequently.

