### PR TITLE
Remove unsupported --all-extras flag from uv tree command

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
@@ -25,7 +25,6 @@ public class UVBuildExtractor {
 
     private static final String TREE_COMMAND = "tree";
     private static final String NO_DEDUPE_FLAG = "--no-dedupe";
-    private static final String ALL_EXTRAS_FLAG = "--all-extras";
     private static final String ALL_GROUPS_FLAG = "--all-groups";
     private static final String NO_GROUP_FLAG = "--no-group";
     private static final String ONLY_GROUP_FLAG = "--only-group";
@@ -102,7 +101,6 @@ public class UVBuildExtractor {
     }
 
     private void addDefaultGroupArguments(List<String> arguments, Set<String> excludedGroups) {
-        arguments.add(ALL_EXTRAS_FLAG);
         arguments.add(ALL_GROUPS_FLAG);
 
         for (String group : excludedGroups) {

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/functional/UVDetectableFunctionalTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/functional/UVDetectableFunctionalTest.java
@@ -77,7 +77,7 @@ public class UVDetectableFunctionalTest extends DetectableFunctionalTest {
                 "│   │   │   │   │   ├── aiohttp v3.12.15 (*)\n" +
                 "│   │   │   │   │   ├── cryptography v44.0.3 (*)");
 
-        addExecutableOutput(uvTreeDependencyOutput, new File("uv").getAbsolutePath(), "tree", "--no-dedupe", "--all-extras", "--all-groups");
+        addExecutableOutput(uvTreeDependencyOutput, new File("uv").getAbsolutePath(), "tree", "--no-dedupe", "--all-groups");
     }
 
     @NotNull

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/functional/UVExcludeDevGroupsFunctionalTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/functional/UVExcludeDevGroupsFunctionalTest.java
@@ -66,7 +66,7 @@ public class UVExcludeDevGroupsFunctionalTest extends DetectableFunctionalTest {
                 "        └── typing-extensions v4.9.0");
 
         // Note: with --no-group dev, pytest and mypy are excluded from output
-        addExecutableOutput(uvTreeDependencyOutput, new File("uv").getAbsolutePath(), "tree", "--no-dedupe", "--all-extras", "--all-groups", "--no-group", "dev");
+        addExecutableOutput(uvTreeDependencyOutput, new File("uv").getAbsolutePath(), "tree", "--no-dedupe", "--all-groups", "--no-group", "dev");
     }
 
     @NotNull

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVBuildExtractorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVBuildExtractorTest.java
@@ -81,7 +81,6 @@ class UVBuildExtractorTest {
         List<String> arguments = captor.getValue().getCommandWithArguments();
         assertTrue(arguments.contains("tree"));
         assertTrue(arguments.contains("--no-dedupe"));
-        assertTrue(arguments.contains("--all-extras"));
         assertTrue(arguments.contains("--all-groups"));
     }
 
@@ -105,7 +104,6 @@ class UVBuildExtractorTest {
         List<String> arguments = captor.getValue().getCommandWithArguments();
         assertTrue(arguments.contains("tree"));
         assertTrue(arguments.contains("--no-dedupe"));
-        assertTrue(arguments.contains("--all-extras"));
         assertTrue(arguments.contains("--all-groups"));
         assertTrue(arguments.contains("--no-group"));
 
@@ -134,7 +132,6 @@ class UVBuildExtractorTest {
 
         List<String> arguments = captor.getValue().getCommandWithArguments();
 
-        assertTrue(arguments.contains("--all-extras"));
         assertTrue(arguments.contains("--all-groups"));
         long noGroupCount = arguments.stream().filter(arg -> arg.equals("--no-group")).count();
         assertEquals(0, noGroupCount);
@@ -157,7 +154,6 @@ class UVBuildExtractorTest {
 
         List<String> arguments = captor.getValue().getCommandWithArguments();
 
-        assertTrue(arguments.contains("--all-extras"));
         assertTrue(arguments.contains("--all-groups"));
         long noGroupCount = arguments.stream().filter(arg -> arg.equals("--no-group")).count();
         assertEquals(1, noGroupCount);
@@ -186,8 +182,7 @@ class UVBuildExtractorTest {
         assertTrue(arguments.contains("tree"));
         assertTrue(arguments.contains("--no-dedupe"));
 
-        // --all-extras and --all-groups should NOT be present when onlyGroups is set
-        assertTrue(!arguments.contains("--all-extras"), "Expected --all-extras to be absent when onlyGroups is set");
+        // --all-groups should NOT be present when onlyGroups is set
         assertTrue(!arguments.contains("--all-groups"), "Expected --all-groups to be absent when onlyGroups is set");
 
         // --only-group flags should be present for each group
@@ -223,7 +218,6 @@ class UVBuildExtractorTest {
 
         List<String> arguments = captor.getValue().getCommandWithArguments();
 
-        assertTrue(!arguments.contains("--all-extras"));
         assertTrue(!arguments.contains("--all-groups"));
         long onlyGroupCount = arguments.stream().filter(arg -> arg.equals("--only-group")).count();
         assertEquals(1, onlyGroupCount);
@@ -251,8 +245,7 @@ class UVBuildExtractorTest {
 
         List<String> arguments = captor.getValue().getCommandWithArguments();
 
-        // --all-extras and --all-groups should NOT be present (onlyGroups path)
-        assertTrue(!arguments.contains("--all-extras"));
+        // --all-groups should NOT be present (onlyGroups path)
         assertTrue(!arguments.contains("--all-groups"));
 
         // "dev" should be excluded — only "lint" should remain as --only-group


### PR DESCRIPTION
# Description

Remove `--all-extras` flag from uv tree command

`--all-extras` is not supported by `uv tree` (only valid for `uv sync`), so it was removed. Updated all related tests to reflect this change.
