### PR TITLE
Enhancements around custom path support for diagnostics archive 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.0.0-SIGQA11-abyreddy.IDETECT-5231-enhancements'
+version = '12.0.0-SIGQA12-abyreddy.IDETECT-5231-enhancements-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.0.0-SIGQA11-SNAPSHOT'
+version = '12.0.0-SIGQA11-abyreddy.IDETECT-5231-enhancements'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -21,6 +21,7 @@
 ### New features
 
 * Introduced a property named `detect.diagnostic.archive.path`, which enables the specification of a custom path for the diagnostic archive.
+* Renamed `detect.quack.patch.output` property to `detect.quack.patch.output.path` for improved clarity.
 * Support for the following package managers have been extended:
   * RubyGems: 4.0.15
   * Gradle: 9.6.1

--- a/documentation/src/main/markdown/troubleshooting/diagnosticmode.md
+++ b/documentation/src/main/markdown/troubleshooting/diagnosticmode.md
@@ -29,7 +29,7 @@ After running [detect_product_short] in diagnostic mode, log messages similar to
 2019-03-29 09:32:03 INFO  [main] --- Diagnostic mode has completed.
 ```
 
-By default, the diagnostic zip is created in the runs output directory. You can specify a custom path for the diagnostic archive using the `detect.diagnostic.archive.path` property.
+By default, the diagnostic zip is created in the runs output directory. You can specify a custom path for the diagnostic archive using the `detect.diagnostic.archive.path` property. An original copy of the diagnostics archive remains in the runs directory as a backup.
 
 
 To conserve disk space, be sure to disable diagnostic mode once it is no longer needed.

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -685,7 +685,7 @@ public class DetectConfigurationFactory {
     }
 
     public String getQuackPatchOutputDirectory(DirectoryManager directoryManager) {
-        String quackPatchOutput = detectConfiguration.getValue(DetectProperties.DETECT_QUACK_PATCH_OUTPUT);
+        String quackPatchOutput = detectConfiguration.getValue(DetectProperties.DETECT_QUACK_PATCH_OUTPUT_PATH);
         if (Objects.isNull(quackPatchOutput) || quackPatchOutput.isEmpty()) {
             return directoryManager.getScanOutputDirectory().getAbsolutePath();
         }

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -773,7 +773,7 @@ public class DetectProperties {
         StringProperty.newBuilder("detect.diagnostic.archive.path", "")
             .setInfo("Diagnostic Archive Output Path", DetectPropertyFromVersion.VERSION_12_0_0)
             .setHelp(
-                "Custom output path for diagnostic archive. A file named detect-run-<runId>.zip will be created under the specified path.",
+                "Custom output path for diagnostic archive. A file named detect-run-<runId>.zip will be created under the specified path. An original copy of the diagnostics archive remains in the runs directory as a backup.",
                 "See the following for more <xref href=\"https://docs.blackduck.com/r/detect/latest/black%2Dduck%2Ddetect/detect%2Ddiagnostic%2Dmode%2Ehtml%5C\" scope=\"external\" format=\"html\" target=\"_blank\">Diagnostic Mode information.</xref>")
             .setGroups(DetectGroup.DEBUG, DetectGroup.GLOBAL)
             .build();
@@ -1155,15 +1155,14 @@ public class DetectProperties {
                     .setGroups(DetectGroup.QUACKPATCH)
                     .build();
                         
-    public static final StringProperty DETECT_QUACK_PATCH_OUTPUT =
-            StringProperty.newBuilder("detect.quack.patch.output", "")
+    public static final StringProperty DETECT_QUACK_PATCH_OUTPUT_PATH =
+            StringProperty.newBuilder("detect.quack.patch.output.path", "")
                     .setInfo("Quack Patch Output Directory", DetectPropertyFromVersion.VERSION_11_4_0)
                     .setHelp(
                             "Specifies the output directory for Quack Patch results.",
                             "If not set, the Quack Patch results are placed in a 'quack-patch' subdirectory under scan output directory."
                     )
                     .setGroups(DetectGroup.QUACKPATCH)
-                    .setDeprecated("This property is deprecated and will be renamed to 'detect.quack.patch.output.path' in Detect release 12.0.", new ProductMajorVersion(12))
                     .build();
 
     public static final StringProperty DETECT_LLM_API_KEY =

--- a/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/diagnostic/DiagnosticSystem.java
@@ -2,6 +2,7 @@ package com.blackduck.integration.detect.workflow.diagnostic;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -128,7 +129,9 @@ public class DiagnosticSystem {
         // If detect.diagnostic.archive.path is specified and is not empty, then copy diagnostic zip to that path.
         if (zipCreated && !detectDiagnosticOutputPath.isEmpty()) {
             copyDiagnosticArchiveToCustomPath("detect-run-" + detectRunId.getRunId() + ".zip", detectDiagnosticOutputPath);
-        } else {
+        }
+
+        if (!zipCreated) {
             logger.error("Diagnostic mode failed to create zip. Cleanup will not occur.");
         }
         logger.info("Diagnostic mode has completed.");
@@ -143,7 +146,7 @@ public class DiagnosticSystem {
     private boolean createZip() {
         // If quack patch is enabled, then add quack patch output directory to the zip
         if (propertyConfiguration.getValueOrDefault(DetectProperties.DETECT_QUACK_PATCH_ENABLED)) {
-            String quackPatchOutputDirPath = propertyConfiguration.getValueOrDefault(DetectProperties.DETECT_QUACK_PATCH_OUTPUT);
+            String quackPatchOutputDirPath = propertyConfiguration.getValueOrDefault(DetectProperties.DETECT_QUACK_PATCH_OUTPUT_PATH);
             // If quack patch output path is customized, then explicitly include it in the diagnostic zip. Otherwise, default behaviour will automatically pack it.
             if (!quackPatchOutputDirPath.isEmpty()) {
                 quackPatchOutputDirPath = quackPatchOutputDirPath.trim() + File.separator + QUACKPATCH_SUBDIRECTORY_NAME;
@@ -169,8 +172,10 @@ public class DiagnosticSystem {
             File destinationFile = new File(detectDiagnosticOutputPath + File.separator + diagnosticArchiveName);
             FileUtils.copyFile(diagnosticZipFile, destinationFile);
             logger.info("Diagnostic zip file copied to {}.", destinationFile.getAbsolutePath());
+        } catch (AccessDeniedException e) {
+            logger.error("Access denied when trying to copy diagnostic zip file to a custom path at {}. Error: {}. Please check the directory permissions.", detectDiagnosticOutputPath, e.getMessage());
         } catch (IOException e) {
-            logger.error("Failed to copy diagnostic zip file to a custom path at {}. Error: {}", detectDiagnosticOutputPath, e.getMessage());
+            logger.error("Failed to copy diagnostic zip file to a custom path at {}. Error: {}. Please check the directory permissions.", detectDiagnosticOutputPath, e.getMessage());
         }
     }
 }

--- a/src/test/java/com/blackduck/integration/detect/workflow/report/DetectorToolTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/report/DetectorToolTest.java
@@ -79,13 +79,13 @@ class DetectorToolTest {
         reportsField.set(toolResult, reports);
 
        
-        DetectConfigurationFactory detectConfigurationFactory = DetectConfigurationFactoryTestUtils.factoryOf(Pair.of(DetectProperties.DETECT_QUACK_PATCH_OUTPUT, tempDir.toString()));
+        DetectConfigurationFactory detectConfigurationFactory = DetectConfigurationFactoryTestUtils.factoryOf(Pair.of(DetectProperties.DETECT_QUACK_PATCH_OUTPUT_PATH, tempDir.toString()));
 
         new DetectorTool(null, null, null, null, null, null, null, detectConfigurationFactory)
             .saveExtractedDetectorsAndTheirRelevantFilePaths(toolResult, directoryManager);
 
         File outputFile = new File(
-            new File(detectConfigurationFactory.getDetectPropertyConfiguration().getValue(DetectProperties.DETECT_QUACK_PATCH_OUTPUT), QUACKPATCH_SUBDIRECTORY_NAME),
+            new File(detectConfigurationFactory.getDetectPropertyConfiguration().getValue(DetectProperties.DETECT_QUACK_PATCH_OUTPUT_PATH), QUACKPATCH_SUBDIRECTORY_NAME),
             INVOKED_DETECTORS_AND_RELEVANT_FILES_JSON
         );
         assertTrue(outputFile.exists());


### PR DESCRIPTION
# Description

## changes,
- Fix diagnostic zip report failure log message
- Doc changes associated with support custom location for diagnostic archive path
- Renamed `detect.quack.patch.output` property to `detect.quack.patch.output.path` 

# Github Issues

IDETECT-5175, IDETECT-5231, IDETECT-5229
