### PR TITLE
fix(gradle): restore dependency detection for phantom subprojects with root-declared dependencies

### DIFF
--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -161,8 +161,16 @@ gradle.projectsEvaluated {
 
         def shouldIncludeProject = projectMatchesFilters && (!selectedConfigs.isEmpty() || isPhantom)
 
-        // Phantoms and excluded projects get an empty config set to avoid unnecessary resolution
-        if (isPhantom || !projectMatchesFilters) {
+        // Always explicitly set configurations to prevent the null-means-all-configs Gradle fallback.
+        // - Excluded projects: [] as Set (don't scan them)
+        // - Any project where the configuration filter matched nothing: [] as Set
+        //   This handles phantom container projects that inherit tool plugin configs (e.g. detekt,
+        //   ktlint) via subprojects{} but have no matching runtime configs. Without this, null
+        //   would be left on the task, causing Gradle to dump ALL configurations into the report.
+        // - Any project (phantom or real) where the filter DID match configs: use those configs.
+        //   Phantom subprojects can have real dependencies declared via subprojects{} or
+        //   project(':name'){} blocks in the root build file — these must not be wiped.
+        if (!projectMatchesFilters || selectedConfigs.isEmpty()) {
             dependenciesTask.configurations = [] as Set
         } else {
             dependenciesTask.configurations = selectedConfigs as Set


### PR DESCRIPTION
**Problem**
Detect 11.5.0 reports 0 components for Gradle projects where submodules have no own build.gradle and all their dependencies are declared from the root `build.gradle` via `subprojects {}` or `project(':name') {}` blocks. Detect 11.4.2 and earlier reported all components correctly.

**Root Cause**
A previous fix (introduced to prevent tool plugin configurations such as `detekt` and `ktlint` from leaking into scan results for phantom subprojects) used `isPhantom` as the gate condition to force `dependenciesTask.configurations = [] as Set`.
This was correct for the original scenario — a phantom container where no matching configurations exist after filtering. However, it was too broad: in certain cases phantom subproject can also have real, scannable configurations registered on it from the root `build.gradle`. In that case `selectedConfigs` is non-empty, but the `isPhantom` guard was still firing and wiping the configurations — causing the dependencies task to output no configurations and Detect to upload 0 components.

**The key distinction:**
`isPhantom` — tells you about file system structure (no build file in the directory)
`selectedConfigs.isEmpty()` — tells you whether any scannable configurations actually exist on the project

These are not the same thing. The original fix treated them as equivalent, which held true for the original scenario but breaks when a phantom has real deps declared from root.

Note - This is not a usual Gradle setup. Gradle offically discourages this - [Avoid cross-project configuration](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins_vs_cross_configuration)