### PR TITLE
Fix(UV):  returning empty sbom when only and excluded groups fully overlap

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
@@ -1,5 +1,9 @@
 package com.blackduck.integration.detectable.detectables.uv.buildexe;
 
+import com.blackduck.integration.bdio.graph.BasicDependencyGraph;
+import com.blackduck.integration.bdio.graph.DependencyGraph;
+import com.blackduck.integration.bdio.model.Forge;
+import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.detectable.ExecutableTarget;
 import com.blackduck.integration.detectable.ExecutableUtils;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
@@ -42,9 +46,27 @@ public class UVBuildExtractor {
 
     public Extraction extract(ExecutableTarget uvExe, UVDetectorOptions uvDetectorOptions, UVTomlParser uvTomlParser) throws ExecutableRunnerException {
         try {
-            List<String> arguments = buildTreeCommandArguments(uvDetectorOptions);
+            Optional<List<String>> arguments = buildTreeCommandArguments(uvDetectorOptions);
 
-            ExecutableOutput executableOutput = executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(sourceDirectory, uvExe, arguments));
+            // If no valid groups remain after exclusion, return an empty BOM (a CodeLocation with zero dependencies)
+            // rather than running "uv tree --no-dedupe" which would incorrectly return ALL dependencies.
+            if (!arguments.isPresent()) {
+                logger.warn(
+                        "All dependency groups specified in 'detect.uv.dependency.groups.only' are also present in "
+                        + "'detect.uv.dependency.groups.excluded'. No dependency groups remain to scan. Returning an empty BOM."
+                );
+                DependencyGraph emptyGraph = new BasicDependencyGraph();
+                Optional<NameVersion> projectNameVersion = uvTomlParser.parseNameVersion();
+                CodeLocation emptyCodeLocation = projectNameVersion
+                        .map(nv -> new CodeLocation(emptyGraph, ExternalId.FACTORY.createNameVersionExternalId(Forge.PYPI, nv.getName(), nv.getVersion())))
+                        .orElse(new CodeLocation(emptyGraph));
+                return new Extraction.Builder()
+                        .success(emptyCodeLocation)
+                        .nameVersionIfPresent(projectNameVersion)
+                        .build();
+            }
+
+            ExecutableOutput executableOutput = executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(sourceDirectory, uvExe, arguments.get()));
             List<String> uvTreeOutput = executableOutput.getStandardOutputAsList();
 
             List<CodeLocation> codeLocations = uvTreeDependencyGraphTransformer.transform(uvTreeOutput, uvDetectorOptions);
@@ -60,7 +82,7 @@ public class UVBuildExtractor {
         }
     }
 
-    private List<String> buildTreeCommandArguments(UVDetectorOptions uvDetectorOptions) {
+    private Optional<List<String>> buildTreeCommandArguments(UVDetectorOptions uvDetectorOptions) {
         List<String> arguments = new ArrayList<>();
         arguments.add(TREE_COMMAND);
         arguments.add(NO_DEDUPE_FLAG);
@@ -69,15 +91,20 @@ public class UVBuildExtractor {
         Set<String> excludedGroups = uvDetectorOptions.getExcludedDependencyGroups();
 
         if (!onlyGroups.isEmpty()) {
-            addOnlyGroupArguments(arguments, onlyGroups, excludedGroups);
+            boolean hasEffectiveGroups = addOnlyGroupArguments(arguments, onlyGroups, excludedGroups);
+            if (!hasEffectiveGroups) {
+                return Optional.empty();
+            }
         } else {
             addDefaultGroupArguments(arguments, excludedGroups);
         }
 
-        return arguments;
+        return Optional.of(arguments);
     }
 
-    private void addOnlyGroupArguments(List<String> arguments, Set<String> onlyGroups, Set<String> excludedGroups) {
+    // Computes effectiveOnlyGroups = onlyGroups minus excludedGroups.
+    // Returns false if no groups remain (signals caller to produce an empty BOM).
+    private boolean addOnlyGroupArguments(List<String> arguments, Set<String> onlyGroups, Set<String> excludedGroups) {
         Set<String> conflictingGroups = onlyGroups.stream()
                 .filter(excludedGroups::contains)
                 .collect(Collectors.toSet());
@@ -94,10 +121,16 @@ public class UVBuildExtractor {
                 .filter(group -> !excludedGroups.contains(group))
                 .collect(Collectors.toSet());
 
+        if (effectiveOnlyGroups.isEmpty()) {
+            return false;
+        }
+
         for (String group : effectiveOnlyGroups) {
             arguments.add(ONLY_GROUP_FLAG);
             arguments.add(group);
         }
+
+        return true;
     }
 
     private void addDefaultGroupArguments(List<String> arguments, Set<String> excludedGroups) {

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVBuildExtractorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVBuildExtractorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -256,7 +257,7 @@ class UVBuildExtractorTest {
     }
 
     @Test
-    void extractAllOnlyGroupsExcludedResultsInNoOnlyGroupFlags() throws Exception {
+    void extractAllOnlyGroupsExcludedResultsInEmptyBom() throws Exception {
         UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
         // All only-groups are also excluded
         UVDetectorOptions options = new UVDetectorOptions(
@@ -269,14 +270,13 @@ class UVBuildExtractorTest {
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
-        verify(executableRunner).executeSuccessfully(captor.capture());
+        // uv tree should never be executed since all groups are excluded
+        verify(executableRunner, never()).executeSuccessfully(any(Executable.class));
 
-        List<String> arguments = captor.getValue().getCommandWithArguments();
-
-        // No --only-group flags since all were excluded
-        long onlyGroupCount = arguments.stream().filter(arg -> arg.equals("--only-group")).count();
-        assertEquals(0, onlyGroupCount, "No --only-group flags should remain when all are excluded");
+        // BOM should exist but contain zero dependencies
+        assertEquals(1, extraction.getCodeLocations().size(), "Expected one code location for empty BOM");
+        assertEquals(0, extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().size(),
+                "Expected zero dependencies when all only-groups are excluded");
     }
 
 


### PR DESCRIPTION

# Description

When `detect.uv.dependency.groups.only` and `detect.uv.dependency.groups.excluded` contained the same values, the effective group list became empty but  the detector would ignore both settings and scan everything. 

After the fix, It instead produces an empty BOM, since the user explicitly asked to scan only those groups but also excluded all of them — leaving nothing to scan.