### PR TITLE
Update to DOCKER_INSPECTOR_LATEST_12

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/docker/DockerDetectable.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/docker/DockerDetectable.java
@@ -83,6 +83,7 @@ public class DockerDetectable extends Detectable {
         if (dockerInspectorInfo == null) {
             return new InspectorNotFoundDetectableResult("docker");
         } else {
+            logger.warn("WARNING: Docker Inspector has been deprecated and will be removed in 13.0.0 release.");
             passedResultBuilder.foundInspector(dockerInspectorInfo.getDockerInspectorJar());
         }
         return passedResultBuilder.build();

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -15,6 +15,7 @@
 	* eu.scass.blackduck.com - 34.54.38.252
 	
 * **Deprecation of Java 8 support** - In alignment with EU Cyber Resilience Act (CRA) requirements and compliance timelines, Java 8 support will be deprecated in the anticipated 2026 Q3 Detect 12.0.0 release.
+* **Deprecation of Docker Inspector** - Docker Inspector has been deprecated and will be removed in 13.0.0 release.
 
 ## Version 11.5.0
 

--- a/src/main/java/com/blackduck/integration/detect/workflow/ArtifactoryConstants.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/ArtifactoryConstants.java
@@ -10,8 +10,8 @@ public class ArtifactoryConstants {
     public static final String NUGET_INSPECTOR_WINDOWS_PROPERTY = "NUGET_INSPECTOR_WINDOWS_LATEST_1";
 
     public static final String DOCKER_INSPECTOR_REPO = "bds-integrations-release/com/blackduck/integration/detect-docker-inspector";
-    public static final String DOCKER_INSPECTOR_PROPERTY = "DOCKER_INSPECTOR_LATEST_11";
-    public static final String DOCKER_INSPECTOR_AIR_GAP_PROPERTY = "DOCKER_INSPECTOR_AIR_GAP_LATEST_11";
+    public static final String DOCKER_INSPECTOR_PROPERTY = "DOCKER_INSPECTOR_LATEST_12";
+    public static final String DOCKER_INSPECTOR_AIR_GAP_PROPERTY = "DOCKER_INSPECTOR_AIR_GAP_LATEST_12";
     public static final String DOCKER_INSPECTOR_VERSION_OVERRIDE =
         "/" + ArtifactoryConstants.VERSION_PLACEHOLDER + "/detect-docker-inspector-" + ArtifactoryConstants.VERSION_PLACEHOLDER + ".jar";
 


### PR DESCRIPTION
Docker Inspector 12 brings in breaking changes so we have introduced a new artifactory property, DOCKER_INSPECTOR_LATEST_12, for Detect versions to use going forward. 

