### PR TITLE
npm workspace filtering when no dependencies are discovered

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -76,8 +76,7 @@ public class NpmLockfileGraphTransformer {
         //   Because the workspace-filter strips those packages from combinedPackageJson before
         //   NpmProject is built, every declared-dep list ends up empty even though a valid
         //   package.json existed. Falling through to the "add all" fallback in this case causes
-        //   every lock-file entry (lodash, chalk, nanoid, …) to be promoted to the root —
-        //   exactly the bug observed in projects like ui-workspace.
+        //   every lock-file entry to be promoted to the root.
         //
         // The fix: use the explicit-declaration path whenever a package.json is present
         // (workspaces != null), even if every declared list is empty. That correctly produces

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -24,7 +24,11 @@ public class NpmLockfileGraphTransformer {
     private final EnumListFilter<NpmDependencyType> npmDependencyTypeFilter;
 
     public NpmLockfileGraphTransformer(EnumListFilter<NpmDependencyType> npmDependencyTypeFilter) {
-        this.npmDependencyTypeFilter = npmDependencyTypeFilter;
+        // Treat null as "include all types" so callers that only care about workspace handling
+        // can pass null without risking NPEs when shouldInclude/shouldExclude are called.
+        this.npmDependencyTypeFilter = npmDependencyTypeFilter != null
+            ? npmDependencyTypeFilter
+            : EnumListFilter.excludeNone();
     }
 
     public DependencyGraph transform(PackageLock packageLock, NpmProject project, List<NameVersion> externalDependencies, List<String> workspaces, Map<String, String> aliasMapping) {
@@ -39,7 +43,7 @@ public class NpmLockfileGraphTransformer {
             createGraphFromResolvedDependencies(project, externalDependencies, workspaces, dependencyGraph, aliasMapping);
 
             //Then we will add relationships between the project (root) and the graph
-            addRootDependencies(project, dependencyGraph, externalDependencies, aliasMapping);
+            addRootDependencies(project, dependencyGraph, externalDependencies, workspaces, aliasMapping);
 
             logger.debug(String.format("Found %d root dependencies.", dependencyGraph.getRootDependencies().size()));
         } else {
@@ -55,11 +59,31 @@ public class NpmLockfileGraphTransformer {
         }
     }
 
-    private void addRootDependencies(NpmProject project, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies, Map<String, String> aliasMapping) {
+    private void addRootDependencies(NpmProject project, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies, List<String> workspaces, Map<String, String> aliasMapping) {
         boolean atLeastOneRequired = !project.getDeclaredDependencies().isEmpty()
             || !project.getDeclaredDevDependencies().isEmpty()
             || !project.getDeclaredPeerDependencies().isEmpty();
-        if (atLeastOneRequired) {
+
+        // Two cases must be distinguished here:
+        //
+        // Case 1 — No package.json was provided (workspaces == null):
+        //   We have only a lock file with no package.json to tell us which entries are "declared".
+        //   The previous fallback (add all resolved entries to root) is the correct behaviour here.
+        //
+        // Case 2 — A package.json WAS provided (workspaces != null), but the declared-dep lists
+        //   are all empty. This happens when the root package.json has no direct dependencies of
+        //   its own AND all workspace packages were excluded by detect.npm.excluded.workspaces.
+        //   Because the workspace-filter strips those packages from combinedPackageJson before
+        //   NpmProject is built, every declared-dep list ends up empty even though a valid
+        //   package.json existed. Falling through to the "add all" fallback in this case causes
+        //   every lock-file entry (lodash, chalk, nanoid, …) to be promoted to the root —
+        //   exactly the bug observed in projects like ui-workspace.
+        //
+        // The fix: use the explicit-declaration path whenever a package.json is present
+        // (workspaces != null), even if every declared list is empty. That correctly produces
+        // zero root dependencies when the root declares nothing and all workspaces are filtered.
+        // The "add all" fallback is preserved only for the true no-package.json case.
+        if (atLeastOneRequired || workspaces != null) {
             addRootDependencies(project.getResolvedDependencies(), project.getDeclaredDependencies(), dependencyGraph, externalDependencies, aliasMapping);
             if (npmDependencyTypeFilter.shouldInclude(NpmDependencyType.DEV)) {
                 addRootDependencies(project.getResolvedDependencies(), project.getDeclaredDevDependencies(), dependencyGraph, externalDependencies, aliasMapping);
@@ -71,6 +95,7 @@ public class NpmLockfileGraphTransformer {
                 addRootDependencies(project.getResolvedDependencies(), project.getDeclaredOptionalDependencies(), dependencyGraph, externalDependencies, aliasMapping);
             }
         } else {
+            // No package.json provided — fall back to treating all resolved lock-file entries as root deps.
             project.getResolvedDependencies()
                 .stream()
                 .filter(this::shouldIncludeDependency)

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParserTest.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detectable.detectables.npm.cli.parse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWorkspaceFilterTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWorkspaceFilterTest.java
@@ -109,7 +109,50 @@ public class NpmWorkspaceFilterTest {
         assertFalse(lodashAtRoot, "lodash should NOT be a root dependency when all workspaces are ignored");
     }
 
+    // Lock file that pairs with NO_ROOT_DEPS_PACKAGE_JSON: same two workspace packages as the
+    // standard fixture, but the root declares zero direct dependencies.
+    private static final String NO_ROOT_DEPS_LOCKFILE =
+        FunctionalTestFiles.asString("/npm/workspace-filter-test/no-root-deps-package-lock.json");
+
+    // Root package.json that declares workspaces but no direct dependencies of its own.
+    // Mirrors the structure of a real project like ui-workspace.
+    private static final String NO_ROOT_DEPS_PACKAGE_JSON =
+        "{\n" +
+        "  \"name\": \"my-project\",\n" +
+        "  \"version\": \"1.0.0\",\n" +
+        "  \"workspaces\": [\"packages/*\"]\n" +
+        "}";
+
+    @Test
+    public void allWorkspacesExcludedWithNoRootDepsProducesEmptyGraph() throws IOException {
+        // Regression test for the case where:
+        //   1. The root package.json has no direct dependencies (only workspaces defined).
+        //   2. All workspaces are excluded via detect.npm.excluded.workspaces=packages/*.
+        //
+        // Before the fix, the lack of declared deps caused addRootDependencies() to fall through
+        // to its "no package.json" fallback, which promoted every lock-file entry (express, lodash,
+        // and even the workspace path entries) to root. The graph should be empty.
+        NpmLockfileOptions options = new NpmLockfileOptions(
+            EnumListFilter.excludeNone(),
+            Arrays.asList("packages/*"),
+            Collections.emptyList()
+        );
+        NpmPackagerResult result = buildResultWithPackageJsonAndLockfile(options, NO_ROOT_DEPS_PACKAGE_JSON, NO_ROOT_DEPS_LOCKFILE);
+        DependencyGraph graph = result.getCodeLocation().getDependencyGraph();
+
+        assertTrue(graph.getRootDependencies().isEmpty(),
+            "Graph should have no root dependencies when root declares none and all workspaces are excluded");
+    }
+
     private NpmPackagerResult buildResult(NpmLockfileOptions options) throws IOException {
+        return buildResultWithPackageJson(options, PACKAGE_JSON);
+    }
+
+    private NpmPackagerResult buildResultWithPackageJson(NpmLockfileOptions options, String packageJsonText) throws IOException {
+        return buildResultWithPackageJsonAndLockfile(options, packageJsonText, LOCKFILE);
+    }
+
+    private NpmPackagerResult buildResultWithPackageJsonAndLockfile(NpmLockfileOptions options, String packageJsonText, String lockfileText) throws IOException {
         String rootJsonPath = FunctionalTestFiles.resolvePath(FIXTURE_PATH);
         Gson gson = new Gson();
         ExternalIdFactory externalIdFactory = new ExternalIdFactory();
@@ -121,6 +164,6 @@ public class NpmWorkspaceFilterTest {
         NpmLockfilePackager packager =
             new NpmLockfilePackager(gson, externalIdFactory,
                 new NpmLockFileProjectIdTransformer(gson, externalIdFactory), transformer, workspaceFilter);
-        return packager.parseAndTransform(rootJsonPath, PACKAGE_JSON, LOCKFILE);
+        return packager.parseAndTransform(rootJsonPath, packageJsonText, lockfileText);
     }
 }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWorkspaceFilterTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWorkspaceFilterTest.java
@@ -115,7 +115,6 @@ public class NpmWorkspaceFilterTest {
         FunctionalTestFiles.asString("/npm/workspace-filter-test/no-root-deps-package-lock.json");
 
     // Root package.json that declares workspaces but no direct dependencies of its own.
-    // Mirrors the structure of a real project like ui-workspace.
     private static final String NO_ROOT_DEPS_PACKAGE_JSON =
         "{\n" +
         "  \"name\": \"my-project\",\n" +

--- a/detectable/src/test/resources/detectables/functional/npm/workspace-filter-test/no-root-deps-package-lock.json
+++ b/detectable/src/test/resources/detectables/functional/npm/workspace-filter-test/no-root-deps-package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "my-project",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "my-project",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ]
+    },
+    "packages/api": {
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "4.18.0"
+      }
+    },
+    "packages/ui": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.0.tgz"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+    }
+  }
+}


### PR DESCRIPTION
This fix handles cases where there are a) no dependencies in the root package.json and b) all workspaces are filtered out. We now no longer fallback to parsing the workspaces incorrectly.